### PR TITLE
Allow was-dissemniation workflow to be kicked off

### DIFF
--- a/robots/dor_repo/accession/end_accession.rb
+++ b/robots/dor_repo/accession/end_accession.rb
@@ -13,19 +13,25 @@ module Robots
 
           # Search for the specialized workflow
           next_dissemination_wf = special_dissemination_wf(druid_obj)
-          druid_obj.initialize_workflow next_dissemination_wf if next_dissemination_wf != 'disseminationWF' && next_dissemination_wf.present?
+          Dor::Config.workflow.client.create_workflow_by_name(druid, next_dissemination_wf) if next_dissemination_wf.present?
 
           # Call the default disseminationWF in all cases
           Dor::Config.workflow.client.create_workflow_by_name(druid, 'disseminationWF')
         end
 
+        private
+
+        # This returns any optional workflow such as wasDisseminationWF
         def special_dissemination_wf(druid_obj)
           apo = druid_obj.admin_policy_object
           raise "#{druid_obj.id} doesn't have a valid apo" if apo.nil?
 
           adminMetadata = apo.datastreams['administrativeMetadata'].content
           adminMetadata_xml = Nokogiri::XML(adminMetadata)
-          adminMetadata_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
+          wf = adminMetadata_xml.xpath('//administrativeMetadata/dissemination/workflow/@id').text
+          return nil if wf == 'disseminationWF'
+
+          wf
         end
       end
     end


### PR DESCRIPTION
Previously we were getting a NoMethodError here.  This adds a test so we don't
run into such a problem again.

Fixes #324 