### PR TITLE
Extract PathFinder from Assembly::Item

### DIFF
--- a/lib/dor/assembly/content_metadata.rb
+++ b/lib/dor/assembly/content_metadata.rb
@@ -12,12 +12,12 @@ module Dor
 
       # return the location to store or load the contentMetadata.xml file (could be in either the new or old location)
       def cm_file_name
-        @cm_file_name ||= path_to_metadata_file(Settings.assembly.cm_file_name)
+        @cm_file_name ||= path_finder.path_to_metadata_file(Settings.assembly.cm_file_name)
       end
 
       # return the location to read the stubContentMetadata.xml file from (could be in either the new or old location)
       def stub_cm_file_name
-        @stub_cm_file_name ||= path_to_metadata_file(Settings.assembly.stub_cm_file_name)
+        @stub_cm_file_name ||= path_finder.path_to_metadata_file(Settings.assembly.stub_cm_file_name)
       end
 
       def content_metadata_exists?
@@ -73,7 +73,7 @@ module Dor
 
       def fnode_tuples(resource_type = '')
         # Returns a list of filenode pairs (file node and associated ObjectFile object), optionally restricted to specific resource content types if specified
-        file_nodes(resource_type).map { |fn| [fn, ::Assembly::ObjectFile.new(path_to_content_file(fn['id']))] }
+        file_nodes(resource_type).map { |fn| [fn, ::Assembly::ObjectFile.new(path_finder.path_to_content_file(fn['id']))] }
       end
 
       def create_basic_content_metadata
@@ -84,7 +84,7 @@ module Dor
         LyberCore::Log.info("Creating basic content metadata for #{druid.id}")
 
         # get a list of files in content folder recursively and sort them
-        files = Dir["#{path_to_content_folder}/**/*"].reject { |file| File.directory? file }.sort
+        files = Dir["#{path_finder.path_to_content_folder}/**/*"].reject { |file| File.directory? file }.sort
         return nil if files.empty? # only generate contentMetadata if there are files in the content folder, else return nil
 
         cm_resources = files.map { |file| ::Assembly::ObjectFile.new(file) }
@@ -102,7 +102,7 @@ module Dor
 
         cm_resources = resources.map do |resource| # loop over all resources from the stub content metadata
           resource_files(resource).map do |file| # loop over the files in this resource
-            obj_file = ::Assembly::ObjectFile.new(File.join(path_to_content_folder, filename(file)))
+            obj_file = ::Assembly::ObjectFile.new(File.join(path_finder.path_to_content_folder, filename(file)))
             # set the default file attributes here (instead of in the create_content_metadata step in the gem below)
             #  so they can overridden/added to by values coming from the stub content metadata
             obj_file.file_attributes = default_file_attributes(obj_file).merge(stub_file_attributes(file))

--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -4,24 +4,18 @@ module Dor
   module Assembly
     class Item
       include Dor::Assembly::ContentMetadata
-      include Dor::Assembly::Findable
 
       def initialize(params = {})
         # Takes a druid, either as a string or as a Druid object.
         # Always converts @druid to a Druid object.
         @druid = params[:druid]
         @druid = DruidTools::Druid.new(@druid) unless @druid.class == DruidTools::Druid
-        root_dir_config = Settings.assembly.root_dir
-        @root_dir = root_dir_config.class == String ? [root_dir_config] : root_dir_config # this allows us to accept either a string or an array of strings as a root dir configuration
-        check_for_path
+        @path_finder = PathFinder.new(druid_id: @druid.id)
+        @path_finder.check_for_path
       end
 
       def object
         @object ||= Dor.find(@druid.druid)
-      end
-
-      def check_for_path
-        raise "Path to object #{@druid.id} not found in any of the root directories: #{@root_dir.join(',')}" if path_to_object.nil?
       end
 
       def object_type
@@ -32,6 +26,8 @@ module Dor
       def item?
         object_type.downcase.strip == 'item'
       end
+
+      attr_reader :path_finder
     end
   end
 end

--- a/lib/dor/assembly/path_finder.rb
+++ b/lib/dor/assembly/path_finder.rb
@@ -2,8 +2,16 @@
 
 module Dor
   module Assembly
-    module Findable
-      attr_reader :folder_style
+    # This finds files associated with a Druid
+    class PathFinder
+      # @param [String] The non-namespaced druid identifier.
+      def initialize(druid_id:)
+        @druid_id = druid_id
+      end
+
+      def check_for_path
+        raise "Path to object #{druid_id} not found in any of the root directories: #{root_dir.join(',')}" if path_to_object.nil?
+      end
 
       # actual path to object, found by iterating through all possible root paths and looking first for the new druid tree path, then for the old druid path
       #  return nil if not found anywhere
@@ -11,7 +19,7 @@ module Dor
         return @path_to_object unless @path_to_object.nil?
 
         path = nil
-        Array(@root_dir).each do |root_dir|
+        root_dir.each do |root_dir|
           new_path = druid_tree_path(root_dir)
           old_path = old_druid_tree_path(root_dir)
           if File.directory? new_path
@@ -27,19 +35,9 @@ module Dor
         @path_to_object = path
       end
 
-      # new style path, e.g. aa/111/bb/2222/aa111bb2222
-      def druid_tree_path(root_dir)
-        DruidTools::Druid.new(@druid.id, root_dir).path
-      end
-
-      # old style path, e.g. aa/111/bb/2222
-      def old_druid_tree_path(root_dir)
-        File.dirname druid_tree_path(root_dir)
-      end
-
       # path to a content folder, defaults to new (aa/111/bb/2222/aa111bb2222/content), but could also be old style (aa/111/bb/2222)
       def path_to_content_folder
-        @folder_style == :old ? path_to_object : File.join(path_to_object, 'content')
+        folder_style == :old ? path_to_object : File.join(path_to_object, 'content')
       end
 
       # path to a content file, e.g.  either aa/111/bb/2222/aa111bb2222/content/some_file.txt or  aa/111/bb/2222/some_file.txt
@@ -47,14 +45,32 @@ module Dor
         File.join path_to_content_folder, filename
       end
 
-      # path to a metadata folder, defaults to new (aa/111/bb/2222/aa111bb2222/metadata), but could also be old style (aa/111/bb/2222)
-      def path_to_metadata_folder
-        @folder_style == :old ? path_to_object : File.join(path_to_object, 'metadata')
-      end
-
       # path to a content file, e.g.  either aa/111/bb/2222/aa111bb2222/metadata/some_file.xml or  aa/111/bb/2222/some_file.xml
       def path_to_metadata_file(filename)
         File.join path_to_metadata_folder, filename
+      end
+
+      private
+
+      attr_reader :folder_style, :druid_id
+
+      def root_dir
+        Array(Settings.assembly.root_dir)
+      end
+
+      # new style path, e.g. aa/111/bb/2222/aa111bb2222
+      def druid_tree_path(root_dir)
+        DruidTools::Druid.new(druid_id, root_dir).path
+      end
+
+      # old style path, e.g. aa/111/bb/2222
+      def old_druid_tree_path(root_dir)
+        File.dirname druid_tree_path(root_dir)
+      end
+
+      # path to a metadata folder, defaults to new (aa/111/bb/2222/aa111bb2222/metadata), but could also be old style (aa/111/bb/2222)
+      def path_to_metadata_folder
+        folder_style == :old ? path_to_object : File.join(path_to_object, 'metadata')
       end
     end
   end

--- a/lib/robots/dor_repo/assembly/accessioning_initiate.rb
+++ b/lib/robots/dor_repo/assembly/accessioning_initiate.rb
@@ -22,7 +22,7 @@ module Robots
         private
 
         def initialize_workspace
-          Dor::Services::Client.object(@ai.druid.druid).workspace.create(source: @ai.path_to_object)
+          Dor::Services::Client.object(@ai.druid.druid).workspace.create(source: @ai.path_finder.path_to_object)
         end
 
         def start_accession_workflow

--- a/lib/robots/dor_repo/assembly/checksum_compute.rb
+++ b/lib/robots/dor_repo/assembly/checksum_compute.rb
@@ -24,7 +24,7 @@ module Robots
           # Process each <file> node in the content metadata.
           assembly_item.file_nodes.each do |fn|
             # Compute checksums.
-            obj = ::Assembly::ObjectFile.new(assembly_item.path_to_content_file(fn['id']))
+            obj = ::Assembly::ObjectFile.new(assembly_item.path_finder.path_to_content_file(fn['id']))
 
             # compute checksums
             checksums = { md5: obj.md5, sha1: obj.sha1 }

--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
   let(:robot) { described_class.new(druid: druid) }
 
   def get_filenames(item)
-    item.file_nodes.map { |fn| item.path_to_content_file fn['id'] }
+    item.file_nodes.map { |fn| item.path_finder.path_to_content_file fn['id'] }
   end
 
   def count_file_types(files, extension)
@@ -64,7 +64,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       end
 
       let(:jp2s) { tifs.map { |t| t.sub(/\.tif$/, '.jp2') } }
-      let(:tifs) { item.file_nodes.map { |fn| item.path_to_content_file fn['id'] } }
+      let(:tifs) { item.file_nodes.map { |fn| item.path_finder.path_to_content_file fn['id'] } }
 
       it 'does not create any jp2 files' do
         item.load_content_metadata
@@ -108,7 +108,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       let(:druid) { 'gg111bb2222' }
 
       before do
-        item.cm_file_name = item.path_to_metadata_file(Settings.assembly.cm_file_name)
+        item.cm_file_name = item.path_finder.path_to_metadata_file(Settings.assembly.cm_file_name)
         allow_any_instance_of(Assembly::ObjectFile).to receive(:jp2able?).and_return(true)
 
         # These files needs to create


### PR DESCRIPTION
## Why was this change made?

There is no reason to have a module that is only used once. Make it a class instead

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a