### PR TITLE
Upgrade to preservation-client 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'moab-versioning', '~> 4.0'
 gem 'net-sftp', '~> 2.1' # for binder_batch_transfer
 gem 'nokogiri'
 gem 'pony' # send email, for etd_submit/build_symphony_marc
-gem 'preservation-client'
+gem 'preservation-client', '~> 2.0'
 gem 'pry'
 gem 'pry-byebug', :platform => [:ruby_20, :ruby_21]
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -258,7 +258,7 @@ GEM
       ast (~> 2.4.0)
     pony (1.13.1)
       mail (>= 2.0)
-    preservation-client (1.0.0)
+    preservation-client (2.0.0)
       activesupport (>= 4.2, < 7)
       faraday (~> 0.15)
       moab-versioning (~> 4.3)
@@ -428,7 +428,7 @@ DEPENDENCIES
   net-sftp (~> 2.1)
   nokogiri
   pony
-  preservation-client
+  preservation-client (~> 2.0)
   pry
   pry-byebug
   rake
@@ -446,4 +446,4 @@ DEPENDENCIES
   zeitwerk (~> 2.1)
 
 BUNDLED WITH
-   2.0.2
+   2.1.0


### PR DESCRIPTION
## Why was this change made?

Need to use the correct urls for preservation service

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a