### PR TITLE
[HOLD] Decouple from Solr

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -50,9 +50,21 @@ module CommonAccessioning
     Dor::Services::Client.configure(url: Settings.dor_services.url,
                                     token: Settings.dor_services.token)
   end
+
+  # Disable Solr updates (by defaualt ActiveFedora updates Solr automatically).
+  # We let activemq messages from Fedora which are received by dor-indexing-app handle this
+  # Cannot just do:
+  #   ::ENABLE_SOLR_UPDATES = false
+  # Because "warning: already initialized constant ENABLE_SOLR_UPDATES".
+  # ActiveFedora assigns a default (if unassigned) and we cannot pre-empt it from here.
+  def self.disable_solr_updates
+    Object.send(:remove_const, 'ENABLE_SOLR_UPDATES') if self.class.const_defined?('ENABLE_SOLR_UPDATES')
+    Object.const_set('ENABLE_SOLR_UPDATES', false)
+  end
 end
 
 CommonAccessioning.connect_dor_services_app
+CommonAccessioning.disable_solr_updates
 
 Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)
 

--- a/lib/robots/dor_repo/accession/embargo_release.rb
+++ b/lib/robots/dor_repo/accession/embargo_release.rb
@@ -15,8 +15,6 @@ module Robots
   module DorRepo
     module Accession
       class EmbargoRelease
-        # Turn off active_fedora updates of solr
-        ENABLE_SOLR_UPDATES = false
         LyberCore::Log.set_logfile(File.join(ROBOT_ROOT, 'log', 'embargo_release.log'))
         # Finds druids from solr based on the passed in query
         # It will then load each item from Dor, and call the block with the item


### PR DESCRIPTION
## Why was this change made?

The common-accessioning doesn't need to index because the dor-indexing-app should be responsible for that. Previously we've been indexing more than one time for each change, which causes undue load on the system.

This is being held until we can test on stage.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a