### PR TITLE
Wait for publish jobs to finish

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 5.2'
 gem 'config', '~> 1.7'
 gem 'dor-fetcher', '~> 1.3'
 gem 'dor-services', '~> 8.0'
-gem 'dor-services-client', '~> 3.5'
+gem 'dor-services-client', '~> 3.6'
 gem 'dor-workflow-client', '~> 3.7'
 gem 'lyber-core', '~> 5.1'
 gem 'marc' # for etd_submit/submit_marc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (3.5.0)
+    dor-services-client (3.6.0)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.6.0)
       deprecation
@@ -413,7 +413,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-fetcher (~> 1.3)
   dor-services (~> 8.0)
-  dor-services-client (~> 3.5)
+  dor-services-client (~> 3.6)
   dor-workflow-client (~> 3.7)
   honeybadger
   jhove-service (~> 1.3)

--- a/lib/robots/dor_repo/accession/publish.rb
+++ b/lib/robots/dor_repo/accession/publish.rb
@@ -14,7 +14,12 @@ module Robots
           object_client = Dor::Services::Client.object(druid)
           obj = object_client.find
 
-          object_client.publish unless obj.is_a?(Cocina::Models::AdminPolicy)
+          return if obj.is_a?(Cocina::Models::AdminPolicy)
+
+          background_result_url = object_client.publish
+          result = object_client.async_result(url: background_result_url)
+          seconds = 2 * 60 * 60 # 2 hours of seconds
+          raise "Job errors from #{background_result_url}: #{result.errors.inspect}" unless result.wait_until_complete(timeout_in_seconds: seconds)
         end
       end
     end

--- a/spec/robots/accession/publish_spec.rb
+++ b/spec/robots/accession/publish_spec.rb
@@ -5,7 +5,13 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::Accession::Publish do
   let(:druid) { 'druid:oo000oo0001' }
   let(:robot) { described_class.new }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, publish: true, find: object) }
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object,
+                    publish: 'http://dor-services/background-job/123',
+                    find: object,
+                    async_result: result)
+  end
+  let(:result) { instance_double(Dor::Services::Client::AsyncResult, wait_until_complete: true) }
 
   describe '#perform' do
     subject(:perform) { robot.perform(druid) }


### PR DESCRIPTION
## Why was this change made?

Publish jobs were made asynchronous as they were timing out. We should wait for them to complete.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a
