### PR TITLE
pass auth token to pres-client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,9 @@ gem 'moab-versioning', '~> 4.0'
 gem 'net-sftp', '~> 2.1' # for binder_batch_transfer
 gem 'nokogiri'
 gem 'pony' # send email, for etd_submit/build_symphony_marc
-gem 'preservation-client', '~> 2.0'
+# switch back to official release once available
+# gem 'preservation-client', '~> 2.0'
+gem 'preservation-client', git: 'https://github.com/sul-dlss/preservation-client.git', branch: 'pass-jwt-token'
 gem 'pry'
 gem 'pry-byebug', platform: %i[ruby_20 ruby_21]
 gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -19,9 +19,7 @@ gem 'moab-versioning', '~> 4.0'
 gem 'net-sftp', '~> 2.1' # for binder_batch_transfer
 gem 'nokogiri'
 gem 'pony' # send email, for etd_submit/build_symphony_marc
-# switch back to official release once available
-# gem 'preservation-client', '~> 2.0'
-gem 'preservation-client', git: 'https://github.com/sul-dlss/preservation-client.git', branch: 'pass-jwt-token'
+gem 'preservation-client', '>= 3.0' # 3.x or greater is needed for token auth
 gem 'pry'
 gem 'pry-byebug', platform: %i[ruby_20 ruby_21]
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/sul-dlss/preservation-client.git
+  revision: 39de52282fa0b0e562d78fd4f8602ad841da1cc1
+  branch: pass-jwt-token
+  specs:
+    preservation-client (2.1.0)
+      activesupport (>= 4.2, < 7)
+      faraday (~> 0.15)
+      moab-versioning (~> 4.3)
+      zeitwerk (~> 2.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -258,11 +269,6 @@ GEM
       ast (~> 2.4.0)
     pony (1.13.1)
       mail (>= 2.0)
-    preservation-client (2.1.0)
-      activesupport (>= 4.2, < 7)
-      faraday (~> 0.15)
-      moab-versioning (~> 4.3)
-      zeitwerk (~> 2.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -431,7 +437,7 @@ DEPENDENCIES
   net-sftp (~> 2.1)
   nokogiri
   pony
-  preservation-client (~> 2.0)
+  preservation-client!
   pry
   pry-byebug
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/sul-dlss/preservation-client.git
-  revision: 39de52282fa0b0e562d78fd4f8602ad841da1cc1
-  branch: pass-jwt-token
-  specs:
-    preservation-client (2.1.0)
-      activesupport (>= 4.2, < 7)
-      faraday (~> 0.15)
-      moab-versioning (~> 4.3)
-      zeitwerk (~> 2.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -269,6 +258,11 @@ GEM
       ast (~> 2.4.0)
     pony (1.13.1)
       mail (>= 2.0)
+    preservation-client (3.0.0)
+      activesupport (>= 4.2, < 7)
+      faraday (>= 0.15, < 2.0)
+      moab-versioning (~> 4.3)
+      zeitwerk (~> 2.1)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -437,7 +431,7 @@ DEPENDENCIES
   net-sftp (~> 2.1)
   nokogiri
   pony
-  preservation-client!
+  preservation-client (>= 3.0)
   pry
   pry-byebug
   rake

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -54,7 +54,7 @@ end
 
 CommonAccessioning.connect_dor_services_app
 
-Preservation::Client.configure(url: Settings.preservation_catalog.url)
+Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)
 
 # Load Resque configuration and controller
 begin

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,3 +24,4 @@ sdr:
 
 preservation_catalog:
   url: 'https://example.org/prescat'
+  token: 'mint-token-with-target-preservation-catalog-rake-generate-token'


### PR DESCRIPTION
HOLD until: 

- [x] shared_configs PRs are merged (sul-dlss/shared_configs/pull/1171, sul-dlss/shared_configs/pull/1175)
- [x] test this branch on stage!
- [x] sul-dlss/preservation-client/pull/29 is merged 
- [x] a new version of pres-client gem is released
- [x] Fix this branch to use released gem
- [x] Take this PR out of draft

## Why was this change made?

pres cat will start requiring that all API clients supply an auth token, or their requests will be rejected as Unauthorized.

Fixes #502
connects to sul-dlss/preservation_catalog#1298
blocks sul-dlss/preservation_catalog#1306

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a