### PR TITLE
Upgrade to net-http-persistent 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,6 @@ gem 'pry-byebug', :platform => [:ruby_20, :ruby_21]
 gem 'robot-controller', '~> 2.0'
 gem 'slop'
 gem 'nokogiri'
-gem 'net-http-persistent', '~>2' # net-http-persistent >=3 breaks with faraday 0.12, see https://github.com/lostisland/faraday/issues/617
 gem 'honeybadger'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     coderay (1.1.2)
     concurrent-ruby (1.1.3)
     confstruct (0.2.7)
+    connection_pool (2.2.2)
     coveralls (0.8.22)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -155,7 +156,8 @@ GEM
     multi_json (1.13.1)
     multipart-post (2.0.0)
     mustermann (1.0.3)
-    net-http-persistent (2.9.4)
+    net-http-persistent (3.0.0)
+      connection_pool (~> 2.2)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -312,7 +314,6 @@ DEPENDENCIES
   honeybadger
   jhove-service (>= 1.1.3)
   lyber-core (>= 4.1.3)
-  net-http-persistent (~> 2)
   nokogiri
   pry
   pry-byebug
@@ -325,4 +326,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.16.3
+   1.17.1


### PR DESCRIPTION
Reverts part of https://github.com/sul-dlss/common-accessioning/commit/bb25acf282b006b394b850943cdb05aa5e65102a
The issue was resolved: https://github.com/lostisland/faraday/pull/619