### PR TITLE
Fix random spec.

### DIFF
--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -204,6 +204,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       context 'and overwrite is true' do
         before do
           Settings.assembly.overwrite_jp2 = true
+          Settings.assembly.overwrite_dpg_jp2 = false
 
           allow_any_instance_of(Assembly::ObjectFile).to receive(:jp2able?).and_return(true)
           out1 = 'tmp/test_input/ff/222/cc/3333/image114.jp2'


### PR DESCRIPTION
Prior to this change this sequence would cause a failure:

```
rspec spec/robots/assembly/jp2_create_spec.rb:227 spec/robots/assembly/jp2_create_spec.rb:321 --seed 54373
```