### PR TITLE
allow 3d content type to pass through from stub content metadata

### DIFF
--- a/lib/dor/assembly/stub_content_metadata_parser.rb
+++ b/lib/dor/assembly/stub_content_metadata_parser.rb
@@ -10,6 +10,8 @@ module Dor
           :simple_book
         elsif stub_object_type.include?('map')
           :map
+        elsif stub_object_type.casecmp('3d').zero? # just in case it comes in as 3D...
+          :"3d"
         elsif stub_object_type == 'image'
           :simple_image
         else

--- a/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
+++ b/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dor::Assembly::StubContentMetadataParser do
+  describe '#stub_content_metadata_parser' do
+    let(:druid) { 'druid:aa111bb3333' }
+    let(:item) { Dor::Assembly::Item.new(druid: druid) }
+
+    it 'maps content metadata types to the gem correctly' do
+      ['flipbook (r-l)', 'book', 'a book (l-r)'].each do |content_type|
+        allow(item).to receive(:stub_object_type).and_return(content_type)
+        expect(item.gem_content_metadata_style).to eq(:simple_book)
+      end
+      allow(item).to receive(:stub_object_type).and_return('image')
+      expect(item.gem_content_metadata_style).to eq(:simple_image)
+      allow(item).to receive(:stub_object_type).and_return('maps')
+      expect(item.gem_content_metadata_style).to eq(:map)
+      %w[3d 3D].each do |content_type|
+        allow(item).to receive(:stub_object_type).and_return(content_type)
+        expect(item.gem_content_metadata_style).to eq(:"3d")
+      end
+      %w[file bogus].each do |content_type|
+        allow(item).to receive(:stub_object_type).and_return(content_type)
+        expect(item.gem_content_metadata_style).to eq(:file)
+      end
+    end
+  end
+end

--- a/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
+++ b/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
@@ -7,22 +7,44 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
     let(:druid) { 'druid:aa111bb3333' }
     let(:item) { Dor::Assembly::Item.new(druid: druid) }
 
-    it 'maps content metadata types to the gem correctly' do
-      ['flipbook (r-l)', 'book', 'a book (l-r)'].each do |content_type|
-        allow(item).to receive(:stub_object_type).and_return(content_type)
-        expect(item.gem_content_metadata_style).to eq(:simple_book)
+    context 'when stub_object_type is book' do
+      it 'maps content metadata types to book correctly' do
+        ['flipbook (r-l)', 'book', 'a book (l-r)'].each do |content_type|
+          allow(item).to receive(:stub_object_type).and_return(content_type)
+          expect(item.gem_content_metadata_style).to eq(:simple_book)
+        end
       end
-      allow(item).to receive(:stub_object_type).and_return('image')
-      expect(item.gem_content_metadata_style).to eq(:simple_image)
-      allow(item).to receive(:stub_object_type).and_return('maps')
-      expect(item.gem_content_metadata_style).to eq(:map)
-      %w[3d 3D].each do |content_type|
-        allow(item).to receive(:stub_object_type).and_return(content_type)
-        expect(item.gem_content_metadata_style).to eq(:"3d")
+    end
+
+    context 'when stub_object_type is image' do
+      it 'maps content metadata types to image correctly' do
+        allow(item).to receive(:stub_object_type).and_return('image')
+        expect(item.gem_content_metadata_style).to eq(:simple_image)
       end
-      %w[file bogus].each do |content_type|
-        allow(item).to receive(:stub_object_type).and_return(content_type)
-        expect(item.gem_content_metadata_style).to eq(:file)
+    end
+
+    context 'when stub_object_type is map' do
+      it 'maps content metadata types to map correctly' do
+        allow(item).to receive(:stub_object_type).and_return('maps')
+        expect(item.gem_content_metadata_style).to eq(:map)
+      end
+    end
+
+    context 'when stub_object_type is 3d' do
+      it 'maps content metadata types to 3d correctly' do
+        %w[3d 3D].each do |content_type|
+          allow(item).to receive(:stub_object_type).and_return(content_type)
+          expect(item.gem_content_metadata_style).to eq(:"3d")
+        end
+      end
+    end
+
+    context 'when stub_object_type is file or unknown' do
+      it 'maps content metadata type to file correctly' do
+        %w[file bogus].each do |content_type|
+          allow(item).to receive(:stub_object_type).and_return(content_type)
+          expect(item.gem_content_metadata_style).to eq(:file)
+        end
       end
     end
   end


### PR DESCRIPTION
ported from https://github.com/sul-dlss-deprecated/assembly/pull/66

This is a pre-req for the actual content metadata generation which occurs here: https://github.com/sul-dlss/assembly-objectfile/pull/7