### PR TITLE
Update dor-services version to 6.0.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem 'activesupport', '~> 5.1.0' # 5.2.0 breaks: "can't modify frozen ActiveSupport::HashWithIndifferentAccess"
 gem 'activemodel', '~> 5.1.0' # needed so activesupport can be ~> 5.1.0
-gem 'dor-services', '~> 6.0'
+gem 'dor-services', '~> 6.0', '>= 6.0.5'
 gem 'lyber-core',  '>=4.1.3'
 gem 'jhove-service', '>=1.1.3'
 gem 'whenever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,9 +41,10 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundle_audit (0.2.1)
+    capistrano-bundle_audit (0.2.2)
       bundler-audit (~> 0.5)
       capistrano (~> 3.0)
+      capistrano-bundler (~> 1.4)
     capistrano-bundler (1.4.0)
       capistrano (~> 3.1)
       sshkit (~> 1.2)
@@ -75,7 +76,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (6.0.2)
+    dor-services (6.0.5)
       active-fedora (>= 7.0, < 9.a)
       activesupport (>= 4.2.10, < 6.0.0)
       confstruct (~> 0.2.7)
@@ -323,7 +324,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   coveralls
   dlss-capistrano (~> 3.1)
-  dor-services (~> 6.0)
+  dor-services (~> 6.0, >= 6.0.5)
   honeybadger
   jhove-service (>= 1.1.3)
   lyber-core (>= 4.1.3)


### PR DESCRIPTION
Updates to the latest 6.x version of dor-services to fix the preservable issue of collections.