### PR TITLE
FIX BUG:  desc metadata required fields check

### DIFF
--- a/lib/datastream_builder.rb
+++ b/lib/datastream_builder.rb
@@ -59,7 +59,7 @@ class DatastreamBuilder
   end
 
   def file_date
-    File.mtime(filename)
+    File.mtime(filename) if filename
   end
 
   def datastream_date

--- a/lib/robots/dor_repo/accession/descriptive_metadata.rb
+++ b/lib/robots/dor_repo/accession/descriptive_metadata.rb
@@ -21,6 +21,7 @@ module Robots
             Dor::Services::Client.object(druid).refresh_metadata
           end
 
+          obj = Dor.find(druid) # reload object to get latest content
           raise "#{druid} descMetadata missing required fields (<title>)" if missing_required_fields?(obj.descMetadata)
         end
 


### PR DESCRIPTION
Fixes #393 
related to #386, and may fix that as well

We have been getting this error but inappropriately -- the descMetadata is there and it has a title:

![image](https://user-images.githubusercontent.com/96775/64902135-a547fa00-d656-11e9-81d5-838843e33202.png)

I was able to reproduce the error in stage consistently by registering an object with a catkey and no label, and then adding the accessioningWF.

This PR fixes the problem by reloading the Dor object before checking for required fields in a possibly newly updated datastream.

I deployed the fix to stage and empirically established that the fix works.