### PR TITLE
improve error messages

### DIFF
--- a/lib/datastream_builder.rb
+++ b/lib/datastream_builder.rb
@@ -21,7 +21,7 @@ class DatastreamBuilder
     @datastream = datastream
     @force = force
     @required = required
-    raise 'Datastream required, but none provided' if required && !datastream
+    raise "Datastream required, but none provided for #{object.pid}" if required && !datastream
   end
 
   # Populates the datastream from the file if the file is newer than the datastream.

--- a/lib/dor/assembly/content_metadata.rb
+++ b/lib/dor/assembly/content_metadata.rb
@@ -75,7 +75,7 @@ module Dor
       end
 
       def create_basic_content_metadata
-        raise "Content metadata file #{Dor::Config.assembly.cm_file_name} exists already" if content_metadata_exists?
+        raise "Content metadata file #{Dor::Config.assembly.cm_file_name} exists already for #{druid.id}" if content_metadata_exists?
 
         LyberCore::Log.info("Creating basic content metadata for #{druid.id}")
 

--- a/lib/robots/dor_repo/accession/descriptive_metadata.rb
+++ b/lib/robots/dor_repo/accession/descriptive_metadata.rb
@@ -21,7 +21,7 @@ module Robots
             Dor::Services::Client.object(druid).refresh_metadata
           end
 
-          raise 'descMetadata missing required fields (<title>)' if missing_required_fields?(obj.descMetadata)
+          raise "#{druid} descMetadata missing required fields (<title>)" if missing_required_fields?(obj.descMetadata)
         end
 
         private

--- a/lib/robots/dor_repo/assembly/content_metadata_create.rb
+++ b/lib/robots/dor_repo/assembly/content_metadata_create.rb
@@ -15,7 +15,7 @@ module Robots
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'object is not an item') unless obj.item? # not an item, skip
 
           # both stub and regular content metadata exist -- this is an ambiguous situation and generates an error
-          raise "#{Dor::Config.assembly.stub_cm_file_name} and #{Dor::Config.assembly.cm_file_name} both exist" if obj.stub_content_metadata_exists? && obj.content_metadata_exists?
+          raise "#{Dor::Config.assembly.stub_cm_file_name} and #{Dor::Config.assembly.cm_file_name} both exist for #{druid}" if obj.stub_content_metadata_exists? && obj.content_metadata_exists?
 
           # regular content metadata exists -- do not recreate it
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: "#{Dor::Config.assembly.cm_file_name} exists") if obj.content_metadata_exists?

--- a/lib/robots/dor_repo/etd_submit/binder_batch_transfer.rb
+++ b/lib/robots/dor_repo/etd_submit/binder_batch_transfer.rb
@@ -59,7 +59,7 @@ module Robots
         # @param [String] report_file path to a pipe-delimited report from https://etd.stanford.edu/reports
         # @param [String] binder_quarter_root path to the binder dropoff directory for the quarter
         def initialize(report_file, binder_quarter_root)
-          raise 'Needs path to report file' if report_file.nil?
+          raise "#{druid} Needs path to report file" if report_file.nil?
 
           LyberCore::Log.set_logfile("#{ROBOT_ROOT}/log/binder-batch-transfer.log")
           LyberCore::Log.set_level(1)
@@ -99,7 +99,7 @@ module Robots
           pair_tree = DruidTools::PurlDruid.new(pid, Dor::Config.stacks.local_storage_root)
           file_path = File.join(pair_tree.content_dir, '*-augmented.pdf')
           file = Dir.glob(file_path).first
-          raise "Augmented File error -- Unable to find #{file_path}." unless file
+          raise "#{druid} Augmented File error -- Unable to find #{file_path}." unless file
 
           file
         end

--- a/lib/robots/dor_repo/etd_submit/other_metadata.rb
+++ b/lib/robots/dor_repo/etd_submit/other_metadata.rb
@@ -43,14 +43,14 @@ module Robots
           true
         rescue StandardError => e
           LyberCore::Log.fatal "Can't rsync contents from #{source_dir} to #{dest_dir}: #{e}"
-          raise
+          raise "Can't rsync contents from #{source_dir} to #{dest_dir}: #{e.message}"
         end
 
         def ensure_workspace_exists(workspace)
           FileUtils.mkdir_p(workspace) unless File.directory?(workspace)
-        rescue StandardError
-          LyberCore::Log.fatal("Can't create workspace_base #{workspace}")
-          raise
+        rescue StandardError => e
+          LyberCore::Log.fatal("Can't create workspace_base #{workspace}: #{e}")
+          raise "Can't create workspace_base #{workspace} #{e.message}"
         end
 
         private

--- a/lib/sdr_ingest_service.rb
+++ b/lib/sdr_ingest_service.rb
@@ -36,7 +36,7 @@ class SdrIngestService
     # start SDR preservation workflow
     Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF')
   rescue Exception => e
-    raise Dor::Exception, "Error exporting new object version to bag: #{e.message}"
+    raise Dor::Exception, "Error exporting new object version to bag for #{dor_item.pid}: #{e.message}"
   end
 
   # Note: the following methods should probably all be private
@@ -93,7 +93,7 @@ class SdrIngestService
     ds = (ds_name == :relationshipMetadata ? 'RELS-EXT' : ds_name.to_s)
     return dor_item.datastreams[ds].content if dor_item.datastreams.key?(ds) && !dor_item.datastreams[ds].new?
 
-    raise "required datastream #{ds_name} not found in DOR" if required
+    raise "required datastream #{ds_name} for #{dor_item.pid} not found in DOR" if required
   end
 
   # @param [Pathname] metadata_dir the location of the metadata directory in the workspace

--- a/spec/lib/sdr_ingest_service_spec.rb
+++ b/spec/lib/sdr_ingest_service_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe SdrIngestService do
   describe 'datastream_content' do
     before do
       @ds_name = 'myMetadata'
-      @mock_item = double('item')
+      @mock_item = double('item', pid: '123')
       @mock_datastream = double('datastream')
     end
 

--- a/spec/robots/accession/descriptive_metadata_spec.rb
+++ b/spec/robots/accession/descriptive_metadata_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe Robots::DorRepo::Accession::DescriptiveMetadata do
         allow(object).to receive(:descMetadata).and_return(mock_desc_md_ds)
         allow(Dor).to receive(:find).and_return(object)
 
-        expect { perform }.to raise_error(RuntimeError, 'descMetadata missing required fields (<title>)')
+        expect { perform }.to raise_error(RuntimeError, "#{druid} descMetadata missing required fields (<title>)")
       end
     end
   end

--- a/spec/robots/assembly/content_metadata_create_spec.rb
+++ b/spec/robots/assembly/content_metadata_create_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Robots::DorRepo::Assembly::ContentMetadataCreate do
       expect(item).not_to receive(:convert_stub_content_metadata)
       expect(item).not_to receive(:create_basic_content_metadata)
       expect(item).not_to receive(:persist_content_metadata)
-      exp_msg = "#{Dor::Config.assembly.stub_cm_file_name} and #{Dor::Config.assembly.cm_file_name} both exist"
+      exp_msg = "#{Dor::Config.assembly.stub_cm_file_name} and #{Dor::Config.assembly.cm_file_name} both exist for #{druid}"
       expect { result }.to raise_error RuntimeError, exp_msg
     end
   end


### PR DESCRIPTION
This PR is motivated from First Responder duties:  looking at some errors in honeybadger that don't have a druid included.

I can't think of any downstream consumers of these error messages that would be negatively impacted ...