### PR TITLE
Don't try to do embargo release on an open object

### DIFF
--- a/lib/robots/dor_repo/accession/embargo_release.rb
+++ b/lib/robots/dor_repo/accession/embargo_release.rb
@@ -53,9 +53,14 @@ module Robots
             return
           end
 
+          dor_service = Dor::Services::Client.object(druid)
+          unless dor_service.version.openable?
+            LyberCore::Log.warn("Skipping #{druid} - object is already open")
+            return
+          end
+
           LyberCore::Log.info("Releasing #{embargo_msg} for #{druid}")
 
-          dor_service = Dor::Services::Client.object(druid)
           dor_service.version.open
           release_block.call(ei)
           ei.save!


### PR DESCRIPTION
This prevents an exception that occurs when opening an object that is already open


Fixes #388 