### PR TITLE
Update dor-services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 
 gem 'activesupport', '~> 5.2'
-gem 'dor-services', '~> 6.4'
+gem 'dor-services', '~> 6.5'
 gem 'lyber-core',  '>=4.1.3'
 gem 'jhove-service', '>=1.1.5'
 gem 'whenever'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,13 +75,13 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     dor-rights-auth (1.3.0)
       nokogiri
-    dor-services (6.4.0)
+    dor-services (6.5.0)
       active-fedora (>= 8.7.0, < 9)
       activesupport (>= 4.2.10, < 6.0.0)
       confstruct (~> 0.2.7)
       deprecation (~> 0)
       dor-rights-auth (~> 1.0, >= 1.2.0)
-      dor-services-client (~> 1.3)
+      dor-services-client (~> 1.5)
       dor-workflow-service (~> 2.0, >= 2.0.1)
       druid-tools (>= 0.4.1)
       equivalent-xml (~> 0.5, >= 0.5.1)
@@ -101,13 +101,13 @@ GEM
       stanford-mods-normalizer (~> 0.1)
       systemu (~> 2.6)
       uuidtools (~> 2.1.4)
-    dor-services-client (1.3.0)
+    dor-services-client (1.5.0)
       activesupport (>= 4.2, < 6)
       deprecation
       faraday (~> 0.15)
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
-    dor-workflow-service (2.6.0)
+    dor-workflow-service (2.9.0)
       activesupport (>= 3.2.1, < 6)
       confstruct (>= 0.2.7, < 2)
       deprecation
@@ -330,7 +330,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   coveralls
   dlss-capistrano (~> 3.1)
-  dor-services (~> 6.4)
+  dor-services (~> 6.5)
   honeybadger
   jhove-service (>= 1.1.5)
   lyber-core (>= 4.1.3)


### PR DESCRIPTION
This allows the technical-metadata robot to use the dor-services-client
rather than RestClient code in dor-services for interacting with the
dor-services-app.

Fixes #182 