### PR TITLE
Remove useless assignment

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -53,11 +53,6 @@ Lint/UnderscorePrefixedVariableName:
   Exclude:
     - 'config/boot.rb'
 
-# Offense count: 1
-Lint/UselessAssignment:
-  Exclude:
-    - 'spec/spec_helper.rb'
-
 # Offense count: 28
 Metrics/AbcSize:
   Max: 98

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Make sure specs run with the definitions from test.rb
-environment = ENV['ROBOT_ENVIRONMENT'] = 'test'
+ENV['ROBOT_ENVIRONMENT'] = 'test'
 
 require 'simplecov'
 require 'coveralls'


### PR DESCRIPTION
## Why was this change made?

Fix rubocop todos.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a