### PR TITLE
Change test config URL to a non resolvable host

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,5 +1,5 @@
   dor_services:
-    url:  'https://example.com'
+    url:  'https://dor-services-test.stanford.test'
     user: 'USERNAME'
     pass: 'PASSWORD'
     token: secret-token


### PR DESCRIPTION
Per the goobi outage post-mortem, we decided to move away from using `example.com` as a test hostname as it can resolve and return unexpected 404 errors during tests. 

This replaces `example.com` with `dor-services-test.stanford.test`.

* The `.test` TLD is specifically setup for testing and not be resolvable (https://en.wikipedia.org/wiki/.test)
* By using the same url structure we see in prod but with `-test` it may be easier to debug production configurations by having easy access to the proper url structure here.