### PR TITLE
do not generate errors for non-accessioned objects when releasing

### DIFF
--- a/lib/robots/dor_repo/accession/embargo_release.rb
+++ b/lib/robots/dor_repo/accession/embargo_release.rb
@@ -47,6 +47,12 @@ module Robots
 
         def self.release_item(druid, embargo_msg, &release_block)
           ei = Dor.find(druid)
+
+          unless Dor::Config.workflow.client.lifecycle('dor', druid, 'accessioned')
+            LyberCore::Log.warn("Skipping #{druid} - not yet accessioned")
+            return
+          end
+
           LyberCore::Log.info("Releasing #{embargo_msg} for #{druid}")
 
           dor_service = Dor::Services::Client.object(druid)


### PR DESCRIPTION
There are some objects that have passed embargo but were not never accessioned (test objects or orphaned).  Right now this generates an exception which gets honeybadgered each day, which seems excessive (unless and until we clean these ones up and don't generate more).  This code simple logs these cases instead of trying to release and then generate an exception.

