### PR TITLE
Correct space around operators

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,15 +14,6 @@ Bundler/OrderedGems:
   Exclude:
     - 'Gemfile'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment.
-Layout/SpaceAroundOperators:
-  Exclude:
-    - 'lib/robots/dor_repo/assembly/jp2_create.rb'
-    - 'spec/lib/sdr_ingest_service_spec.rb'
-    - 'spec/lib/technical_metadata_service_spec.rb'
-
 # Offense count: 1
 Lint/AmbiguousBlockAssociation:
   Exclude:

--- a/lib/robots/dor_repo/assembly/jp2_create.rb
+++ b/lib/robots/dor_repo/assembly/jp2_create.rb
@@ -48,7 +48,7 @@ module Robots
             LyberCore::Log.warn(message)
           else
             tmp_folder = Settings.assembly.tmp_folder
-            jp2       = img.create_jp2(overwrite: Settings.assembly.overwrite_jp2, tmp_folder: tmp_folder)
+            jp2 = img.create_jp2(overwrite: Settings.assembly.overwrite_jp2, tmp_folder: tmp_folder)
             # generate new filename for jp2 file node in content metadata by replacing filename in base file node with new jp2 filename
             file_name = file_node['id'].gsub(File.basename(img.path), File.basename(jp2.path))
             add_jp2_file_node file_node.parent, file_name

--- a/spec/lib/technical_metadata_service_spec.rb
+++ b/spec/lib/technical_metadata_service_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe TechnicalMetadataService do
     allow(Settings.sdr).to receive_messages(local_workspace_root: wsfixtures)
     @sdr_repo = fixtures.join('sdr_repo')
     @inventory_differences = {}
-    @deltas      = {}
-    @new_files   = {}
+    @deltas = {}
+    @new_files = {}
     @repo_techmd = {}
     @new_file_techmd = {}
     @expected_techmd = {}


### PR DESCRIPTION
## Why was this change made?

Fix rubocop todos

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a