### PR TITLE
Use the non-deprecated workflow methods

### DIFF
--- a/lib/robots/dor_repo/etd_submit/binder_batch_transfer.rb
+++ b/lib/robots/dor_repo/etd_submit/binder_batch_transfer.rb
@@ -144,7 +144,7 @@ module Robots
         end
 
         def workflow_error(druid, error)
-          workflow_service.update_workflow_error_status 'dor', druid, 'etdSubmitWF', 'binder-transfer', error.inspect
+          workflow_service.update_error_status druid: druid, workflow: 'etdSubmitWF', process: 'binder-transfer', error_msg: error.inspect
         rescue StandardError => e
           LyberCore::Log.error("Unable to set workflow to error for #{druid}")
           LyberCore::Log.error(e.inspect.to_s)

--- a/lib/robots/dor_repo/etd_submit/catalog_status.rb
+++ b/lib/robots/dor_repo/etd_submit/catalog_status.rb
@@ -34,14 +34,13 @@ module Robots
 
           #========= check the symphonystatus and update it with any changes ==========#
 
-          etd_accession_wf = Nokogiri::XML(workflow_service.workflow_xml('dor', druid, 'etdSubmitWF'))
-          status = etd_accession_wf.search('//process[@name = "catalog-status"]').first
-
           #========= if current_location = home_location, return true to advance workflow ==========#
           return true if current_location.content == home_location.content
 
+          status = workflow_service.workflow_status(druid: druid, workflow: 'etdSubmitWF', process: 'catalog-status')
+
           #========= if status != current_location, update the ds ==========#
-          return if status['status'] == current_location.content
+          return if status == current_location.content
 
           @status = current_location.content
           nil

--- a/spec/robots/etd_submit/catalog_status_spec.rb
+++ b/spec/robots/etd_submit/catalog_status_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe Robots::DorRepo::EtdSubmit::CatalogStatus do
 
     before do
       allow(Dor).to receive(:find).and_return(object)
-      allow(Dor::Config.workflow.client).to receive(:workflow_xml).and_return(workflow)
+      allow(Dor::Config.workflow.client).to receive(:workflow_status).and_return(status)
       stub_request(:get, 'http://lyberservices-dev.stanford.edu/cgi-bin/holdings.php?flexkey=dorbd185gs2259')
         .to_return(status: 200, body: xml)
     end
 
     let(:druid) { 'druid:bd185gs2259' }
     let(:object) { Etd.new(pid: druid) }
-    let(:workflow) { '<processes />' }
+    let(:status) { nil }
 
     context 'when nodes are empty' do
       let(:xml) { '<xml />' }
@@ -74,27 +74,7 @@ RSpec.describe Robots::DorRepo::EtdSubmit::CatalogStatus do
         XML
       end
 
-      let(:workflow) do
-        <<~XML
-          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <workflow objectId="druid:mj151qw9093" id="etdAccessionWF">
-                <process name="start-accession" lifecycle="inprocess" status="completed" attempts="1" />
-                <process name="submit-marc" lifecycle="inprocess" status="waiting" />
-                <process name="check-marc" status="waiting" />
-                <process name="catalog-status" status="waiting" />
-                <process name="descriptive-metadata" status="waiting" />
-                <process name="ingest-deposit" status="waiting" />
-                <process name="ingest-receipt" status="waiting" />
-                <process name="shelve" life-cycle="released" status="waiting" />
-                <process name="google-send" status="waiting" />
-                <process name="google-confirm" status="waiting" />
-                <process name="qoop-send" status="waiting" />
-                <process name="qoop-confirm" status="waiting" />
-                <process name="cleanup" lifecycle="accessioned" status="waiting" />
-                <process name="ingest-complete" lifecycle="archived" status="waiting" />
-            </workflow>
-        XML
-      end
+      let(:status) { 'waiting' }
 
       it 'returns nil' do
         expect(perform).to be_nil


### PR DESCRIPTION
## Why was this change made?

These methods are deprecated, so we should use the preferred methods instead.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a