### PR TITLE
Remove unused writers

### DIFF
--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -4,6 +4,7 @@ module Dor
   module Assembly
     class Item
       include Dor::Assembly::ContentMetadata
+      include Dor::Assembly::StubContentMetadataParser
 
       def initialize(params = {})
         # Takes a druid, either as a string or as a Druid object.

--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       let(:druid) { 'gg111bb2222' }
 
       before do
-        item.cm_file_name = item.path_finder.path_to_metadata_file(Settings.assembly.cm_file_name)
+        allow(item).to receive(:cm_file_name).and_return(item.path_finder.path_to_metadata_file(Settings.assembly.cm_file_name))
         allow_any_instance_of(Assembly::ObjectFile).to receive(:jp2able?).and_return(true)
 
         # These files needs to create


### PR DESCRIPTION
Reorganize stub content metadata methods into StubContentMetadataParser

## Why was this change made?

Tests should use stubs instead of writers.  This helps tease appart the files for stub contentMetadata vs regular contentMetadata


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
