### PR TITLE
Update nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "pry-byebug", :platform => [:ruby_20, :ruby_21]
 gem 'robot-controller', '~> 2.0'
 gem 'slop'
 gem 'addressable', '2.3.5'
-gem 'nokogiri' , '1.6.2.1'
+gem 'nokogiri'
 
 group :test do
 	gem "simplecov"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (4.0.5)
+    byebug (5.0.0)
       columnize (= 0.9.0)
     capistrano (3.4.0)
       i18n
@@ -83,7 +83,7 @@ GEM
     docopt (0.5.0)
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services (4.21.2)
+    dor-services (4.21.3)
       active-fedora (~> 5.7.1)
       activesupport (~> 3.2, >= 3.2.18)
       addressable (= 2.3.5)
@@ -152,7 +152,7 @@ GEM
     mediashelf-loggable (0.4.10)
     method_source (0.8.2)
     mime-types (2.6.1)
-    mini_portile (0.6.0)
+    mini_portile (0.6.2)
     moab-versioning (1.4.4)
       confstruct
       json
@@ -175,8 +175,8 @@ GEM
       gssapi (~> 1.2.0)
       net-ssh (>= 2.0)
     netrc (0.10.3)
-    nokogiri (1.6.2.1)
-      mini_portile (= 0.6.0)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
     nom-xml (0.5.2)
@@ -200,8 +200,8 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.1.0)
-      byebug (~> 4.0)
+    pry-byebug (3.2.0)
+      byebug (~> 5.0)
       pry (~> 0.10)
     pry-debugger (0.2.3)
       debugger (~> 1.3)
@@ -322,7 +322,7 @@ DEPENDENCIES
   lyber-core (~> 3.2, >= 3.2.3)
   lyberteam-capistrano-devel (~> 3.1)
   net-ssh-krb
-  nokogiri (= 1.6.2.1)
+  nokogiri
   pony
   pry
   pry-byebug

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,10 +1,10 @@
 set :output, '/home/lyberadmin/common-accessioning/current/log/crondebug.log'
 
-every :day, :at => '2:16am', :roles [:app] do
+every :day, :at => '2:16am', :roles => [:app] do
  command "BUNDLE_GEMFILE=/home/lyberadmin/common-accessioning/current/Gemfile ROBOT_ENVIRONMENT=#{environment} /usr/local/rvm/wrappers/default/ruby /home/lyberadmin/common-accessioning/current/robots/accession/embargo_release.rb"
 end
 
-every 5.minutes, :roles [:app] do
+every 5.minutes, :roles => [:app] do
   # cannot use :output with Hash/String because we don't want append behavior
   set :output, proc { '> log/verify.log 2> log/cron.log' }
   set :environment_variable, 'ROBOT_ENVIRONMENT'


### PR DESCRIPTION
Received this advisory while running a deploy:

Name: nokogiri
Version: 1.6.2.1
Advisory: 118481
Criticality: Unknown
URL: https://github.com/sparklemotion/nokogiri/pull/1087
Title: Nokogiri Gem for JRuby XML Document Root Element Handling Memory Consumption
Remote DoS
Solution: upgrade to >= 1.6.3

Currently nokogiri is pinned at 1.6.2.1.  This pull request unpins nokogiri.