### PR TITLE
Extract a member service from Release::Item

### DIFF
--- a/lib/dor/release/item.rb
+++ b/lib/dor/release/item.rb
@@ -6,37 +6,15 @@ require 'dor-fetcher'
 module Dor
   module Release
     class Item
-      attr_accessor :druid, :fetcher
+      attr_accessor :druid
 
-      def initialize(params = {})
+      def initialize(druid:)
         # Takes a druid, either as a string or as a Druid object.
-        @druid = params[:druid]
-        skip_heartbeat = params[:skip_heartbeat] || false
-        @fetcher = DorFetcher::Client.new(service_url: Settings.release.fetcher_root, skip_heartbeat: skip_heartbeat)
+        @druid = druid
       end
 
       def object
         @object ||= Dor.find(@druid)
-      end
-
-      def members
-        @members || with_retries(max_tries: Settings.release.max_tries, base_sleep_seconds: Settings.release.base_sleep_seconds, max_sleep_seconds: Settings.release.max_sleep_seconds) do |_attempt|
-          @members = @fetcher.get_collection(@druid) # cache members in an instance variable
-        end
-      end
-
-      def item_members
-        members['items'] || []
-      end
-
-      def sub_collections
-        unless @sub_collections
-          @sub_collections = []
-          @sub_collections += members['sets'] if members['sets']
-          @sub_collections += members['collections'] if members['collections']
-          @sub_collections.delete_if { |collection| collection['druid'] == druid } # if this is a collection, do not include yourself in the sub-collection list
-        end
-        @sub_collections
       end
 
       def object_type

--- a/lib/dor/release/member_service.rb
+++ b/lib/dor/release/member_service.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'retries'
+require 'dor-fetcher'
+
+module Dor
+  module Release
+    # Retrieves the members of a collection, both items and sub-collections
+    class MemberService
+      def initialize(druid:, skip_heartbeat: false)
+        @druid = druid
+        @skip_heartbeat = skip_heartbeat
+      end
+
+      def item_members
+        members['items'] || []
+      end
+
+      def sub_collections
+        unless @sub_collections
+          @sub_collections = []
+          @sub_collections += members['sets'] if members['sets']
+          @sub_collections += members['collections'] if members['collections']
+          @sub_collections.delete_if { |collection| collection['druid'] == druid } # if this is a collection, do not include yourself in the sub-collection list
+        end
+        @sub_collections
+      end
+
+      private
+
+      attr_reader :druid, :skip_heartbeat
+
+      def fetcher
+        @fetcher ||= DorFetcher::Client.new(service_url: Settings.release.fetcher_root, skip_heartbeat: skip_heartbeat)
+      end
+
+      def members
+        @members || with_retries(max_tries: Settings.release.max_tries, base_sleep_seconds: Settings.release.base_sleep_seconds, max_sleep_seconds: Settings.release.max_sleep_seconds) do |_attempt|
+          @members = fetcher.get_collection(druid) # cache members in an instance variable
+        end
+      end
+    end
+  end
+end

--- a/lib/robots/dor_repo/release/release_members.rb
+++ b/lib/robots/dor_repo/release/release_members.rb
@@ -20,7 +20,7 @@ module Robots
 
           case item.object_type
           when 'collection', 'set' # this is a collection or set
-            publish_collection(item)
+            publish_collection(druid, item)
           else # this is not a collection of set
             LyberCore::Log.debug "...this is a #{item.object_type}, NOOP"
           end
@@ -28,34 +28,36 @@ module Robots
 
         private
 
-        def publish_collection(item)
+        def publish_collection(druid, item)
+          member_service = Dor::Release::MemberService.new(druid: druid)
+
           # check to see if all of the release tags for all targets are what=self, if so, we can skip adding workflow for all the members
           #   if at least one of the targets is *not* what=self, we will do it
           tag_service = Dor::ReleaseTagService.for(item.object)
           release_tags = tag_service.newest_release_tag(tag_service.release_tags) # get the latest release tag for each target
           if release_tags.collect { |_k, v| v['what'] == 'self' }.include?(false) # if there are any *non* what=self release tags in any targets, go ahead and add the workflow to the items
-            add_workflow_to_members(item)
+            add_workflow_to_members(member_service, item.object_type)
           else # all of the latest release tags are what=self or there are no release tags, so skip
             LyberCore::Log.debug "...all release tags are what=self for #{item.object_type}; skipping member workflows"
           end
 
-          add_workflow_to_sub_collections(item)
+          add_workflow_to_sub_collections(member_service)
         end
 
-        def add_workflow_to_members(item)
-          LyberCore::Log.debug "...fetching members of #{item.object_type}"
-          if item.item_members # if there are any members, iterate through and add item workflows (which includes setting the first step to completed)
+        def add_workflow_to_members(member_service, object_type)
+          LyberCore::Log.debug "...fetching members of #{object_type}"
+          if member_service.item_members # if there are any members, iterate through and add item workflows (which includes setting the first step to completed)
 
-            item.item_members.each do |item_member|
+            member_service.item_members.each do |item_member|
               create_release_workflow(item_member['druid'])
             end
           else # no members found
-            LyberCore::Log.debug "...no members found in #{item.object_type}"
+            LyberCore::Log.debug "...no members found in #{object_type}"
           end
         end
 
-        def add_workflow_to_sub_collections(item)
-          item.sub_collections&.each do |sub_collection|
+        def add_workflow_to_sub_collections(member_service)
+          member_service.sub_collections&.each do |sub_collection|
             create_release_workflow(sub_collection['druid'])
           end
         end

--- a/spec/lib/dor/release/item_spec.rb
+++ b/spec/lib/dor/release/item_spec.rb
@@ -5,15 +5,11 @@ require 'spec_helper'
 RSpec.describe Dor::Release::Item do
   before do
     @druid = 'oo000oo0001'
-    @item = described_class.new(druid: @druid, skip_heartbeat: true) # skip heartbeat check for dor-fetcher
+    @item = described_class.new(druid: @druid)
     @n = 0
 
     # setup doubles and mocks so we can stub out methods and not make actual dor, webservice or workflow calls
-    @client = instance_double(DorFetcher::Client)
     @response = { 'items' => ['returned_members'], 'sets' => ['returned_sets'], 'collections' => ['returned_collections'] }
-    allow(@client).to receive(:get_collection).and_return(@response)
-    @item.fetcher = @client
-
     @dor_object = instance_double(Dor::Item)
     allow(Dor).to receive(:find).and_return(@dor_object)
 
@@ -30,22 +26,6 @@ RSpec.describe Dor::Release::Item do
       expect(@item.object).to eq @dor_object
       @n += 1
     end
-  end
-
-  it 'calls dor-fetcher-client to get the members, but only once' do
-    expect(@item.fetcher).to receive(:get_collection).once
-    while @n < 3
-      expect(@item.members).to eq @response
-      @n += 1
-    end
-  end
-
-  it 'gets the right value for item_members' do
-    expect(@item.item_members).to eq @response['items']
-  end
-
-  it 'gets the right value for sub_collections' do
-    expect(@item.sub_collections).to eq @response['sets'] + @response['collections']
   end
 
   describe 'object_type' do

--- a/spec/robots/release/release_publish_spec.rb
+++ b/spec/robots/release/release_publish_spec.rb
@@ -4,14 +4,10 @@ require 'spec_helper'
 
 RSpec.describe Robots::DorRepo::Release::ReleasePublish do
   let(:druid) { 'aa222cc3333' }
-  let(:release_item) { Dor::Release::Item.new(druid: druid, skip_heartbeat: true) }
-  let(:dor_item) { instance_double(Dor::Item, id: druid) }
   let(:robot) { described_class.new }
   let(:object_client) { instance_double(Dor::Services::Client::Object, publish: true) }
 
   before do
-    allow(release_item).to receive(:object).and_return(dor_item)
-    allow(Dor::Release::Item).to receive_messages(new: release_item)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ def clone_test_input(destination)
 end
 
 def setup_release_item(druid, obj_type, members)
-  @release_item = Dor::Release::Item.new(druid: druid, skip_heartbeat: true)
+  @release_item = Dor::Release::Item.new(druid: druid)
   @dor_item = instance_double(Dor::Item)
   allow(@dor_item).to receive_messages(
     id: druid


### PR DESCRIPTION
## Why was this change made?

A class should have a single responsibility.  The Release::Item class had several responsibilities, this extracts the responsibility for finding collection members to its own class


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a
