### PR TITLE
Bump dor-services version and unpin rspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,17 @@
 source 'https://rubygems.org'
 
 gem 'activesupport'
-gem 'dor-services', '~> 4.21'
+gem 'dor-services', '~> 5.2'
 gem 'lyber-core', '~> 3.2', '>=3.2.3'
 gem 'daemons'
 gem 'jhove-service', '>=1.0.2'
 gem 'pony'
 gem 'whenever'
 gem 'rake'
-gem 'rspec', '2.14.1'
+gem 'rspec', '~> 2.99'
 gem 'net-ssh-krb'
 gem 'resque'
 gem 'pry'
-gem 'pry-debugger', :platform => :ruby_19
 gem 'pry-byebug', :platform => [:ruby_20, :ruby_21]
 gem 'robot-controller', '~> 2.0'
 gem 'slop'
@@ -28,7 +27,6 @@ group :development do
   if File.exists?(mygems = File.join(ENV['HOME'], '.gemfile'))
     instance_eval(File.read(mygems))
   end
-  gem 'debugger', :platform => :ruby_19
   gem 'yard'
   gem 'capistrano', '~> 3.0'
   gem 'capistrano-bundler', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,35 +1,36 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    active-fedora (5.7.1)
-      activeresource (>= 3.0.0)
+    active-fedora (6.7.3)
       activesupport (>= 3.0.0)
-      builder (~> 3.0.0)
       deprecation
       mediashelf-loggable
       nom-xml (>= 0.5.1)
-      om (~> 1.8.0)
+      om (~> 3.0.0)
       rdf
-      rdf-rdfxml (~> 0.3.8)
+      rdf-rdfxml (= 1.0.1)
       rsolr
-      rubydora (~> 1.6)
-      solrizer (~> 2.1)
-    activemodel (3.2.22)
-      activesupport (= 3.2.22)
-      builder (~> 3.0.0)
-    activeresource (3.2.22)
-      activemodel (= 3.2.22)
-      activesupport (= 3.2.22)
-    activesupport (3.2.22)
-      i18n (~> 0.6, >= 0.6.4)
-      multi_json (~> 1.0)
+      rubydora (~> 1.6, >= 1.6.5)
+    activemodel (4.2.5)
+      activesupport (= 4.2.5)
+      builder (~> 3.1)
+    activeresource (4.0.0)
+      activemodel (~> 4.0)
+      activesupport (~> 4.0)
+      rails-observers (~> 0.1.1)
+    activesupport (4.2.5)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
     addressable (2.3.5)
-    assembly-utils (1.4.5)
+    assembly-utils (1.4.4)
       activeresource
       activesupport
       addressable (= 2.3.5)
       csv-mapper
-      dor-services (~> 4.19)
+      dor-services (>= 4.0.0)
       dor-workflow-service (>= 1.3.1)
       druid-tools (>= 0.2.6)
       fastercsv
@@ -43,12 +44,11 @@ GEM
       blue-daemons (~> 1.1.11)
       i18n (~> 0.5)
       state_machine (~> 1.1)
-    builder (3.0.4)
+    builder (3.2.2)
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (5.0.0)
-      columnize (= 0.9.0)
+    byebug (8.2.1)
     capistrano (3.4.0)
       i18n
       rake (>= 10.0.0)
@@ -65,17 +65,10 @@ GEM
       faraday
     chronic (0.10.2)
     coderay (1.1.0)
-    columnize (0.9.0)
     confstruct (0.2.7)
     csv-mapper (0.5.1)
       fastercsv
     daemons (1.2.3)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.8)
     deprecation (0.2.2)
       activesupport
     diff-lcs (1.2.5)
@@ -83,12 +76,15 @@ GEM
     docopt (0.5.0)
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
-    dor-services (4.22.3)
-      active-fedora (~> 5.7.1)
-      activesupport (~> 3.2, >= 3.2.18)
+    dor-rights-auth (1.0.2)
+      nokogiri
+    dor-services (5.2.0)
+      active-fedora (~> 6.0)
+      activesupport (>= 3.2.18)
       addressable (= 2.3.5)
       confstruct (~> 0.2.7)
-      dor-workflow-service (~> 1.7, >= 1.7.7)
+      dor-rights-auth (~> 1.0, >= 1.0.1)
+      dor-workflow-service (~> 1.7, >= 1.7.1)
       druid-tools (~> 0.4, >= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
       json (~> 1.8.1)
@@ -97,24 +93,25 @@ GEM
       net-sftp (~> 2.1.2)
       net-ssh (~> 2.6.5)
       nokogiri (~> 1.6.0)
-      om (~> 1.8.0)
+      om (~> 3.0)
       osullivan (~> 0.0.3)
       progressbar (~> 0.21.0)
-      rdf (~> 1.0.9.0)
+      rdf (~> 1.1.7)
       rest-client (~> 1.7)
       retries
       rsolr-ext (~> 1.0.3)
       ruby-cache (~> 0.3.0)
       ruby-graphviz (~> 1.0.9)
       rubydora (~> 1.6.5)
-      solrizer (~> 2.0)
-      stanford-mods (~> 0.0.14)
+      solrizer (~> 3.0)
+      stanford-mods (~> 1.1)
       systemu (~> 2.6.0)
       uuidtools (~> 2.1.4)
-      validatable (~> 1.6.7)
-    dor-workflow-service (1.7.7)
+    dor-workflow-service (1.8.0)
       activesupport (>= 3.2.1, < 5)
       confstruct (>= 0.2.7, < 2)
+      faraday (~> 0.9.2)
+      net-http-persistent (~> 2.9.4)
       nokogiri (~> 1.6.0)
       rest-client (~> 1.7)
       retries
@@ -136,6 +133,7 @@ GEM
     jhove-service (1.0.3)
       nokogiri (>= 1.4.3.1)
     json (1.8.3)
+    link_header (0.0.8)
     lyber-core (3.3.0)
       dor-workflow-service (~> 1.7)
     lyber-utils (0.1.2)
@@ -152,8 +150,9 @@ GEM
       mime-types (>= 1.16, < 3)
     mediashelf-loggable (0.4.10)
     method_source (0.8.2)
-    mime-types (2.6.2)
-    mini_portile (0.6.2)
+    mime-types (2.99)
+    mini_portile2 (2.0.0)
+    minitest (5.8.3)
     moab-versioning (1.4.4)
       confstruct
       json
@@ -167,6 +166,7 @@ GEM
     mono_logger (1.1.0)
     multi_json (1.11.2)
     multipart-post (2.0.0)
+    net-http-persistent (2.9.4)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -175,21 +175,22 @@ GEM
     net-ssh-krb (0.4.0)
       gssapi (~> 1.2.0)
       net-ssh (>= 2.0)
-    netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    netrc (0.11.0)
+    nokogiri (1.6.7)
+      mini_portile2 (~> 2.0.0.rc2)
     nokogiri-happymapper (0.5.9)
       nokogiri (~> 1.5)
-    nom-xml (0.5.3)
+    nom-xml (0.5.4)
       activesupport (>= 3.2.18)
       i18n
       nokogiri
-    om (1.8.0)
+    om (3.0.7)
       activemodel
       activesupport
       deprecation
       mediashelf-loggable
       nokogiri (>= 1.4.2)
+      solrizer (~> 3.1.0)
     osullivan (0.0.3)
       activesupport (>= 3.2.18)
       faraday (~> 0.9.0)
@@ -197,29 +198,27 @@ GEM
     pony (1.11)
       mail (>= 2.0)
     progressbar (0.21.0)
-    pry (0.10.2)
+    pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-byebug (3.2.0)
-      byebug (~> 5.0)
+    pry-byebug (3.3.0)
+      byebug (~> 8.0)
       pry (~> 0.10)
-    pry-debugger (0.2.3)
-      debugger (~> 1.3)
-      pry (>= 0.9.10, < 0.11.0)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
+    rails-observers (0.1.2)
+      activemodel (~> 4.0)
     rake (10.4.2)
-    rdf (1.0.9)
-      addressable (>= 2.3)
-    rdf-rdfxml (0.3.9)
-      rdf (>= 0.3.11)
-      rdf-xsd (>= 0.3.8)
-    rdf-xsd (1.0.2.1)
-      nokogiri (>= 1.5.0)
-      rdf (>= 0.3.4)
-    redis (3.2.1)
+    rdf (1.1.17.1)
+      link_header (~> 0.0, >= 0.0.8)
+    rdf-rdfxml (1.0.1)
+      rdf (>= 1.0)
+      rdf-xsd (>= 1.0)
+    rdf-xsd (1.1.5.1)
+      rdf (~> 1.1, >= 1.1.9, < 1.99)
+    redis (3.2.2)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     resque (1.25.2)
@@ -242,14 +241,14 @@ GEM
       builder (>= 2.1.2)
     rsolr-ext (1.0.3)
       rsolr (>= 1.0.2)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.8)
-    rspec-expectations (2.14.5)
+    rspec (2.99.0)
+      rspec-core (~> 2.99.0)
+      rspec-expectations (~> 2.99.0)
+      rspec-mocks (~> 2.99.0)
+    rspec-core (2.99.2)
+    rspec-expectations (2.99.2)
       diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.6)
+    rspec-mocks (2.99.4)
     ruby-cache (0.3.0)
     ruby-graphviz (1.0.9)
     rubydora (1.6.5)
@@ -262,7 +261,7 @@ GEM
       mime-types
       nokogiri
       rest-client
-    simplecov (0.10.0)
+    simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
@@ -272,28 +271,30 @@ GEM
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
     slop (3.6.0)
-    solrizer (2.2.0)
+    solrizer (3.1.1)
       activesupport
       daemons
       mediashelf-loggable (~> 0.4.7)
       nokogiri
-      om (>= 1.5.0)
       stomp
       xml-simple
     sshkit (1.3.0)
       net-scp (>= 1.1.2)
       net-ssh
       term-ansicolor
-    stanford-mods (0.0.27)
-      mods
+    stanford-mods (1.3.3)
+      mods (~> 2.0.2)
     state_machine (1.2.0)
     stomp (1.3.4)
     systemu (2.6.5)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.5)
     tilt (2.0.1)
-    tins (1.6.0)
+    tins (1.8.1)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
     uber (0.0.15)
     unf (0.1.4)
       unf_ext
@@ -317,8 +318,7 @@ DEPENDENCIES
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
   daemons
-  debugger
-  dor-services (~> 4.21)
+  dor-services (~> 5.2)
   jhove-service (>= 1.0.2)
   lyber-core (~> 3.2, >= 3.2.3)
   lyberteam-capistrano-devel (~> 3.1)
@@ -327,11 +327,10 @@ DEPENDENCIES
   pony
   pry
   pry-byebug
-  pry-debugger
   rake
   resque
   robot-controller (~> 2.0)
-  rspec (= 2.14.1)
+  rspec (~> 2.99)
   simplecov
   slop
   whenever


### PR DESCRIPTION
Also remove ruby 1.9 references.
Merge now, deploy when new index and OPS are ready.

Fixes #39 
