### PR TITLE
Bump jhove-service to 1.3.0 to pick up JHOVE 1.22.x for testing in stage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -188,7 +188,7 @@ GEM
     ice_nine (0.11.2)
     iso-639 (0.2.8)
     jaro_winkler (1.5.3)
-    jhove-service (1.2.0)
+    jhove-service (1.3.0)
       nokogiri (>= 1.4.3.1)
     json (2.2.0)
     link_header (0.0.8)

--- a/spec/fixtures/workspace/dd/116/zh/0343/dd116zh0343/metadata/technicalMetadata.xml
+++ b/spec/fixtures/workspace/dd/116/zh/0343/dd116zh0343/metadata/technicalMetadata.xml
@@ -40,9 +40,6 @@
     <jhove:size>5941</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
-    <jhove:sigMatch>
-      <jhove:module>WARC-kb</jhove:module>
-    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -61,9 +58,6 @@
     <jhove:size>3614</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
-    <jhove:sigMatch>
-      <jhove:module>WARC-kb</jhove:module>
-    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -114,9 +108,6 @@
     <jhove:size>5645</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
-    <jhove:sigMatch>
-      <jhove:module>WARC-kb</jhove:module>
-    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -135,9 +126,6 @@
     <jhove:size>10717</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
-    <jhove:sigMatch>
-      <jhove:module>WARC-kb</jhove:module>
-    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -188,9 +176,6 @@
     <jhove:size>25336</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
-    <jhove:sigMatch>
-      <jhove:module>WARC-kb</jhove:module>
-    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>
@@ -209,9 +194,6 @@
     <jhove:size>28726</jhove:size>
     <jhove:format>ASCII</jhove:format>
     <jhove:status>Well-Formed and valid</jhove:status>
-    <jhove:sigMatch>
-      <jhove:module>WARC-kb</jhove:module>
-    </jhove:sigMatch>
     <jhove:mimeType>text/plain; charset=US-ASCII</jhove:mimeType>
     <jhove:properties>
       <textmd:textMD>

--- a/spec/fixtures/workspace/jq/937/jp/0017/jq937jp0017/metadata/technicalMetadata.xml
+++ b/spec/fixtures/workspace/jq/937/jp/0017/jq937jp0017/metadata/technicalMetadata.xml
@@ -3,7 +3,7 @@
     xmlns:mix='http://www.loc.gov/mix/v10'
     xmlns:textmd='info:lc/xmlns/textMD-v3'>
   <file id='page-1.jpg'>
-    <jhove:reportingModule release='1.2' date='2007-02-13'>JPEG-hul</jhove:reportingModule>
+    <jhove:reportingModule release='1.4' date='2018-03-29'>JPEG-hul</jhove:reportingModule>
     <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
     <jhove:size>32915</jhove:size>
     <jhove:format>JPEG</jhove:format>
@@ -55,7 +55,7 @@
     </jhove:properties>
   </file>
   <file id='page-2.jpg'>
-    <jhove:reportingModule release='1.2' date='2007-02-13'>JPEG-hul</jhove:reportingModule>
+    <jhove:reportingModule release='1.4' date='2018-03-29'>JPEG-hul</jhove:reportingModule>
     <jhove:lastModified>2012-08-28T09:44:26-07:00</jhove:lastModified>
     <jhove:size>39539</jhove:size>
     <jhove:format>JPEG</jhove:format>


### PR DESCRIPTION
This branch is now deployed to stage. Would like @andrewjbtw to toss a new object up (that has the buildSubtree problem in prod, such as https://argo.stanford.edu/view/druid:cm855qk5101) and confirm that this works OK before making it a real PR and pushing to prod.