### PR TITLE
Upgrades lyber-core to 5.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'dor-services-client', '~> 4.0'
 gem 'dor-workflow-client', '~> 3.17'
 gem 'honeybadger'
 gem 'jhove-service', '~> 1.4'
-gem 'lyber-core', '~> 5.4'
+gem 'lyber-core', '~> 5.5'
 gem 'marc' # for etd_submit/submit_marc
 gem 'moab-versioning', '~> 4.0'
 gem 'net-sftp', '~> 2.1' # for binder_batch_transfer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -121,7 +121,7 @@ GEM
       moab-versioning (~> 4.0)
       nokogiri (~> 1.8)
       zeitwerk (~> 2.1)
-    dor-workflow-client (3.17.1)
+    dor-workflow-client (3.18.0)
       activesupport (>= 3.2.1, < 7)
       deprecation (>= 0.99.0)
       faraday (>= 0.9.2, < 2.0)
@@ -201,7 +201,7 @@ GEM
       nokogiri (>= 1.4.3.1)
     json (2.3.0)
     link_header (0.0.8)
-    lyber-core (5.4.0)
+    lyber-core (5.5.0)
       activesupport
       dor-services (>= 7.0.0, < 9)
       dor-workflow-client (~> 3.11)
@@ -425,7 +425,7 @@ DEPENDENCIES
   dor-workflow-client (~> 3.17)
   honeybadger
   jhove-service (~> 1.4)
-  lyber-core (~> 5.4)
+  lyber-core (~> 5.5)
   marc
   moab-versioning (~> 4.0)
   net-sftp (~> 2.1)


### PR DESCRIPTION
## Why was this change made?
So that robots will start reporting the started status.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
No.