### PR TITLE
raise error and/or notify Honeybadger and log error if a fedora save doesn't work.

### DIFF
--- a/lib/datastream_builder.rb
+++ b/lib/datastream_builder.rb
@@ -33,10 +33,12 @@ class DatastreamBuilder
     elsif force || empty_datastream?
       yield(datastream)
     end
-    datastream.save
+    # NOTE: can't use save! because this is an ActiveFedora::Datastream, so we get
+    # OM::XML::Terminology::BadPointerError:
+    #   This Terminology does not have a root term defined that corresponds to ":save!"
+    raise "Problem saving ActiveFedora::Datastream #{datastream_name} for #{object.pid}" unless datastream.save
 
-    # Check for success.
-    raise "Required datastream #{datastream_name} could not be populated!" if required && empty_datastream?
+    raise "Required datastream #{datastream_name} was not populated for #{object.pid}" if required && empty_datastream?
   end
 
   private

--- a/lib/robots/dor_repo/accession/embargo_release.rb
+++ b/lib/robots/dor_repo/accession/embargo_release.rb
@@ -58,7 +58,7 @@ module Robots
           dor_service = Dor::Services::Client.object(druid)
           dor_service.version.open
           release_block.call(ei)
-          ei.save
+          ei.save!
           dor_service.version.close(description: "#{embargo_msg} released", significance: 'admin')
         rescue Exception => e
           LyberCore::Log.error("!!! Unable to release embargo for: #{druid}\n#{e.inspect}\n#{e.backtrace.join("\n")}")

--- a/lib/robots/dor_repo/etd_submit/check_marc.rb
+++ b/lib/robots/dor_repo/etd_submit/check_marc.rb
@@ -46,7 +46,7 @@ module Robots
           ds = ActiveFedora::Datastream.new(etd.inner_object, 'identityMetadata', dsLabel: 'identityMetadata', controlGroup: 'X')
           ds.content = identity_xml.to_xml
           etd.add_datastream(ds)
-          etd.save
+          etd.save!
 
           true
         end

--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -33,7 +33,11 @@ class TechnicalMetadataService
     ds = dor_item.datastreams['technicalMetadata']
     ds.dsLabel = 'Technical Metadata'
     ds.content = final_techmd
-    ds.save
+    # NOTE: can't use save! because this is an ActiveFedora::Datastream, so we get
+    # OM::XML::Terminology::BadPointerError:
+    #   This Terminology does not have a root term defined that corresponds to ":save!"
+    raise "problem saving ActiveFedora::Datastream technicalMetadata for #{druid}" unless ds.save
+
     true
   end
 

--- a/spec/lib/datastream_builder_spec.rb
+++ b/spec/lib/datastream_builder_spec.rb
@@ -83,8 +83,24 @@ RSpec.describe DatastreamBuilder do
           # fails because the block doesn't build the datastream
 
           it 'raises an exception' do
-            expect { build }.to raise_error(RuntimeError)
+            expect { build }.to raise_error(RuntimeError, 'Required datastream technicalMetadata was not populated for druid:ab123cd4567')
           end
+        end
+      end
+
+      context 'when it cannot save the datastream' do
+        subject(:build) { builder.build { |ds| } }
+
+        before do
+          allow_any_instance_of(described_class).to receive(:find_metadata_file).and_return(nil)
+          allow(TechnicalMetadataService).to receive(:add_update_technical_metadata) do |obj|
+            obj.technicalMetadata.content = dm_builder_xml
+          end
+          allow(ds).to receive(:save).and_return(false)
+        end
+
+        it 'raises an error' do
+          expect { build }.to raise_error(StandardError, 'Problem saving ActiveFedora::Datastream technicalMetadata for druid:ab123cd4567')
         end
       end
     end


### PR DESCRIPTION
raise error and/or notify Honeybadger and log error if a fedora save doesn't work.

Ran into this oversight while working on #372 (descMetadata must have required fields.)

This PR isn't perfect, but I think it should be merged if you believe it represents an improvement over what currently exists in the code and if you don't see any blockers.

Closes #377 (not user facing, so can autoclose with merge)