### PR TITLE
Remove force flag for contentMetadata

### DIFF
--- a/lib/robots/dor_repo/accession/content_metadata.rb
+++ b/lib/robots/dor_repo/accession/content_metadata.rb
@@ -14,8 +14,7 @@ module Robots
           return unless obj.is_a?(Dor::Item)
 
           builder = DatastreamBuilder.new(object: obj,
-                                          datastream: obj.contentMetadata,
-                                          force: true)
+                                          datastream: obj.contentMetadata)
           builder.build do |ds|
             # No-op
           end

--- a/spec/robots/accession/content_metadata_spec.rb
+++ b/spec/robots/accession/content_metadata_spec.rb
@@ -21,7 +21,6 @@ RSpec.describe Robots::DorRepo::Accession::ContentMetadata do
       it 'builds a datastream' do
         expect(DatastreamBuilder).to receive(:new)
           .with(datastream: Dor::ContentMetadataDS,
-                force: true,
                 object: object).and_return(builder)
         expect(builder).to receive(:build)
         perform


### PR DESCRIPTION
## Why was this change made?

This has no effect when the block passed to build is empty.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

N/A.