### PR TITLE
Upgraded JHOVE Service to 1.4.0 (for XHTML fix for Google Books).

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'dor-services', '~> 8.0'
 gem 'dor-services-client', '~> 4.0'
 gem 'dor-workflow-client', '~> 3.11'
 gem 'honeybadger'
-gem 'jhove-service', '~> 1.3'
+gem 'jhove-service', '~> 1.4'
 gem 'lyber-core', '~> 5.4'
 gem 'marc' # for etd_submit/submit_marc
 gem 'moab-versioning', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,7 @@ GEM
     ice_nine (0.11.2)
     iso-639 (0.2.8)
     jaro_winkler (1.5.4)
-    jhove-service (1.3.0)
+    jhove-service (1.4.0)
       nokogiri (>= 1.4.3.1)
     json (2.3.0)
     link_header (0.0.8)
@@ -424,7 +424,7 @@ DEPENDENCIES
   dor-services-client (~> 4.0)
   dor-workflow-client (~> 3.11)
   honeybadger
-  jhove-service (~> 1.3)
+  jhove-service (~> 1.4)
   lyber-core (~> 5.4)
   marc
   moab-versioning (~> 4.0)
@@ -449,4 +449,4 @@ DEPENDENCIES
   zeitwerk (~> 2.1)
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/spec/lib/technical_metadata_service_spec.rb
+++ b/spec/lib/technical_metadata_service_spec.rb
@@ -405,11 +405,19 @@ RSpec.describe TechnicalMetadataService do
       deltas = @deltas[id]
       merged_nodes = instance.send(:merge_file_nodes, old_techmd, new_techmd, deltas)
 
-      # the final and expected_techmd need to be scrubbed of dates in a couple spots for the comparison to match since these will vary from test run to test run
-      # "druid:#{id}",
-      final_techmd = instance.send(:build_technical_metadata, merged_nodes).gsub(/datetime=["'].*?["']/, '').gsub(%r{<jhove:lastModified>.*?</jhove:lastModified>}, '')
-      expected_techmd = @expected_techmd[id].gsub(/datetime=["'].*?["']/, '').gsub(%r{<jhove:lastModified>.*?</jhove:lastModified>}, '')
+      final_techmd = scrub_techmd(instance.send(:build_technical_metadata, merged_nodes))
+      expected_techmd = scrub_techmd(@expected_techmd[id])
       expect(final_techmd).to be_equivalent_to expected_techmd
     end
+  end
+
+  def scrub_techmd(techmd)
+    # the final and expected_techmd need to be scrubbed of dates in a couple spots for the comparison to match since these will vary from test run to test run
+    # "druid:#{id}",
+    # Also, need to scrub reporting module versions.
+    techmd
+      .gsub(/datetime=["'].*?["']/, '')
+      .gsub(%r{<jhove:lastModified>.*?</jhove:lastModified>}, '')
+      .gsub(/<jhove:reportingModule release='\d+\.\d+(\.\d+)*' date='20\d\d-\d\d-\d\d'>/, "<jhove:reportingModule release='X.X' date='20XX-XX-XX'>")
   end
 end


### PR DESCRIPTION
## Why was this change made?
The latest version of JHOVE-service has a performance improvement for processing XTML files.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
No.