### PR TITLE
Revert pinning redis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,6 @@ gem 'moab-versioning', '~> 4.0'
 gem 'whenever'
 gem 'rake'
 gem 'rspec', '~> 3.0'
-# We're locking redis to 4.1.0, to test the theory that 4.1.1 causes redis errors like:
-# Redis::CannotConnectError: Error connecting to Redis on sul-robots-redis-prod.stanford.edu:6379 (Redis::TimeoutError)
-gem 'redis', '4.1.0'
 gem 'resque'
 gem 'resque-pool'
 gem 'pony' # send email, for etd_submit/build_symphony_marc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
       rdf (~> 1.1, >= 1.1.10)
     rdf-xsd (1.99.0)
       rdf (~> 1.99)
-    redis (4.1.0)
+    redis (4.1.2)
     redis-namespace (1.6.0)
       redis (>= 3.0.4)
     resque (2.0.0)
@@ -402,7 +402,6 @@ DEPENDENCIES
   pry
   pry-byebug
   rake
-  redis (= 4.1.0)
   resque
   resque-pool
   rspec (~> 3.0)


### PR DESCRIPTION
We haven't seen that 4.1.0 helps resolve timeout errors