### PR TITLE
TechnicalMetadataService copes with no technical metadata from preservation

### DIFF
--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -103,6 +103,11 @@ class TechnicalMetadataService
   # @return [String] The datastream contents from the previous version of the digital object (fetched from preservation)
   def preservation_metadata(dsname)
     Preservation::Client.objects.metadata(druid: dor_item.pid, filepath: "#{dsname}.xml")
+  rescue Preservation::Client::UnexpectedResponseError => e
+    # return nil if not found
+    return if e.message.match?('404 .* Not Found')
+
+    raise
   end
 
   # @param [Hash<Symbol,Array>] deltas Sets of filenames grouped by change type for use in performing file or metadata operations


### PR DESCRIPTION
## Why was this change made?

When we are accessioning an object for the first time, there is no technicalMetadata.  We need to handle this case properly.

Fixes https://app.honeybadger.io/projects/52894/faults/58394059

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a