### PR TITLE
Cap deploy fixes

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -2,7 +2,7 @@ set :application, 'common-accessioning'
 set :repo_url, 'https://github.com/sul-dlss/common-accessioning.git'
 
 # Default branch is :master
-# ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
+ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }
 
 # Default deploy_to directory is /var/www/my_app
 set :deploy_to, "/home/lyberadmin/#{fetch(:application)}"

--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,5 +1,8 @@
 server 'sul-robots1-prod.stanford.edu', user: 'lyberadmin', roles: %w{web app db}
 server 'sul-robots2-prod.stanford.edu', user: 'lyberadmin', roles: %w{web app}
+server 'sul-robots3-prod.stanford.edu', user: 'lyberadmin', roles: %w{web app}
+server 'sul-robots4-prod.stanford.edu', user: 'lyberadmin', roles: %w{web app}
+server 'sul-robots5-prod.stanford.edu', user: 'lyberadmin', roles: %w{web app}
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
This PR provides for deploying a specific branch to production, and deploys to robots1-5. @blalbrit can you please review? It looks like Rosy has common-accessioning running on all robots1-5...

![screen shot 2016-02-18 at 10 51 01 am](https://cloud.githubusercontent.com/assets/1861171/13154394/9569ca82-d62d-11e5-83cd-cd38d9ab8748.png)
