### PR TITLE
update to use new dor services url location in config

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,9 +39,8 @@ Dor::Config.configure do
     iiif_profile 'http://iiif.io/api/image/2/level1.json'
   end
 
-  dor do
-    service_root 'https://USERNAME:PASSWORD@example.com/dor/v1'
-  end
+  dor_services.url 'https://USERNAME:PASSWORD@example.com/dor/v1'
+  purl_services.url 'https://example.com'
 end
 
 REDIS_URL = '127.0.0.1:6379/resque:development' # hostname:port[:db]/namespace

--- a/lib/dor/item.rb
+++ b/lib/dor/item.rb
@@ -71,7 +71,7 @@ module Dor::Release
 
     def update_marc_record
       with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
-        url = "#{Dor::Config.dor.service_root}/objects/#{@druid}/update_marc_record"
+        url = "#{Dor::Config.dor_services.url}/objects/#{@druid}/update_marc_record"
         response = RestClient.post url, {}
         response.code
       end


### PR DESCRIPTION
update-marc step in item-release fails since it is using a misconfigured dor-services-url, fix and update local test.rb config to match latest style.