### PR TITLE
Update to dor-services 6.1.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (6.1.7)
+    dor-services (6.1.9)
       active-fedora (>= 8.7.0, < 9)
       activesupport (>= 4.2.10, < 6.0.0)
       confstruct (~> 0.2.7)


### PR DESCRIPTION
This has a fix for `undefined method 'dsid' for nil:NilClass`