### PR TITLE
Fix rake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config/certs
 .DS_Store
 .ruby-version
 .ruby-gemset
+.pry_history
 
 /tmp/*
 !/tmp/.keep

--- a/Rakefile
+++ b/Rakefile
@@ -18,14 +18,20 @@ begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
 rescue LoadError
+  # should only get here from production
   desc 'Run rubocop'
   task :rubocop do
     abort 'Please install the rubocop gem to run rubocop.'
   end
 end
 
-require 'rspec/core/rake_task'
-RSpec::Core::RakeTask.new(:spec)
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+  # should only get here from production or dev environments
+  puts 'no rspec found;  hopefully this is a production environment'
+end
 
 desc 'Get application version'
 task :app_version do


### PR DESCRIPTION
## Why was this change made?

Trying to run `cap prod resque:pool:full_restart` wasn't working and gave the following message in `resque-pool.stderr.log`:

```
rake aborted!
LoadError: cannot load such file -- rspec/core/rake_task
/opt/app/lyberadmin/common-accessioning/releases/20191209142258/Rakefile:27:in `require'
/opt/app/lyberadmin/common-accessioning/releases/20191209142258/Rakefile:27:in `<top (required)>'
/opt/app/lyberadmin/common-accessioning/shared/bundle/ruby/2.5.0/gems/resque-pool-0.7.0/lib/resque/pool/cli.rb:184:in `start_pool'
/opt/app/lyberadmin/common-accessioning/shared/bundle/ruby/2.5.0/gems/resque-pool-0.7.0/lib/resque/pool/cli.rb:21:in `run'
/opt/app/lyberadmin/common-accessioning/shared/bundle/ruby/2.5.0/gems/resque-pool-0.7.0/exe/resque-pool:7:in `<top (required)>'
/opt/app/lyberadmin/common-accessioning/shared/bundle/ruby/2.5.0/bin/resque-pool:23:in `load'
/opt/app/lyberadmin/common-accessioning/shared/bundle/ruby/2.5.0/bin/resque-pool:23:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `load'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:28:in `run'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/cli.rb:465:in `exec'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/cli.rb:27:in `dispatch'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/cli.rb:18:in `start'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/exe/bundle:30:in `block in <top (required)>'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
/usr/local/rvm/gems/ruby-2.5.3/gems/bundler-2.0.2/exe/bundle:22:in `<top (required)>'
/usr/local/rvm/gems/ruby-2.5.3/bin/bundle:23:in `load'
/usr/local/rvm/gems/ruby-2.5.3/bin/bundle:23:in `<main>'
/usr/local/rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `eval'
/usr/local/rvm/gems/ruby-2.5.3/bin/ruby_executable_hooks:24:in `<main>'
(See full trace by running task with --trace)
```

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a