### PR TITLE
Use the cocina endpoint to determine object_type

### DIFF
--- a/lib/dor/release/item.rb
+++ b/lib/dor/release/item.rb
@@ -17,12 +17,12 @@ module Dor
         @object ||= Dor.find(@druid)
       end
 
-      def object_type
-        unless @obj_type
-          obj_type = object.identityMetadata.objectType
-          @obj_type = (obj_type.nil? ? 'unknown' : obj_type.first)
-        end
-        @obj_type.downcase.strip
+      def cocina_model
+        @cocina_model ||= Dor::Services::Client.object(@druid).find
+      end
+
+      def collection?
+        cocina_model.is_a?(Cocina::Models::Collection)
       end
     end
   end

--- a/spec/lib/dor/release/item_spec.rb
+++ b/spec/lib/dor/release/item_spec.rb
@@ -26,35 +26,31 @@ RSpec.describe Dor::Release::Item do
     end
   end
 
-  describe 'object_type' do
-    subject { @item.object_type }
+  describe 'collection?' do
+    subject { @item.collection? }
+
+    let(:object_client) { instance_double(Dor::Services::Client::Object, find: object_type.allocate) }
 
     before do
-      allow(@dor_object).to receive(:identityMetadata).and_return(Dor::IdentityMetadataDS.from_xml("<identityMetadata><objectType>#{object_type}</objectType></identityMetadata>"))
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     end
 
     context 'when object_type is item' do
-      let(:object_type) { 'item' }
+      let(:object_type) { Cocina::Models::DRO }
 
-      it { is_expected.to eq 'item' }
-    end
-
-    context 'when object_type is set' do
-      let(:object_type) { 'set' }
-
-      it { is_expected.to eq 'set' }
+      it { is_expected.to be false }
     end
 
     context 'when object_type is collection' do
-      let(:object_type) { 'collection' }
+      let(:object_type) { Cocina::Models::Collection }
 
-      it { is_expected.to eq 'collection' }
+      it { is_expected.to be true }
     end
 
     context 'when object_type is adminPolicy' do
-      let(:object_type) { 'adminPolicy' }
+      let(:object_type) { Cocina::Models::AdminPolicy }
 
-      it { is_expected.to eq 'adminpolicy' }
+      it { is_expected.to be false }
     end
   end
 end

--- a/spec/robots/release/release_members_spec.rb
+++ b/spec/robots/release/release_members_spec.rb
@@ -7,8 +7,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
 
   let(:robot) { described_class.new }
   let(:druid) { 'druid:aa222cc3333' }
-  let(:work_item) { instance_double(Dor::Item) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, find: cocina_model) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
   let(:fetcher) { instance_double(DorFetcher::Client, get_collection: members) }
   let(:members) { {} }
@@ -21,146 +20,156 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
     allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
   end
 
-  it 'runs the robot' do
-    setup_release_item(druid, :item, nil)
-    perform
-  end
+  context 'when the model is an item' do
+    let(:cocina_model) { instance_double(Cocina::Models::DRO) }
 
-  it 'runs the robot for an item or an apo and do nothing as a result' do
-    %w[:item :apo].each do |item_type|
-      setup_release_item(druid, item_type, nil)
+    it 'does nothing' do
       expect(robot).not_to receive(:item_members) # we won't bother looking for item members if this is an item
+
       perform
     end
   end
 
-  context 'when the collection is released to self only' do
-    let(:tag_service) do
-      instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' } },
-                                              release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' }] })
-    end
+  context 'when the model is an apo' do
+    let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy) }
 
-    let(:members) do
-      { 'sets' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' }] }
+    it 'does nothing' do
+      expect(robot).not_to receive(:item_members) # we won't bother looking for item members if this is an item
+
+      perform
     end
+  end
+
+  context 'when the model is a collection' do
+    let(:cocina_model) { Cocina::Models::Collection.allocate }
+    let(:work_item) { instance_double(Dor::Item) }
 
     before do
-      setup_release_item(druid, :collection, members)
-      allow(Dor::ReleaseTagService).to receive(:for).with(@dor_item).and_return(tag_service)
+      allow(Dor).to receive(:find).and_return(work_item)
     end
 
-    it 'runs for a collection but never add workflow or ask for item members' do
-      expect(workflow_client).to receive(:create_workflow_by_name).once # one workflow added for the sub-collection
-      perform
-    end
-  end
-
-  context 'when there are multiple targets but they are all released to self only' do
-    let(:tag_service) do
-      instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
-                                                                    'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' } },
-                                              release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
-                                                                                'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' }] })
-    end
-    let(:members) do
-      { 'collections' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' }] }
-    end
-
-    before do
-      setup_release_item(druid, :collection, members)
-      allow(Dor::ReleaseTagService).to receive(:for).with(@dor_item).and_return(tag_service)
-    end
-
-    it 'runs for a collection but never adds workflow or ask for item members' do
-      expect(workflow_client).to receive(:create_workflow_by_name).once # one workflow added for the sub-collection
-      perform
-    end
-  end
-
-  context 'when the collection is not released to self' do
-    let(:tag_service) do
-      instance_double(Dor::ReleaseTagService,
-                      newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' } },
-                      release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' }] })
-    end
-
-    let(:members) do
-      { 'items' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' },
-                    { 'druid' => 'druid:bb023nj3137', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Snetterton Vanwall Trophy: 1958', 'catkey' => '3051732' },
-                    { 'druid' => 'druid:bb027yn4436', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Crystal Palace BARC: 1954', 'catkey' => '3051733' },
-                    { 'druid' => 'druid:bb048rn5648', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => '', 'catkey' => '3051734' }] }
-    end
-
-    before do
-      setup_release_item(druid, :collection, members)
-      allow(Dor::ReleaseTagService).to receive(:for).with(@dor_item).and_return(tag_service)
-    end
-
-    it 'runs for a collection and execute the item_members method' do
-      expect(workflow_client).to receive(:create_workflow_by_name).exactly(4).times # four workflows added, one for each item
-
-      perform
-    end
-  end
-
-  context 'when there are multiple targets and at least one of the release tagets is not released to self' do
-    let(:tag_service) do
-      instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
-                                                                    'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' } },
-                                              release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
-                                                                                'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' }] })
-    end
-    let(:members) do
-      { 'items' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' },
-                    { 'druid' => 'druid:bb023nj3137', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Snetterton Vanwall Trophy: 1958', 'catkey' => '3051732' },
-                    { 'druid' => 'druid:bb027yn4436', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Crystal Palace BARC: 1954', 'catkey' => '3051733' },
-                    { 'druid' => 'druid:bb048rn5648', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => '', 'catkey' => '3051734' }] }
-    end
-
-    before do
-      setup_release_item(druid, :collection, members)
-      allow(Dor::ReleaseTagService).to receive(:for).with(@dor_item).and_return(tag_service)
-    end
-
-    it 'runs for a collection and execute the item_members method' do
-      expect(workflow_client).to receive(:create_workflow_by_name).exactly(4).times # four workflows added, one for each item
-      perform
-    end
-  end
-
-  context 'with sub collections' do
-    let(:tag_service) do
-      instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' } },
-                                              release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' }] })
-    end
-
-    let(:collections) { [{ 'druid' => 'druid:bb001zc5754' }, { 'druid' => 'druid:bb023nj3137' }] }
-
-    context 'with only collections' do
-      before do
-        setup_release_item(druid, :collection, members)
-        allow(Dor::ReleaseTagService).to receive(:for).with(@dor_item).and_return(tag_service)
+    context 'when the collection is released to self only' do
+      let(:tag_service) do
+        instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' } },
+                                                release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' }] })
       end
 
-      let(:members) { { 'collections' => collections } }
+      let(:members) do
+        { 'sets' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' }] }
+      end
 
-      it 'runs for a collection and execute the sub_collection method' do
-        expect(workflow_client).to receive(:create_workflow_by_name).twice # two workflows added, one for each collection
+      before do
+        allow(Dor::ReleaseTagService).to receive(:for).with(work_item).and_return(tag_service)
+      end
+
+      it 'runs for a collection but never add workflow or ask for item members' do
+        expect(workflow_client).to receive(:create_workflow_by_name).once # one workflow added for the sub-collection
         perform
       end
     end
 
-    context 'with collections and itself' do
-      let(:members) { { 'collections' => collections + [{ 'druid' => druid }] } }
-
-      before do
-        setup_release_item(druid, :collection, 'collections' => collections + [{ 'druid' => druid }])
-        allow(Dor::ReleaseTagService).to receive(:for).with(@dor_item).and_return(tag_service)
+    context 'when there are multiple targets but they are all released to self only' do
+      let(:tag_service) do
+        instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
+                                                                      'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' } },
+                                                release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
+                                                                                  'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' }] })
+      end
+      let(:members) do
+        { 'collections' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' }] }
       end
 
-      it 'runs for a collection and execute the sub_collection method but not add a workflow for the collection itself' do
-        expect(workflow_client).to receive(:create_workflow_by_name).twice # two workflows added, one for each collection
+      before do
+        allow(Dor::ReleaseTagService).to receive(:for).with(work_item).and_return(tag_service)
+      end
+
+      it 'runs for a collection but never adds workflow or ask for item members' do
+        expect(workflow_client).to receive(:create_workflow_by_name).once # one workflow added for the sub-collection
         perform
+      end
+    end
+
+    context 'when the collection is not released to self' do
+      let(:tag_service) do
+        instance_double(Dor::ReleaseTagService,
+                        newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' } },
+                        release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' }] })
+      end
+
+      let(:members) do
+        { 'items' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' },
+                      { 'druid' => 'druid:bb023nj3137', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Snetterton Vanwall Trophy: 1958', 'catkey' => '3051732' },
+                      { 'druid' => 'druid:bb027yn4436', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Crystal Palace BARC: 1954', 'catkey' => '3051733' },
+                      { 'druid' => 'druid:bb048rn5648', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => '', 'catkey' => '3051734' }] }
+      end
+
+      before do
+        allow(Dor::ReleaseTagService).to receive(:for).with(work_item).and_return(tag_service)
+      end
+
+      it 'runs for a collection and execute the item_members method' do
+        expect(workflow_client).to receive(:create_workflow_by_name).exactly(4).times # four workflows added, one for each item
+
+        perform
+      end
+    end
+
+    context 'when there are multiple targets and at least one of the release tagets is not released to self' do
+      let(:tag_service) do
+        instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
+                                                                      'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' } },
+                                                release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' },
+                                                                                  'Revs' => { 'release' => true, 'what' => 'self', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'petucket' }] })
+      end
+      let(:members) do
+        { 'items' => [{ 'druid' => 'druid:bb001zc5754', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'French Grand Prix and 12 Hour Rheims: 1954', 'catkey' => '3051728' },
+                      { 'druid' => 'druid:bb023nj3137', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Snetterton Vanwall Trophy: 1958', 'catkey' => '3051732' },
+                      { 'druid' => 'druid:bb027yn4436', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => 'Crystal Palace BARC: 1954', 'catkey' => '3051733' },
+                      { 'druid' => 'druid:bb048rn5648', 'latest_change' => '2014-06-06T05:06:06Z', 'title' => '', 'catkey' => '3051734' }] }
+      end
+
+      before do
+        allow(Dor::ReleaseTagService).to receive(:for).with(work_item).and_return(tag_service)
+      end
+
+      it 'runs for a collection and execute the item_members method' do
+        expect(workflow_client).to receive(:create_workflow_by_name).exactly(4).times # four workflows added, one for each item
+        perform
+      end
+    end
+
+    context 'with sub collections' do
+      let(:tag_service) do
+        instance_double(Dor::ReleaseTagService, newest_release_tag: { 'SearchWorks' => { 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' } },
+                                                release_tags: { 'SearchWorks' => [{ 'release' => true, 'what' => 'collection', 'when' => '2016-10-07 19:34:43 UTC', 'who' => 'lmcrae' }] })
+      end
+
+      let(:collections) { [{ 'druid' => 'druid:bb001zc5754' }, { 'druid' => 'druid:bb023nj3137' }] }
+
+      context 'with only collections' do
+        before do
+          allow(Dor::ReleaseTagService).to receive(:for).with(work_item).and_return(tag_service)
+        end
+
+        let(:members) { { 'collections' => collections } }
+
+        it 'runs for a collection and execute the sub_collection method' do
+          expect(workflow_client).to receive(:create_workflow_by_name).twice # two workflows added, one for each collection
+          perform
+        end
+      end
+
+      context 'with collections and itself' do
+        let(:members) { { 'collections' => collections + [{ 'druid' => druid }] } }
+
+        before do
+          allow(Dor::ReleaseTagService).to receive(:for).with(work_item).and_return(tag_service)
+        end
+
+        it 'runs for a collection and execute the sub_collection method but not add a workflow for the collection itself' do
+          expect(workflow_client).to receive(:create_workflow_by_name).twice # two workflows added, one for each collection
+          perform
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,20 +36,6 @@ def clone_test_input(destination)
   system "rsync -rqOlt --delete #{source}/ #{destination}/"
 end
 
-def setup_release_item(druid, obj_type, members)
-  @release_item = Dor::Release::Item.new(druid: druid)
-  @dor_item = instance_double(Dor::Item)
-  allow(@dor_item).to receive_messages(
-    id: druid
-  )
-  allow(@release_item).to receive_messages(
-    object: @dor_item,
-    object_type: obj_type.to_s.downcase,
-    members: members
-  )
-  allow(Dor::Release::Item).to receive_messages(new: @release_item)
-end
-
 def instantiate_fixture(druid, klass = ActiveFedora::Base)
   mask = File.join(fixture_dir, "*_#{druid.sub(/:/, '_')}.xml")
   fname = Dir[mask].first


### PR DESCRIPTION


## Why was this change made?

This avoids a call to Fedora

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a
