### PR TITLE
do not set error status for a workflow step that does not exist

### DIFF
--- a/lib/robots/dor_repo/accession/embargo_release.rb
+++ b/lib/robots/dor_repo/accession/embargo_release.rb
@@ -56,7 +56,7 @@ module Robots
           dor_service.version.close(description: "#{embargo_msg} released", significance: 'admin')
         rescue Exception => e
           LyberCore::Log.error("!!! Unable to release embargo for: #{druid}\n#{e.inspect}\n#{e.backtrace.join("\n")}")
-          Dor::Config.workflow.client.update_workflow_error_status 'dor', druid, 'disseminationWF', 'embargo-release', e.to_s
+          Honeybadger.notify "Unable to release embargo for: #{druid}", backtrace: e.backtrace
         end
         private_class_method :release_item
 

--- a/spec/robots/accession/embargo_release_spec.rb
+++ b/spec/robots/accession/embargo_release_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe 'Robots::DorRepo::Accession::EmbargoRelease' do
 
       it "handles the error" do
         expect(LyberCore::Log).to receive(:error).with(/!!! Unable to release embargo for: druid:999\n#<StandardError: Not Found>/)
-        expect(Dor::Config.workflow.client).to receive(:update_workflow_error_status)
+        expect(Honeybadger).to receive(:notify)
         release_items
       end
     end


### PR DESCRIPTION
embargo script rescue block currently explodes and stops the script because we are trying to set a workflowstep that doesn't exist anymore -- just use an HB notification instead