### PR TITLE
Prune dead code

### DIFF
--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -18,10 +18,6 @@ module Dor
         check_for_path
       end
 
-      def object
-        @object ||= Dor.find(@druid.druid)
-      end
-
       def check_for_path
         raise "Path to object #{@druid.id} not found in any of the root directories: #{@root_dir.join(',')}" if path_to_object.nil?
       end


### PR DESCRIPTION
## Why was this change made?

Having dead code lying around is confusing.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a