### PR TITLE
Do assembly without hitting Fedora (directly)

### DIFF
--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -14,17 +14,12 @@ module Dor
         @path_finder.check_for_path
       end
 
-      def object
-        @object ||= Dor.find(@druid.druid)
-      end
-
-      def object_type
-        obj_type = object.identityMetadata.objectType
-        (obj_type.nil? ? 'unknown' : obj_type.first)
+      def cocina_model
+        @cocina_model ||= Dor::Services::Client.object(druid.druid).find
       end
 
       def item?
-        object_type.downcase.strip == 'item'
+        cocina_model.is_a?(Cocina::Models::DRO)
       end
 
       attr_reader :path_finder

--- a/spec/robots/assembly/accessioning_initiate_spec.rb
+++ b/spec/robots/assembly/accessioning_initiate_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Robots::DorRepo::Assembly::AccessioningInitiate do
   let(:workspace_client) { instance_double(Dor::Services::Client::Workspace, create: nil) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
   let(:object_client) do
-    instance_double(Dor::Services::Client::Object, version: version_client, workspace: workspace_client)
+    instance_double(Dor::Services::Client::Object, version: version_client, workspace: workspace_client, find: object)
   end
 
   before do
@@ -21,13 +21,15 @@ RSpec.describe Robots::DorRepo::Assembly::AccessioningInitiate do
   end
 
   context 'when the type is item' do
-    before do
-      @assembly_item = setup_assembly_item(druid, :item)
+    let(:object) do
+      Cocina::Models::DRO.new(externalIdentifier: '123',
+                              type: Cocina::Models::DRO::TYPES.first,
+                              label: 'my dro',
+                              version: 1)
     end
 
     it 'initiates accessioning' do
-      expect(@assembly_item).to be_item
-      robot.perform(@assembly_item)
+      robot.perform(druid)
       expect(workspace_client).to have_received(:create)
         .with(source: 'spec/test_input2/aa/222/cc/3333')
       expect(workflow_client).to have_received(:create_workflow_by_name)
@@ -36,13 +38,15 @@ RSpec.describe Robots::DorRepo::Assembly::AccessioningInitiate do
   end
 
   context 'when the type is set' do
-    before do
-      @assembly_item = setup_assembly_item(druid, :set)
+    let(:object) do
+      Cocina::Models::Collection.new(externalIdentifier: '123',
+                                     type: Cocina::Models::Collection::TYPES.first,
+                                     label: 'my collection',
+                                     version: 1)
     end
 
     it 'initiates accessioning, but does not initialize the workspace' do
-      expect(@assembly_item).not_to be_item
-      robot.perform(@assembly_item)
+      robot.perform(druid)
       expect(workspace_client).not_to have_received(:create)
       expect(workflow_client).to have_received(:create_workflow_by_name)
         .with(namespaced_druid, 'accessionWF', version: '1')

--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -14,32 +14,50 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
   end
 
   describe '#perform' do
-    subject(:perform) { robot.perform(@assembly_item) }
+    subject(:perform) { robot.perform(druid) }
+
+    ``
+    let(:assembly_item) { Dor::Assembly::Item.new(druid: druid) }
+
+    let(:object_client) do
+      instance_double(Dor::Services::Client::Object, find: object)
+    end
 
     before do
-      @assembly_item = setup_assembly_item(druid, type)
+      allow(robot).to receive(:item).and_return(assembly_item)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     end
 
     let(:druid) { 'aa222cc3333' }
 
     context 'for an item' do
-      let(:type) { :item }
+      let(:object) do
+        Cocina::Models::DRO.new(externalIdentifier: '123',
+                                type: Cocina::Models::DRO::TYPES.first,
+                                label: 'my dro',
+                                version: 1)
+      end
 
-      it 'creates jp2 for type=item' do
-        expect(@assembly_item).to receive(:item?).and_call_original
-        expect(@assembly_item).to receive(:load_content_metadata)
-        expect(robot).to receive(:create_jp2s).with(@assembly_item)
+      it 'creates jp2' do
+        expect(assembly_item).to receive(:item?).and_call_original
+        expect(assembly_item).to receive(:load_content_metadata)
+        expect(robot).to receive(:create_jp2s).with(assembly_item)
         perform
       end
     end
 
-    context 'for a set' do
-      let(:type) { :set }
+    context 'for a collection' do
+      let(:object) do
+        Cocina::Models::Collection.new(externalIdentifier: '123',
+                                       type: Cocina::Models::Collection::TYPES.first,
+                                       label: 'my collection',
+                                       version: 1)
+      end
 
-      it 'does not create jp2 for type=set' do
-        expect(@assembly_item).to receive(:item?)
-        expect(@assembly_item).not_to receive(:load_content_metadata)
-        expect(robot).not_to receive(:create_jp2s).with(@assembly_item)
+      it 'does not create jp2' do
+        expect(assembly_item).to receive(:item?)
+        expect(assembly_item).not_to receive(:load_content_metadata)
+        expect(robot).not_to receive(:create_jp2s).with(assembly_item)
         perform
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,16 +69,3 @@ end
 def fixture_dir
   @fixture_dir ||= File.join(File.dirname(__FILE__), 'fixtures')
 end
-
-def setup_assembly_item(druid, obj_type = :item)
-  assembly_item = Dor::Assembly::Item.new(druid: druid)
-  allow(assembly_item).to receive('druid').and_return(DruidTools::Druid.new(druid))
-  allow(assembly_item).to receive('id').and_return(druid)
-  # have to disable this check, because OM is doing odd metaprogramming
-  # rubocop:disable RSpec/VerifiedDoubles
-  identity_metadata = double(Dor::IdentityMetadataDS, objectType: [obj_type.to_s])
-  # rubocop:enable RSpec/VerifiedDoubles
-  allow(Dor).to receive(:find).and_return(instance_double(Dor::Item, identityMetadata: identity_metadata))
-  allow(Dor::Assembly::Item).to receive(:new).and_return(assembly_item)
-  assembly_item
-end


### PR DESCRIPTION
## Why was this change made?

We want to keep common-accessioning from accessing fedora so we can replace it.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a
