### PR TITLE
switch from Dor::Item.find to Dor.find when object type is unknown a priori

### DIFF
--- a/bin/fix_xsums.rb
+++ b/bin/fix_xsums.rb
@@ -2,7 +2,7 @@
 # Compare with SDRs checksums and log any differences
 
 def fix_xsums(druid)
-  i = Dor::Item.find druid
+  i = Dor.find druid
   cmds = i.contentMetadata
   files = cmds.resource.file.id
 

--- a/bin/repub
+++ b/bin/repub
@@ -8,7 +8,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 IO.readlines('/home/lyberadmin/repub_druids.txt').each do |druid|
   begin
     puts "Republishing #{druid}"
-    o = Dor::Item.find(druid)
+    o = Dor.find(druid)
     o.publish_metadata
   rescue Exception => e
     puts "ERR Problem with #{druid}\n" << e.inspect << "\n" << e.backtrace.join("\n")

--- a/integration_tests/versioning/versioning_spec.rb
+++ b/integration_tests/versioning/versioning_spec.rb
@@ -10,7 +10,7 @@ describe 'Digital Object Versioning' do
 
   let(:fixture_base) { File.expand_path(File.dirname(__FILE__) + '/../fixtures/versioning') }
   let(:pid) { 'druid:oo000vt0001' }
-  let(:obj) { Dor::Item.find pid }
+  let(:obj) { Dor.find pid }
   let(:wfi) { WfItem.new(pid) }  # Simulates workflow_item passed to the robots
 
   before(:each) do
@@ -59,7 +59,7 @@ describe 'Digital Object Versioning' do
 
   def nuke
     # Nuke from test environment
-    old = Dor::Item.find pid rescue nil
+    old = Dor.find pid rescue nil
     old.cleanup unless old.nil?
     Assembly::Utils.cleanup_object pid, [:stacks, :dor]
     Assembly::Utils.delete_all_workflows pid

--- a/lib/dor/accession_lite.rb
+++ b/lib/dor/accession_lite.rb
@@ -41,7 +41,7 @@ module Dor
     end
 
     def reset druid
-      @i = Dor::Item.find druid
+      @i = Dor.find druid
       build_tech_md
       init_accession_wf
     end

--- a/robots/accession/abstract_metadata.rb
+++ b/robots/accession/abstract_metadata.rb
@@ -17,7 +17,7 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor::Item.find(druid)
+          obj = Dor.find(druid)
           obj.build_datastream(self.class.params[:datastream], self.class.params[:force] ? true : false, self.class.params[:require] ? true : false)
         end
       end

--- a/robots/accession/embargo_release.rb
+++ b/robots/accession/embargo_release.rb
@@ -38,7 +38,7 @@ class EmbargoRelease
       begin
         druid = doc['id']
         LyberCore::Log.info("Releasing #{embargo_msg} for #{druid}")
-        ei = Dor::Item.find(druid)
+        ei = Dor.find(druid)
         ei.open_new_version
         release_block.call(ei)
         ei.save

--- a/robots/accession/end_accession.rb
+++ b/robots/accession/end_accession.rb
@@ -9,7 +9,7 @@ module Robots
         end
 
         def perform(druid)
-          druid_obj = Dor::Item.find(druid)
+          druid_obj = Dor.find(druid)
 
           #Search for the specialized workflow
           next_disseminationWF = get_special_disseminationWF(druid_obj)

--- a/robots/accession/provenance_metadata.rb
+++ b/robots/accession/provenance_metadata.rb
@@ -9,7 +9,7 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor::Item.find(druid)
+          obj = Dor.find(druid)
           obj.build_provenanceMetadata_datastream('accessionWF', 'DOR Common Accessioning completed')
         end
 

--- a/robots/accession/publish.rb
+++ b/robots/accession/publish.rb
@@ -11,7 +11,7 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor::Item.find(druid)
+          obj = Dor.find(druid)
           obj.publish_metadata
         end
       end

--- a/robots/accession/remediate_object.rb
+++ b/robots/accession/remediate_object.rb
@@ -10,7 +10,7 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor::Item.find(druid)
+          obj = Dor.find(druid)
           obj.upgrade!
         end
       end

--- a/robots/accession/reset_workspace.rb
+++ b/robots/accession/reset_workspace.rb
@@ -9,7 +9,7 @@ module Robots
         end
 
         def perform(druid)
-          druid_obj = Dor::find(druid)
+          druid_obj = Dor.find(druid)
           version = druid_obj.current_version
 
           workspace_root = Dor::Config.stacks.local_workspace_root

--- a/robots/accession/sdr_ingest_transfer.rb
+++ b/robots/accession/sdr_ingest_transfer.rb
@@ -9,7 +9,7 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor::Item.find(druid)
+          obj = Dor.find(druid)
           obj.sdr_ingest_transfer('')
         end
       end

--- a/robots/accession/shelve.rb
+++ b/robots/accession/shelve.rb
@@ -8,7 +8,7 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor::Item.find(druid)
+          obj = Dor.find(druid)
           obj.shelve
         end
 


### PR DESCRIPTION
This PR fixes #75 and is in preparation to use ActiveFedora 7 which will throw exceptions on type mismatches (i.e., using `Dor::Item.find` for a `Dor::Collection` object).