### PR TITLE
Update descMetadata using an API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 5.2'
 gem 'config', '~> 1.7'
 gem 'dor-fetcher', '~> 1.3'
 gem 'dor-services', '~> 8.0'
-gem 'dor-services-client', '~> 3.7'
+gem 'dor-services-client', '~> 3.9'
 gem 'dor-workflow-client', '~> 3.11'
 gem 'lyber-core', '~> 5.4'
 gem 'marc' # for etd_submit/submit_marc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (3.8.0)
+    dor-services-client (3.9.0)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.6.0)
       deprecation
@@ -413,7 +413,7 @@ DEPENDENCIES
   dlss-capistrano (~> 3.1)
   dor-fetcher (~> 1.3)
   dor-services (~> 8.0)
-  dor-services-client (~> 3.7)
+  dor-services-client (~> 3.9)
   dor-workflow-client (~> 3.11)
   honeybadger
   jhove-service (~> 1.3)


### PR DESCRIPTION
## Why was this change made?

This decouples the robot from Fedora and switches to an API based interface.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a
