### PR TITLE
Create the releaseWF by name

### DIFF
--- a/lib/dor/release/item.rb
+++ b/lib/dor/release/item.rb
@@ -76,25 +76,13 @@ module Dor
         end
       end
 
-      def self.add_workflow_for_collection(druid)
-        create_workflow(druid)
-      end
-
-      def self.add_workflow_for_item(druid)
-        create_workflow(druid)
-      end
-
-      def self.create_workflow(druid)
+      def self.create_release_workflow(druid)
         LyberCore::Log.debug "...adding workflow releaseWF for #{druid}"
 
         # initiate workflow by making workflow service call
         with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
-          Dor::Config.workflow.client.create_workflow(Dor::WorkflowObject.initial_repo('releaseWF'), druid, 'releaseWF', initial_workflow, {})
+          Dor::Config.workflow.client.create_workflow_by_name(druid, 'releaseWF')
         end
-      end
-
-      def self.initial_workflow
-        Dor::Services::Client.workflows.initial(name: 'releaseWF')
       end
     end
   end

--- a/robots/dor_repo/release/release_members.rb
+++ b/robots/dor_repo/release/release_members.rb
@@ -32,7 +32,7 @@ module Robots
               if item.item_members # if there are any members, iterate through and add item workflows (which includes setting the first step to completed)
 
                 item.item_members.each do |item_member|
-                  Dor::Release::Item.add_workflow_for_item(item_member['druid'])
+                  Dor::Release::Item.create_release_workflow(item_member['druid'])
                 end
 
               else # no members found
@@ -49,7 +49,7 @@ module Robots
 
             item.sub_collections&.each do |sub_collection|
               with_retries(max_tries: Dor::Config.release.max_tries, base_sleep_seconds: Dor::Config.release.base_sleep_seconds, max_sleep_seconds: Dor::Config.release.max_sleep_seconds) do |_attempt|
-                Dor::Release::Item.add_workflow_for_collection(sub_collection['druid'])
+                Dor::Release::Item.create_release_workflow(sub_collection['druid'])
               end
             end
 

--- a/spec/lib/dor/release/item_spec.rb
+++ b/spec/lib/dor/release/item_spec.rb
@@ -3,8 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe Dor::Release::Item do
-  let(:xml) { '<xml/>' }
-
   before do
     @druid = 'oo000oo0001'
     @item = Dor::Release::Item.new(druid: @druid, skip_heartbeat: true) # skip heartbeat check for dor-fetcher
@@ -20,7 +18,6 @@ RSpec.describe Dor::Release::Item do
     allow(Dor).to receive(:find).and_return(@dor_object)
 
     allow(Dor::WorkflowObject).to receive(:initial_repo).with('releaseWF').and_return(true)
-    allow(Dor::Services::Client).to receive_message_chain(:workflows, :initial).and_return(xml)
   end
 
   it 'should initialize' do
@@ -56,17 +53,15 @@ RSpec.describe Dor::Release::Item do
   end
 
   it 'creates the workflow for a collection' do
-    expect(Dor::Config.workflow.client).to receive(:create_workflow).with(Dor::WorkflowObject.initial_repo('releaseWF'), @druid, 'releaseWF', xml, {}).once
+    expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(@druid, 'releaseWF').once
 
-    expect(Dor::Services::Client).to receive_message_chain(:workflows, :initial).with(name: 'releaseWF')
-    Dor::Release::Item.add_workflow_for_collection(@druid)
+    Dor::Release::Item.create_release_workflow(@druid)
   end
 
   it 'creates the workflow for an item' do
-    expect(Dor::Config.workflow.client).to receive(:create_workflow).with(Dor::WorkflowObject.initial_repo('releaseWF'), @druid, 'releaseWF', xml, {}).once
+    expect(Dor::Config.workflow.client).to receive(:create_workflow_by_name).with(@druid, 'releaseWF').once
 
-    expect(Dor::Services::Client).to receive_message_chain(:workflows, :initial).with(name: 'releaseWF')
-    Dor::Release::Item.add_workflow_for_item(@druid)
+    Dor::Release::Item.create_release_workflow(@druid)
   end
 
   it 'makes a webservice call for updating_marc_records' do

--- a/spec/robots/release/release_members_spec.rb
+++ b/spec/robots/release/release_members_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
       expect(@release_item.item_members).to eq([])
       expect(@release_item.sub_collections).to eq(members['sets'])
       expect(@release_item).to_not receive(:item_members)
-      expect(Dor::Release::Item).to receive(:create_workflow).once # one workflow added for the sub-collection
+      expect(Dor::Release::Item).to receive(:create_release_workflow).once # one workflow added for the sub-collection
       perform
     end
   end
@@ -73,7 +73,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
       expect(@release_item.item_members).to eq([])
       expect(@release_item.sub_collections).to eq(members['collections'])
       expect(@release_item).to_not receive(:item_members)
-      expect(Dor::Release::Item).to receive(:create_workflow).once # one workflow added for the sub-collection
+      expect(Dor::Release::Item).to receive(:create_release_workflow).once # one workflow added for the sub-collection
       perform
     end
   end
@@ -101,7 +101,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
       expect(@release_item.collection?).to be true
       expect(@release_item.item_members).to eq(members['items'])
       expect(@release_item.sub_collections).to eq([])
-      expect(Dor::Release::Item).to receive(:add_workflow_for_item).exactly(4).times # four workflows added, one for each item
+      expect(Dor::Release::Item).to receive(:create_release_workflow).exactly(4).times # four workflows added, one for each item
       perform
     end
   end
@@ -128,7 +128,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
     it 'runs for a collection and execute the item_members method' do
       expect(@release_item.collection?).to be true
       expect(@release_item.item_members).to eq(members['items'])
-      expect(Dor::Release::Item).to receive(:add_workflow_for_item).exactly(4).times # four workflows added, one for each item
+      expect(Dor::Release::Item).to receive(:create_release_workflow).exactly(4).times # four workflows added, one for each item
       perform
     end
   end
@@ -151,7 +151,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
         expect(@release_item.collection?).to be true
         expect(@release_item.item_members).to eq([])
         expect(@release_item.sub_collections).to eq(collections)
-        expect(Dor::Release::Item).to receive(:add_workflow_for_collection).exactly(2).times # two workflows added, one for each collection
+        expect(Dor::Release::Item).to receive(:create_release_workflow).exactly(2).times # two workflows added, one for each collection
         perform
       end
     end
@@ -166,7 +166,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
         expect(@release_item.collection?).to be true
         expect(@release_item.item_members).to eq([])
         expect(@release_item.sub_collections).to eq(collections) # it has removed itself and is back to the original list
-        expect(Dor::Release::Item).to receive(:add_workflow_for_collection).exactly(2).times # only two workflows added (it doesn't add a workflow for itself)
+        expect(Dor::Release::Item).to receive(:create_release_workflow).exactly(2).times # only two workflows added (it doesn't add a workflow for itself)
         perform
       end
     end


### PR DESCRIPTION
This avoids a number of deprecated methods and APIs