### PR TITLE
TechnicalMetadataService copes PROPERLY with no technical metadata from preservation

### DIFF
--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -103,9 +103,10 @@ class TechnicalMetadataService
   # @return [String] The datastream contents from the previous version of the digital object (fetched from preservation)
   def preservation_metadata(dsname)
     Preservation::Client.objects.metadata(druid: dor_item.pid, filepath: "#{dsname}.xml")
-  rescue Preservation::Client::UnexpectedResponseError => e
+  rescue Preservation::Client::Error => e
+    # preservation-client *should* throw Preservation::Client::NotFoundError but ... dunno.  See #16 in that repo
     # return nil if not found
-    return if e.message.match?('404 .* Not Found')
+    return if e.message.match?(/Not Found.*404/im)
 
     raise
   end

--- a/spec/lib/technical_metadata_service_spec.rb
+++ b/spec/lib/technical_metadata_service_spec.rb
@@ -200,9 +200,9 @@ RSpec.describe TechnicalMetadataService do
 
     context 'when Preservation::Client gets 404 from API' do
       before do
-        errmsg = "Preservation::Client.metadata for #{druid} got 404 File Not Found (404) from Preservation ..."
+        errmsg = "Preservation::Client.file for #{druid} got Not Found (404) from Preservation ... 404 Not Found ..."
         allow(Preservation::Client.objects).to receive(:metadata)
-          .and_raise(Preservation::Client::UnexpectedResponseError, errmsg)
+          .and_raise(Preservation::Client::NotFoundError, errmsg)
         allow(JhoveService).to receive(:new)
       end
 


### PR DESCRIPTION
## Why was this change made?

b/c I goofed in the previous PR #472 to fix https://app.honeybadger.io/projects/52894/faults/58394059.

I believe the real problem was that the regex didn't accommodate multiple lines;  it is also a bit worrying that the exception from pres-client isn't a NotFound, but I have a diff ticket for that.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a