### PR TITLE
preservation-client v1.0.0 to get technicalMetadata.xml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
     jaro_winkler (1.5.4)
     jhove-service (1.3.0)
       nokogiri (>= 1.4.3.1)
-    json (2.2.0)
+    json (2.3.0)
     link_header (0.0.8)
     lyber-core (5.4.0)
       activesupport
@@ -258,7 +258,7 @@ GEM
       ast (~> 2.4.0)
     pony (1.13.1)
       mail (>= 2.0)
-    preservation-client (0.4.0)
+    preservation-client (1.0.0)
       activesupport (>= 4.2, < 7)
       faraday (~> 0.15)
       moab-versioning (~> 4.3)

--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -76,7 +76,7 @@ class TechnicalMetadataService
     dor_technical_metadata
   end
 
-  # @return [String] The technicalMetadata datastream from the previous version of the digital object (fetched from preeservation)
+  # @return [String] The technicalMetadata datastream from the previous version of the digital object (fetched from preservation)
   #   The data is updated to the latest format.
   def preservation_technical_metadata
     pres_techmd = preservation_metadata('technicalMetadata')
@@ -100,15 +100,12 @@ class TechnicalMetadataService
   end
 
   # @param [String] dsname The identifier of the metadata datastream
-  # @return [String] The datastream contents from the previous version of the digital object (fetched from preservation)
+  # @return [String] The datastream contents from the previous version of the digital object (fetched from preservation),
+  #   or nil if there is no such datastream (e.g. object not yet in preservation)
   def preservation_metadata(dsname)
     Preservation::Client.objects.metadata(druid: dor_item.pid, filepath: "#{dsname}.xml")
-  rescue Preservation::Client::Error => e
-    # preservation-client *should* throw Preservation::Client::NotFoundError but ... dunno.  See #16 in that repo
-    # return nil if not found
-    return if e.message.match?(/Not Found.*404/im)
-
-    raise
+  rescue Preservation::Client::NotFoundError
+    nil
   end
 
   # @param [Hash<Symbol,Array>] deltas Sets of filenames grouped by change type for use in performing file or metadata operations


### PR DESCRIPTION
## Why was this change made?

preservation-client v1.0.0 throws a Preservation::Client::NotFoundError when an API call to preservation-catalog returns 404.  This simplifies code here that traps for that error.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a