### PR TITLE
Increase the timeout for shelve jobs

### DIFF
--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -12,7 +12,7 @@ module Robots
         def perform(druid)
           background_result_url = Dor::Services::Client.object(druid).shelve
           result = Dor::Services::Client::AsyncResult.new(url: background_result_url)
-          seconds = 30 * 60 # 30 minutes -  web-archive jobs can take a long time. I've seen 20 minutes
+          seconds = 12 * 60 * 60 # 12 hours worth of seconds - web-archive jobs can take a long time. I've seen over 10 hrs
           raise "Job errors from #{background_result_url}: #{result.errors.inspect}" unless result.wait_until_complete(timeout_in_seconds: seconds)
           # rubocop:disable Lint/HandleExceptions
         rescue Dor::Services::Client::UnexpectedResponse


### PR DESCRIPTION
## Why was this change made?

To accommodate long jobs without having timeouts.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a