### PR TITLE
Reduce the reliance on Dor.find

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 5.2'
 gem 'config', '~> 1.7'
 gem 'dor-fetcher', '~> 1.3'
 gem 'dor-services', '~> 8.0'
-gem 'dor-services-client', '~> 3.2'
+gem 'dor-services-client', '~> 3.3'
 gem 'dor-workflow-client', '~> 3.7'
 gem 'lyber-core', '~> 5.1'
 gem 'marc' # for etd_submit/submit_marc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       resque-pool
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.4.1)
+    cocina-models (0.6.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -114,9 +114,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (3.2.0)
+    dor-services-client (3.3.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.4.0)
+      cocina-models (~> 0.6.0)
       deprecation
       faraday (~> 0.15)
       moab-versioning (~> 4.0)
@@ -413,7 +413,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-fetcher (~> 1.3)
   dor-services (~> 8.0)
-  dor-services-client (~> 3.2)
+  dor-services-client (~> 3.3)
   dor-workflow-client (~> 3.7)
   honeybadger
   jhove-service (~> 1.3)

--- a/lib/robots/dor_repo/accession/publish.rb
+++ b/lib/robots/dor_repo/accession/publish.rb
@@ -11,10 +11,10 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor.find(druid)
-          return unless obj.is_a?(Dor::Set) || obj.is_a?(Dor::Item)
+          object_client = Dor::Services::Client.object(druid)
+          obj = object_client.find
 
-          Dor::Services::Client.object(druid).publish
+          object_client.publish unless obj.is_a?(Cocina::Models::AdminPolicy)
         end
       end
     end

--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -10,14 +10,10 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor.find(druid)
-          # TODO: Use Dor::Services::Client::ObjectClient#find to determine the type.
-          #       Currently we can't until #find can differentiate between DRO and Collection
-          #       https://github.com/sul-dlss/dor-services-client/issues/106
-          return unless obj.is_a?(Dor::Item)
+          object_client = Dor::Services::Client.object(druid)
+          obj = object_client.find
 
-          client = Dor::Services::Client.object(druid)
-          client.shelve
+          object_client.shelve if obj.is_a?(Cocina::Models::DRO)
         end
       end
     end

--- a/spec/robots/accession/publish_spec.rb
+++ b/spec/robots/accession/publish_spec.rb
@@ -5,11 +5,7 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::Accession::Publish do
   let(:druid) { 'druid:oo000oo0001' }
   let(:robot) { described_class.new }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, publish: true) }
-
-  before do
-    expect(Dor).to receive(:find).with(druid).and_return(object)
-  end
+  let(:object_client) { instance_double(Dor::Services::Client::Object, publish: true, find: object) }
 
   describe '#perform' do
     subject(:perform) { robot.perform(druid) }
@@ -20,7 +16,12 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
     end
 
     context 'when called on a Collection' do
-      let(:object) { Dor::Collection.new }
+      let(:object) do
+        Cocina::Models::Collection.new(externalIdentifier: '123',
+                                       type: Cocina::Models::Collection::TYPES.first,
+                                       label: 'my collection',
+                                       version: 1)
+      end
 
       it 'publishes metadata' do
         expect(object_client).to have_received(:publish)
@@ -28,7 +29,12 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
     end
 
     context 'when called on an Item' do
-      let(:object) { Dor::Item.new }
+      let(:object) do
+        Cocina::Models::DRO.new(externalIdentifier: '123',
+                                type: Cocina::Models::DRO::TYPES.first,
+                                label: 'my repository object',
+                                version: 1)
+      end
 
       it 'publishes metadata' do
         expect(object_client).to have_received(:publish)
@@ -36,7 +42,12 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
     end
 
     context 'when called on an APO' do
-      let(:object) { Dor::AdminPolicyObject.new }
+      let(:object) do
+        Cocina::Models::AdminPolicy.new(externalIdentifier: '123',
+                                        type: Cocina::Models::AdminPolicy::TYPES.first,
+                                        label: 'my admin policy',
+                                        version: 1)
+      end
 
       it 'does not publish metadata' do
         expect(object_client).not_to have_received(:publish)

--- a/spec/robots/accession/shelve_spec.rb
+++ b/spec/robots/accession/shelve_spec.rb
@@ -5,10 +5,9 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::Accession::Shelve do
   let(:druid) { 'druid:oo000oo0001' }
   let(:robot) { described_class.new }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, shelve: nil) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, shelve: nil, find: object) }
 
   before do
-    expect(Dor).to receive(:find).with(druid).and_return(object)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
   end
 
@@ -20,7 +19,12 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
     end
 
     context 'when called on a Collection' do
-      let(:object) { Dor::Collection.new }
+      let(:object) do
+        Cocina::Models::Collection.new(externalIdentifier: '123',
+                                       type: Cocina::Models::Collection::TYPES.first,
+                                       label: 'my collection',
+                                       version: 1)
+      end
 
       it 'does not shelve' do
         expect(object_client).not_to have_received(:shelve)
@@ -28,7 +32,12 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
     end
 
     context 'when called on an Item' do
-      let(:object) { Dor::Item.new }
+      let(:object) do
+        Cocina::Models::DRO.new(externalIdentifier: '123',
+                                type: Cocina::Models::DRO::TYPES.first,
+                                label: 'my repository object',
+                                version: 1)
+      end
 
       it 'shelves the item' do
         expect(object_client).to have_received(:shelve)
@@ -36,7 +45,12 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
     end
 
     context 'when called on an APO' do
-      let(:object) { Dor::AdminPolicyObject.new }
+      let(:object) do
+        Cocina::Models::AdminPolicy.new(externalIdentifier: '123',
+                                        type: Cocina::Models::AdminPolicy::TYPES.first,
+                                        label: 'my admin policy',
+                                        version: 1)
+      end
 
       it 'does not shelve' do
         expect(object_client).not_to have_received(:shelve)


### PR DESCRIPTION
Instead call the dor-service-app API.  This will enable us to break the coupling to ActiveFedora and Fedora 3