### PR TITLE
Log when auth is missing

### DIFF
--- a/robots/dor_repo/assembly/accessioning_initiate.rb
+++ b/robots/dor_repo/assembly/accessioning_initiate.rb
@@ -21,6 +21,7 @@ module Robots
         private
 
         def initialize_workspace
+          Honeybadger.notify('No auth header set') unless Dor::Services::Client.instance.send(:connection).headers.key?('X-Auth')
           Dor::Services::Client.object(@ai.druid.druid).workspace.create(source: @ai.path_to_object)
         end
 


### PR DESCRIPTION
We are seeing situations where the headers are never sent to dor-services-app,
I'm hoping to log when that situation happens so we can better troubleshoot