### PR TITLE
Extract file and image node classes from exif_collect

### DIFF
--- a/lib/dor/assembly/file_node.rb
+++ b/lib/dor/assembly/file_node.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Dor
+  module Assembly
+    class FileNode
+      # @param [Nokogiri::XML::Element] xml_node
+      def initialize(xml_node:)
+        @xml_node = xml_node
+      end
+
+      def size=(size)
+        xml_node['size'] = size.to_s unless xml_node['size']
+      end
+
+      def mimetype=(mimetype)
+        xml_node['mimetype'] = mimetype unless xml_node['mimetype']
+      end
+
+      # add publish/preserve/shelve attributes based on mimetype,
+      # unless they already exist in content metadata (use defaults if mimetype not found in mapping)
+      def add_defaults(mimetype)
+        defaults = Dor::Assembly::Item.default_file_attributes(mimetype)
+        defaults.each { |key, default| xml_node[key.to_s] ||= default }
+      end
+
+      def add_image_data(exif_data)
+        return if xml_node.css(ImageDataNode::NODE_NAME).present?
+
+        xml_node.add_child(ImageDataNode.build(exif_data))
+      end
+
+      private
+
+      attr_reader :xml_node
+    end
+  end
+end

--- a/lib/dor/assembly/image_data_node.rb
+++ b/lib/dor/assembly/image_data_node.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Dor
+  module Assembly
+    # Represents an XML node which is a child of the file node in contentMetadata.xml
+    class ImageDataNode
+      NODE_NAME = 'imageData'
+
+      def self.build(exif_data)
+        w = exif_data.image_width
+        h = exif_data.image_height
+        %(<#{NODE_NAME} width="#{w}" height="#{h}"/>)
+      end
+    end
+  end
+end

--- a/spec/lib/dor/assembly/image_data_node_spec.rb
+++ b/spec/lib/dor/assembly/image_data_node_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dor::Assembly::ImageDataNode do
+  describe '#build' do
+    subject(:build) { described_class.build(exif) }
+    # rubocop:disable RSpec/VerifiedDoubles
+
+    let(:exif) { double(MiniExiftool, image_width: 55, image_height: 66) }
+    # rubocop:enable RSpec/VerifiedDoubles
+
+    it { is_expected.to eq('<imageData width="55" height="66"/>') }
+  end
+end

--- a/spec/robots/assembly/exif_collect_spec.rb
+++ b/spec/robots/assembly/exif_collect_spec.rb
@@ -57,14 +57,6 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
     end
   end
 
-  describe '#image_data_xml' do
-    subject(:image_data_xml) { robot.send(:image_data_xml,  exif) }
-
-    let(:exif) { double 'image_width' => 55, 'image_height' => 66 }
-
-    it { is_expected.to eq('<imageData width="55" height="66"/>') }
-  end
-
   describe '#collect_exif_info' do
     subject(:result) { robot.send(:collect_exif_info, item) }
 


### PR DESCRIPTION
## Why was this change made?
This represents a unique concept that is separate from the ExifCollect robot


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a