### PR TITLE
Initialize honeybadger

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -6,6 +6,7 @@ $:.unshift File.expand_path(File.join(File.dirname(__FILE__), '..', 'robots'))
 require 'rubygems'
 require 'bundler/setup'
 require 'logger'
+require 'honeybadger'
 
 # Load the environment file based on Environment.  Default to development
 environment = ENV['ROBOT_ENVIRONMENT'] ||= 'development'


### PR DESCRIPTION
Because Bundler.require is never used, we need to require honeybadger explicitly