### PR TITLE
Reinstate run_marc_builder

### DIFF
--- a/bin/run_marc_builder.sh
+++ b/bin/run_marc_builder.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+/opt/app/lyberadmin/common-accessioning/current/robots/dor_repo/etd_submit/build_symphony_marc.rb
+/bin/chown 214:214 /etd/*

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -17,7 +17,7 @@ every :day, at: '9:10pm' do
 end
 
 every :day, at: '10:10pm' do
-  command "cd #{path}; #{environment_variable}=#{environment} #{bundle_command} robots/dor_repo/etd_submit/build_symphony_marc.rb"
+  command "cd #{path}; #{environment_variable}=#{environment} #{bundle_command} bin/run_marc_builder.sh"
 end
 
 every :hour, at: 40 do


### PR DESCRIPTION
  This time, in order to make marc deposits
  owned by the sirsi user