### PR TITLE
Update contentMetadata using an API

### DIFF
--- a/lib/robots/dor_repo/accession/content_metadata.rb
+++ b/lib/robots/dor_repo/accession/content_metadata.rb
@@ -10,12 +10,23 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor.find(druid)
-          return unless obj.is_a?(Dor::Item)
+          object_client = Dor::Services::Client.object(druid)
+          obj = object_client.find
 
-          DatastreamBuilder.new(datastream: obj.contentMetadata).build do |ds|
-            # No-op
-          end
+          # non-items don't attach contentMetadata
+          return unless obj.is_a?(Cocina::Models::DRO)
+
+          object = DruidTools::Druid.new(druid, Dor::Config.stacks.local_workspace_root)
+          path = object.find_metadata('contentMetadata.xml')
+
+          return unless path
+
+          object_client.metadata.legacy_update(
+            content: {
+              updated: File.mtime(path),
+              content: File.read(path)
+            }
+          )
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?
This decouples the robot from Fedora and switches to an API based interface.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a
