### PR TITLE
Remove unnecessary object parameter from DatastreamBuilder

### DIFF
--- a/lib/datastream_builder.rb
+++ b/lib/datastream_builder.rb
@@ -11,12 +11,10 @@
 # exists and is newer than the object's current datastream (see above); otherwise,
 # builds the datastream by calling build_fooMetadata_datastream.
 class DatastreamBuilder
-  # @param [ActiveFedora::Base] object The object that contains the datastream
   # @param [ActiveFedora::Datastream] datastream The datastream object
   # @param [Boolean] force Should we overwrite existing datastream?
   # @return [ActiveFedora::Datastream]
-  def initialize(object:, datastream:, force: false)
-    @object = object
+  def initialize(datastream:, force: false)
     @datastream = datastream
     @force = force
   end
@@ -41,12 +39,12 @@ class DatastreamBuilder
     # NOTE: can't use save! because this is an ActiveFedora::Datastream, so we get
     # OM::XML::Terminology::BadPointerError:
     #   This Terminology does not have a root term defined that corresponds to ":save!"
-    raise "Problem saving ActiveFedora::Datastream #{datastream_name} for #{object.pid}" unless datastream.save
+    raise "Problem saving ActiveFedora::Datastream #{datastream_name} for #{datastream.pid}" unless datastream.save
   end
 
   private
 
-  attr_reader :datastream, :force, :object
+  attr_reader :datastream, :force
 
   def filename
     @filename ||= find_metadata_file
@@ -80,7 +78,7 @@ class DatastreamBuilder
   # Tries to find a file for the datastream.
   # @return [String, nil] path to datastream or nil
   def find_metadata_file
-    druid = DruidTools::Druid.new(object.pid, Dor::Config.stacks.local_workspace_root)
+    druid = DruidTools::Druid.new(datastream.pid, Dor::Config.stacks.local_workspace_root)
     druid.find_metadata("#{datastream_name}.xml")
   end
 

--- a/lib/robots/dor_repo/accession/content_metadata.rb
+++ b/lib/robots/dor_repo/accession/content_metadata.rb
@@ -13,9 +13,7 @@ module Robots
           obj = Dor.find(druid)
           return unless obj.is_a?(Dor::Item)
 
-          builder = DatastreamBuilder.new(object: obj,
-                                          datastream: obj.contentMetadata)
-          builder.build do |ds|
+          DatastreamBuilder.new(datastream: obj.contentMetadata).build do |ds|
             # No-op
           end
         end

--- a/lib/robots/dor_repo/accession/descriptive_metadata.rb
+++ b/lib/robots/dor_repo/accession/descriptive_metadata.rb
@@ -13,8 +13,7 @@ module Robots
 
         def perform(druid)
           obj = Dor.find(druid)
-          builder = DatastreamBuilder.new(object: obj,
-                                          datastream: obj.descMetadata)
+          builder = DatastreamBuilder.new(datastream: obj.descMetadata)
           builder.build do |_ds|
             # If there's no file on disk that's newer than the datastream and
             # the datastream has never been populated, use Symphony:

--- a/lib/robots/dor_repo/accession/rights_metadata.rb
+++ b/lib/robots/dor_repo/accession/rights_metadata.rb
@@ -11,8 +11,7 @@ module Robots
 
         def perform(druid)
           obj = Dor.find(druid)
-          builder = DatastreamBuilder.new(object: obj,
-                                          datastream: obj.rightsMetadata)
+          builder = DatastreamBuilder.new(datastream: obj.rightsMetadata)
 
           builder.build do |datastream|
             build_datastream(obj, datastream)

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -13,8 +13,7 @@ module Robots
           obj = Dor.find(druid)
           return unless obj.is_a?(Dor::Item)
 
-          builder = DatastreamBuilder.new(object: obj,
-                                          datastream: obj.technicalMetadata,
+          builder = DatastreamBuilder.new(datastream: obj.technicalMetadata,
                                           force: true)
           builder.build do |_datastream|
             TechnicalMetadataService.add_update_technical_metadata(obj)

--- a/spec/lib/datastream_builder_spec.rb
+++ b/spec/lib/datastream_builder_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe DatastreamBuilder do
   subject(:builder) do
-    described_class.new(object: item, datastream: ds, force: true)
+    described_class.new(datastream: ds, force: true)
   end
 
   let(:ds) { item.technicalMetadata }

--- a/spec/robots/accession/content_metadata_spec.rb
+++ b/spec/robots/accession/content_metadata_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Robots::DorRepo::Accession::ContentMetadata do
 
       it 'builds a datastream' do
         expect(DatastreamBuilder).to receive(:new)
-          .with(datastream: Dor::ContentMetadataDS,
-                object: object).and_return(builder)
+          .with(datastream: Dor::ContentMetadataDS)
+          .and_return(builder)
         expect(builder).to receive(:build)
         perform
       end

--- a/spec/robots/accession/descriptive_metadata_spec.rb
+++ b/spec/robots/accession/descriptive_metadata_spec.rb
@@ -28,11 +28,11 @@ RSpec.describe Robots::DorRepo::Accession::DescriptiveMetadata do
       end
 
       let(:desc_md) do
-        instance_double(Dor::DescMetadataDS, mods_title: nil, dsid: 'descMetadata', new?: true, save: true)
+        instance_double(Dor::DescMetadataDS, pid: druid, mods_title: nil, dsid: 'descMetadata', new?: true, save: true)
       end
 
       let!(:object) do
-        instance_double(Dor::Item, pid: druid, catkey: '12345', reload: true, descMetadata: desc_md)
+        instance_double(Dor::Item, catkey: '12345', reload: true, descMetadata: desc_md)
       end
 
       context 'when descMetadata mods has no <title>' do
@@ -43,7 +43,7 @@ RSpec.describe Robots::DorRepo::Accession::DescriptiveMetadata do
 
       context 'when descMetadata has a mods_title value' do
         let(:desc_md) do
-          instance_double(Dor::DescMetadataDS, mods_title: 'anything', dsid: 'descMetadata', new?: true, save: true)
+          instance_double(Dor::DescMetadataDS, pid: druid, mods_title: 'anything', dsid: 'descMetadata', new?: true, save: true)
         end
 
         it 'does not raise error' do

--- a/spec/robots/accession/technical_metadata_spec.rb
+++ b/spec/robots/accession/technical_metadata_spec.rb
@@ -20,9 +20,8 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
 
       it 'builds a datastream' do
         expect(DatastreamBuilder).to receive(:new)
-          .with(datastream: Dor::TechnicalMetadataDS,
-                force: true,
-                object: object).and_return(builder)
+          .with(datastream: Dor::TechnicalMetadataDS, force: true)
+          .and_return(builder)
         expect(builder).to receive(:build)
         perform
       end


### PR DESCRIPTION
## Why was this change made?

There's no need to pass object as an argument, the datastream object has all the information this class needs.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a