### PR TITLE
add in whenever roles

### DIFF
--- a/config/deploy/dev.rb
+++ b/config/deploy/dev.rb
@@ -9,3 +9,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :deploy_environment, 'development'
 set :whenever_environment, fetch(:deploy_environment)
 set :default_env, { :robot_environment => fetch(:deploy_environment) }
+set :whenever_roles, [:db, :app]

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -6,5 +6,6 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :deploy_environment, 'production'
 set :whenever_environment, fetch(:deploy_environment)
 set :default_env, { :robot_environment => fetch(:deploy_environment) }
+set :whenever_roles, [:db, :app]
 
 set :copy_exclude, ['bin/nuke'] # no-no for production

--- a/config/deploy/staging.rb
+++ b/config/deploy/staging.rb
@@ -9,3 +9,4 @@ Capistrano::OneTimeKey.generate_one_time_key!
 set :deploy_environment, 'test'
 set :whenever_environment, fetch(:deploy_environment)
 set :default_env, { :robot_environment => fetch(:deploy_environment) }
+set :whenever_roles, [:db, :app]


### PR DESCRIPTION
somewhere along the line
```
set :whenever_roles, [:db, :app]
```
was removed from from the cap deploy files.  unfortunately, this meant that only servers with the db role were getting updates to their crons.  fixing this so crons are deployed appropriated