### PR TITLE
Handle asynchronous shelving

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 5.2'
 gem 'config', '~> 1.7'
 gem 'dor-fetcher', '~> 1.3'
 gem 'dor-services', '~> 8.0'
-gem 'dor-services-client', '~> 3.3'
+gem 'dor-services-client', '~> 3.5'
 gem 'dor-workflow-client', '~> 3.7'
 gem 'lyber-core', '~> 5.1'
 gem 'marc' # for etd_submit/submit_marc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (3.3.0)
+    dor-services-client (3.5.0)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.6.0)
       deprecation
@@ -218,7 +218,7 @@ GEM
     mini_exiftool (2.9.0)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.12.2)
+    minitest (5.13.0)
     moab-versioning (4.2.2)
       confstruct
       druid-tools (>= 1.0.0)
@@ -413,7 +413,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-fetcher (~> 1.3)
   dor-services (~> 8.0)
-  dor-services-client (~> 3.3)
+  dor-services-client (~> 3.5)
   dor-workflow-client (~> 3.7)
   honeybadger
   jhove-service (~> 1.3)

--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -10,10 +10,14 @@ module Robots
         end
 
         def perform(druid)
-          object_client = Dor::Services::Client.object(druid)
-          obj = object_client.find
+          background_result_url = Dor::Services::Client.object(druid).shelve
+          result = Dor::Services::Client::AsyncResult.new(url: background_result_url)
 
-          object_client.shelve if obj.is_a?(Cocina::Models::DRO)
+          raise "Job errors from #{background_result_url}: #{result.errors.inspect}" unless result.wait_until_complete
+          # rubocop:disable Lint/HandleExceptions
+        rescue Dor::Services::Client::UnexpectedResponse
+          # nop - this object wasn't an item.
+          # rubocop:enable Lint/HandleExceptions
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

Some shelving takes too long so was moved to being asynchronous.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a