### PR TITLE
Fix a flapping spec

### DIFF
--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -203,9 +203,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
 
       context 'and overwrite is true' do
         before do
-          Settings.assembly.overwrite_jp2 = true
-          Settings.assembly.overwrite_dpg_jp2 = false
-
+          allow(Settings.assembly).to receive_messages(overwrite_jp2: true, overwrite_dpg_jp2: false)
           allow_any_instance_of(Assembly::ObjectFile).to receive(:jp2able?).and_return(true)
           out1 = 'tmp/test_input/ff/222/cc/3333/image114.jp2'
           d1 = instance_double(Assembly::Image, path: out1)


### PR DESCRIPTION
## Why was this change made?

Prior to this change, a test failure could be triggered by running:
```
rspec spec/robots/assembly/jp2_create_spec.rb[1:2:1:1,1:2:4:2:1] --seed 15263
```

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a