### PR TITLE
Update the timeout to 30 minutes for shelving

### DIFF
--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -12,8 +12,8 @@ module Robots
         def perform(druid)
           background_result_url = Dor::Services::Client.object(druid).shelve
           result = Dor::Services::Client::AsyncResult.new(url: background_result_url)
-
-          raise "Job errors from #{background_result_url}: #{result.errors.inspect}" unless result.wait_until_complete
+          seconds = 30 * 60 # 30 minutes -  web-archive jobs can take a long time. I've seen 20 minutes
+          raise "Job errors from #{background_result_url}: #{result.errors.inspect}" unless result.wait_until_complete(timeout_in_seconds: seconds)
           # rubocop:disable Lint/HandleExceptions
         rescue Dor::Services::Client::UnexpectedResponse
           # nop - this object wasn't an item.


### PR DESCRIPTION
## Why was this change made?

Some shelving operations, namely web-archiving take a long time.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a