### PR TITLE
Remove exception that obscures the source of the error

### DIFF
--- a/lib/sdr_ingest_service.rb
+++ b/lib/sdr_ingest_service.rb
@@ -35,8 +35,6 @@ class SdrIngestService
 
     # start SDR preservation workflow
     Dor::Config.workflow.client.create_workflow_by_name(druid, 'preservationIngestWF')
-  rescue Exception => e
-    raise Dor::Exception, "Error exporting new object version to bag for #{dor_item.pid}: #{e.message}"
   end
 
   # Note: the following methods should probably all be private


### PR DESCRIPTION
## Why was this change made?
Previously Honeybadger was reporting any error in this method the same and obscuring the source.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a
