### PR TITLE
Revert "Prune Dead Code"

### DIFF
--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -18,6 +18,10 @@ module Dor
         check_for_path
       end
 
+      def object
+        @object ||= Dor.find(@druid.druid)
+      end
+
       def check_for_path
         raise "Path to object #{@druid.id} not found in any of the root directories: #{@root_dir.join(',')}" if path_to_object.nil?
       end

--- a/lib/robots/dor_repo/assembly/base.rb
+++ b/lib/robots/dor_repo/assembly/base.rb
@@ -8,7 +8,6 @@ module Robots
 
         def with_item(druid)
           ai = item(druid)
-
           if !ai.item?
             LyberCore::Log.info("Skipping #{@step_name} for #{druid} since it is not an item")
           else

--- a/spec/robots/assembly/accessioning_initiate_spec.rb
+++ b/spec/robots/assembly/accessioning_initiate_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Robots::DorRepo::Assembly::AccessioningInitiate do
 
   context 'when the type is item' do
     before do
-      setup_assembly_item(druid, :item)
+      @assembly_item = setup_assembly_item(druid, :item)
     end
 
     it 'initiates accessioning' do
@@ -32,7 +32,7 @@ RSpec.describe Robots::DorRepo::Assembly::AccessioningInitiate do
 
   context 'when the type is set' do
     before do
-      setup_assembly_item(druid, :set)
+      @assembly_item = setup_assembly_item(druid, :set)
     end
 
     it 'initiates accessioning, but does not initialize the workspace' do

--- a/spec/robots/assembly/checksum_compute_spec.rb
+++ b/spec/robots/assembly/checksum_compute_spec.rb
@@ -5,12 +5,11 @@ require 'spec_helper'
 describe Robots::DorRepo::Assembly::ChecksumCompute do
   before do
     @druid = 'aa222cc3333'
-    allow(Dor::Assembly::Item).to receive(:new).and_return(@assembly_item)
     @r = described_class.new(druid: @druid)
   end
 
   it 'computes checksums for type=item' do
-    setup_assembly_item(@druid, :item)
+    @assembly_item = setup_assembly_item(@druid, :item)
     expect(@assembly_item).to be_item
     expect(@assembly_item).to receive(:load_content_metadata)
     expect(@assembly_item).to receive(:compute_checksums)
@@ -18,7 +17,7 @@ describe Robots::DorRepo::Assembly::ChecksumCompute do
   end
 
   it 'does not compute checksums for type=set' do
-    setup_assembly_item(@druid, :set)
+    @assembly_item = setup_assembly_item(@druid, :set)
     expect(@assembly_item).not_to be_item
     expect(@assembly_item).not_to receive(:load_content_metadata)
     expect(@assembly_item).not_to receive(:compute_checksums)

--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
     subject(:perform) { robot.perform(@assembly_item) }
 
     before do
-      setup_assembly_item(druid, type)
+      @assembly_item = setup_assembly_item(druid, type)
     end
 
     let(:druid) { 'aa222cc3333' }
@@ -26,7 +26,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       let(:type) { :item }
 
       it 'creates jp2 for type=item' do
-        expect(@assembly_item).to receive(:item?)
+        expect(@assembly_item).to receive(:item?).and_call_original
         expect(@assembly_item).to receive(:load_content_metadata)
         expect(robot).to receive(:create_jp2s).with(@assembly_item)
         perform

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,15 +71,14 @@ def fixture_dir
 end
 
 def setup_assembly_item(druid, obj_type = :item)
-  @assembly_item = Dor::Assembly::Item.new(druid: druid)
-  allow(@assembly_item).to receive('druid').and_return(DruidTools::Druid.new(druid))
-  allow(@assembly_item).to receive('id').and_return(druid)
-  if obj_type == :item
-    allow(@assembly_item).to receive(:object_type).and_return('item')
-    allow(@assembly_item).to receive(:item?).and_return(true)
-  else
-    allow(@assembly_item).to receive(:object_type).and_return(obj_type.to_s)
-    allow(@assembly_item).to receive(:item?).and_return(false)
-  end
-  allow(Dor::Assembly::Item).to receive(:new).and_return(@assembly_item)
+  assembly_item = Dor::Assembly::Item.new(druid: druid)
+  allow(assembly_item).to receive('druid').and_return(DruidTools::Druid.new(druid))
+  allow(assembly_item).to receive('id').and_return(druid)
+  # have to disable this check, because OM is doing odd metaprogramming
+  # rubocop:disable RSpec/VerifiedDoubles
+  identity_metadata = double(Dor::IdentityMetadataDS, objectType: [obj_type.to_s])
+  # rubocop:enable RSpec/VerifiedDoubles
+  allow(Dor).to receive(:find).and_return(instance_double(Dor::Item, identityMetadata: identity_metadata))
+  allow(Dor::Assembly::Item).to receive(:new).and_return(assembly_item)
+  assembly_item
 end


### PR DESCRIPTION
## Why was this change made?

This reverts commit aefba29f681438e73066343d2413fccefc46f540. Because the code wasn't dead, it just wasn't covered by tests.  Added tests that cover it.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

N/a