### PR TITLE
[Need PO approval] Allow dor-services-app to use callbacks rather than polling

### DIFF
--- a/lib/robots/dor_repo/accession/publish.rb
+++ b/lib/robots/dor_repo/accession/publish.rb
@@ -16,10 +16,8 @@ module Robots
 
           return if obj.is_a?(Cocina::Models::AdminPolicy)
 
-          background_result_url = object_client.publish
-          result = object_client.async_result(url: background_result_url)
-          seconds = 2 * 60 * 60 # 2 hours of seconds
-          raise "Job errors from #{background_result_url}: #{result.errors.inspect}" unless result.wait_until_complete(timeout_in_seconds: seconds)
+          # This is an async result and it will have a callback.
+          object_client.publish
         end
       end
     end

--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -10,10 +10,8 @@ module Robots
         end
 
         def perform(druid)
-          background_result_url = Dor::Services::Client.object(druid).shelve
-          result = Dor::Services::Client::AsyncResult.new(url: background_result_url)
-          seconds = 12 * 60 * 60 # 12 hours worth of seconds - web-archive jobs can take a long time. I've seen over 10 hrs
-          raise "Job errors from #{background_result_url}: #{result.errors.inspect}" unless result.wait_until_complete(timeout_in_seconds: seconds)
+          # This is an async result and it will have a callback.
+          Dor::Services::Client.object(druid).shelve
           # rubocop:disable Lint/HandleExceptions
         rescue Dor::Services::Client::UnexpectedResponse
           # nop - this object wasn't an item.

--- a/spec/robots/accession/publish_spec.rb
+++ b/spec/robots/accession/publish_spec.rb
@@ -8,10 +8,8 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object,
                     publish: 'http://dor-services/background-job/123',
-                    find: object,
-                    async_result: result)
+                    find: object)
   end
-  let(:result) { instance_double(Dor::Services::Client::AsyncResult, wait_until_complete: true) }
 
   describe '#perform' do
     subject(:perform) { robot.perform(druid) }

--- a/spec/robots/accession/shelve_spec.rb
+++ b/spec/robots/accession/shelve_spec.rb
@@ -28,24 +28,9 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
     context 'when called on an Item' do
       let(:object_client) { instance_double(Dor::Services::Client::Object, shelve: 'http://dor-services/background-job/123') }
 
-      before do
-        allow(Dor::Services::Client::AsyncResult).to receive(:new).and_return(result)
-      end
-
       context "when it's successful" do
-        let(:result) { instance_double(Dor::Services::Client::AsyncResult, wait_until_complete: true) }
-
         it 'shelves the item' do
           perform
-          expect(object_client).to have_received(:shelve)
-        end
-      end
-
-      context 'when there is an error' do
-        let(:result) { instance_double(Dor::Services::Client::AsyncResult, wait_until_complete: false, errors: ['bad time']) }
-
-        it 'raises the error item' do
-          expect { perform }.to raise_error('Job errors from http://dor-services/background-job/123: ["bad time"]')
           expect(object_client).to have_received(:shelve)
         end
       end


### PR DESCRIPTION
## Why was this change made?

The polling operations can timeout and are not possible to reset using argo.
Depends on https://github.com/sul-dlss/dor-services-app/pull/490
 and https://github.com/sul-dlss/workflow-server-rails/pull/271


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a