### PR TITLE
dor-services v5.29.0 to use new preservationIngestWF

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'activesupport'
+gem 'activesupport', '~> 5.1.0' # 5.2.0 breaks: "can't modify frozen ActiveSupport::HashWithIndifferentAccess"
+gem 'activemodel', '~> 5.1.0' # needed so activesupport can be ~> 5.1.0
 gem 'dor-services', '>= 5.23.1', '< 6'
 gem 'lyber-core',  '>=4.1.3'
 gem 'jhove-service', '>=1.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ GEM
       deprecation (~> 0.1)
       rdf (~> 1.1)
       rdf-vocab (~> 0.8)
-    activemodel (5.1.6)
-      activesupport (= 5.1.6)
-    activesupport (5.1.6)
+    activemodel (5.2.0)
+      activesupport (= 5.2.0)
+    activesupport (5.2.0)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -67,11 +67,11 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.0)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (5.28.0)
+    dor-services (5.29.0)
       active-fedora (>= 6.0, < 9.a)
       activesupport (>= 3.2.18)
       confstruct (~> 0.2.7)
@@ -96,7 +96,7 @@ GEM
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
-    dor-workflow-service (2.2.1)
+    dor-workflow-service (2.3.0)
       activesupport (>= 3.2.1, < 6)
       confstruct (>= 0.2.7, < 2)
       faraday (~> 0.9, >= 0.9.2)
@@ -118,7 +118,7 @@ GEM
     htmlentities (4.3.4)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.0.0)
+    i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.8)
     jhove-service (1.1.3)
@@ -134,7 +134,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    moab-versioning (4.2.0)
+    moab-versioning (4.2.1)
       confstruct
       druid-tools (>= 1.0.0)
       json

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,9 +16,9 @@ GEM
       deprecation (~> 0.1)
       rdf (~> 1.1)
       rdf-vocab (~> 0.8)
-    activemodel (5.2.0)
-      activesupport (= 5.2.0)
-    activesupport (5.2.0)
+    activemodel (5.1.6)
+      activesupport (= 5.1.6)
+    activesupport (5.1.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -293,7 +293,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activemodel (~> 5.1.0)
+  activesupport (~> 5.1.0)
   assembly-utils
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)


### PR DESCRIPTION
by using dor-services v5.29.0, common-accessioning robot `sdr-ingest-transfer` will kick off preservationIngestWF instead of sdrIngestWF, thus using the new code preservation_robots instead of sdr-preservation-core.

I assert that there is functional parity;  this has been tested by manually running a test object through common accessioning and preservation robots on production.