### PR TITLE
Marks publish-complete to completed for APOs.

### DIFF
--- a/lib/robots/dor_repo/accession/publish.rb
+++ b/lib/robots/dor_repo/accession/publish.rb
@@ -14,7 +14,11 @@ module Robots
           object_client = Dor::Services::Client.object(druid)
           obj = object_client.find
 
-          return if obj.is_a?(Cocina::Models::AdminPolicy)
+          # Since not being published, need to set publish-complete so that will proceed with wf.
+          if obj.is_a?(Cocina::Models::AdminPolicy)
+            workflow_service.update_status(druid: druid, workflow: @workflow_name, process: 'publish-complete', status: 'completed', elapsed: 1, note: 'APOs are not published, so marking completed.')
+            return
+          end
 
           # This is an async result and it will have a callback.
           object_client.publish(workflow: 'accessionWF')

--- a/spec/robots/accession/publish_spec.rb
+++ b/spec/robots/accession/publish_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
 
     before do
       allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+      allow(Dor::Config.workflow.client).to receive(:update_status)
       perform
     end
 
@@ -55,6 +56,10 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
 
       it 'does not publish metadata' do
         expect(object_client).not_to have_received(:publish)
+      end
+
+      it 'sets publish-complete to completed' do
+        expect(Dor::Config.workflow.client).to have_received(:update_status).with(druid: druid, workflow: 'accessionWF', process: 'publish-complete', status: 'completed', elapsed: 1, note: 'APOs are not published, so marking completed.')
       end
     end
   end


### PR DESCRIPTION
closes #1768

## Why was this change made?
To allow APOs to proceed with AccessionWF without invoking publish.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
No