### PR TITLE
Refactor to put the updating marc code close to where it is used

### DIFF
--- a/lib/dor/release/item.rb
+++ b/lib/dor/release/item.rb
@@ -46,12 +46,6 @@ module Dor
         end
         @obj_type.downcase.strip
       end
-
-      def update_marc_record
-        with_retries(max_tries: Settings.release.max_tries, base_sleep_seconds: Settings.release.base_sleep_seconds, max_sleep_seconds: Settings.release.max_sleep_seconds) do |_attempt|
-          Dor::Services::Client.object(@druid).update_marc_record
-        end
-      end
     end
   end
 end

--- a/lib/robots/dor_repo/release/update_marc.rb
+++ b/lib/robots/dor_repo/release/update_marc.rb
@@ -14,8 +14,11 @@ module Robots
         # @param [String] druid -- the Druid identifier for the object to process
         def perform(druid)
           LyberCore::Log.debug "update_marc working on #{druid}"
-          item = Dor::Release::Item.new druid: druid
-          item.update_marc_record # this makes a web-service call for dor-services app
+          with_retries(max_tries: Settings.release.max_tries,
+                       base_sleep_seconds: Settings.release.base_sleep_seconds,
+                       max_sleep_seconds: Settings.release.max_sleep_seconds) do |_attempt|
+            Dor::Services::Client.object(druid).update_marc_record
+          end
         end
       end
     end

--- a/spec/lib/dor/release/item_spec.rb
+++ b/spec/lib/dor/release/item_spec.rb
@@ -48,12 +48,6 @@ RSpec.describe Dor::Release::Item do
     expect(@item.sub_collections).to eq @response['sets'] + @response['collections']
   end
 
-  it 'makes a webservice call for updating_marc_records' do
-    stub_request(:post, 'https://dor-services-test.stanford.test/v1/objects/oo000oo0001/update_marc_record')
-      .to_return(status: 201, body: '', headers: {})
-    expect(@item.update_marc_record).to be true
-  end
-
   describe 'object_type' do
     subject { @item.object_type }
 

--- a/spec/robots/release/update_marc_spec.rb
+++ b/spec/robots/release/update_marc_spec.rb
@@ -2,16 +2,13 @@
 
 require 'spec_helper'
 
-describe Robots::DorRepo::Release::UpdateMarc do
-  before do
-    @druid = 'aa222cc3333'
-    @work_item = instance_double(Dor::Item)
-    @r = described_class.new
-  end
+RSpec.describe Robots::DorRepo::Release::UpdateMarc do
+  let(:druid) { 'aa222cc3333' }
+  let(:robot) { described_class.new }
 
-  it 'calls the update marc record method' do
-    setup_release_item(@druid, :item, nil)
-    expect(@release_item).to receive(:update_marc_record)
-    @r.perform(@work_item)
+  it 'posts to the update marc record api' do
+    stub_request(:post, 'https://dor-services-test.stanford.test/v1/objects/aa222cc3333/update_marc_record')
+      .to_return(status: 201, body: '', headers: {})
+    robot.perform(druid)
   end
 end


### PR DESCRIPTION
## Why was this change made?
Removes unnecessary indirection on how the update_marc code is called.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a