### PR TITLE
Replace resque:pool:full_restart with hot_swap

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -46,4 +46,4 @@ set :resque_server_roles, :app
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
 
-after 'deploy:publishing', 'resque:pool:full_restart'
+after 'deploy:publishing', 'resque:pool:hot_swap'


### PR DESCRIPTION
  To avoid worker downtime during deployment
  Used in preservation_robots successfully for a while now