### PR TITLE
Make the remediate step a no-op

### DIFF
--- a/lib/robots/dor_repo/accession/remediate_object.rb
+++ b/lib/robots/dor_repo/accession/remediate_object.rb
@@ -11,8 +11,7 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor.find(druid)
-          obj.upgrade! if obj.respond_to? :upgrade!
+          # nop
         end
       end
     end

--- a/spec/robots/accession/remediate_object_spec.rb
+++ b/spec/robots/accession/remediate_object_spec.rb
@@ -11,26 +11,8 @@ RSpec.describe Robots::DorRepo::Accession::RemediateObject do
   end
 
   describe '#perform' do
-    before do
-      expect(Dor).to receive(:find).with(druid).and_return(object)
-    end
-
-    context 'on an object where upgrade! is defined' do
-      let(:object) { double(:upgrade! => true) }
-
-      it 'calls .upgrade!' do
-        robot.perform(druid)
-        expect(object).to have_received(:upgrade!)
-      end
-    end
-
-    context 'on an object where upgrade! is defined' do
-      let(:object) { Object.new }
-
-      it 'does not call .upgrade!' do
-        # we want to be sure that a NoMethodError is not raised
-        expect { robot.perform(druid) }.not_to raise_error
-      end
+    it 'gives no error' do
+      robot.perform(druid)
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?

The method this is calling was removed 3 years ago:
https://github.com/sul-dlss/dor-services/pull/260/files#diff-a42b00f2db1198c23e44cdfc6ed95658L58


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
