### PR TITLE
Directed at production problem related to dependency shift

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -43,3 +43,8 @@ begin
   end
 end
 require 'robot-controller'
+
+# ActiveFedora::OmDatastream v8.4.2 uses old-style `return false` to break callback cycle
+# Note: This setting is deprecated in ActiveSupport 5.1, removed in 5.2
+# We will need a different fix with the next upgrade.
+ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
ActiveFedora (in our old-ass version) still expects to be able to `return false` out of a callback to skip remaining callbacks.

This buys us some time to still use rails 5.1 with ActiveFedora, but it is fleeting, since the option goes away in rails 5.2.

See: https://github.com/sul-dlss/hydrus/issues/161