### PR TITLE
Honeybadger expects app or the honeybadger_server to be set

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -14,3 +14,4 @@ set :default_env, { :robot_environment => fetch(:deploy_environment) }
 set :whenever_roles, [:cron]
 
 set :copy_exclude, ['bin/nuke'] # no-no for production
+set :honeybadger_server, primary(:cron)

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -10,3 +10,4 @@ set :deploy_environment, 'production'
 set :whenever_environment, fetch(:deploy_environment)
 set :default_env, { :robot_environment => fetch(:deploy_environment) }
 set :whenever_roles, [:cron]
+set :honeybadger_server, primary(:cron)


### PR DESCRIPTION
Otherwise deploys don't get reported