### PR TITLE
Report which workflow the callback for publish should report to

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 5.2'
 gem 'config', '~> 1.7'
 gem 'dor-fetcher', '~> 1.3'
 gem 'dor-services', '~> 8.0'
-gem 'dor-services-client', '~> 3.6'
+gem 'dor-services-client', '~> 3.7'
 gem 'dor-workflow-client', '~> 3.7'
 gem 'lyber-core', '~> 5.1'
 gem 'marc' # for etd_submit/submit_marc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (3.6.0)
+    dor-services-client (3.7.0)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.6.0)
       deprecation
@@ -413,7 +413,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-fetcher (~> 1.3)
   dor-services (~> 8.0)
-  dor-services-client (~> 3.6)
+  dor-services-client (~> 3.7)
   dor-workflow-client (~> 3.7)
   honeybadger
   jhove-service (~> 1.3)

--- a/lib/robots/dor_repo/accession/publish.rb
+++ b/lib/robots/dor_repo/accession/publish.rb
@@ -17,7 +17,7 @@ module Robots
           return if obj.is_a?(Cocina::Models::AdminPolicy)
 
           # This is an async result and it will have a callback.
-          object_client.publish
+          object_client.publish(workflow: 'accessionWF')
         end
       end
     end

--- a/lib/robots/dor_repo/release/release_publish.rb
+++ b/lib/robots/dor_repo/release/release_publish.rb
@@ -16,7 +16,8 @@ module Robots
         # @param [String] druid -- the Druid identifier for the object to process
         def perform(druid)
           LyberCore::Log.debug "release-publish working on #{druid}"
-          Dor::Services::Client.object(druid).publish
+          # This is an async result and it will have a callback.
+          Dor::Services::Client.object(druid).publish(workflow: 'releaseWF')
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

So the api call knows which workflow to callback to.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a