### PR TITLE
Tweak to experiment to ignore empty content dirs.

### DIFF
--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -50,11 +50,16 @@ class TechnicalMetadataService
     ng_doc = Nokogiri::XML(content_metadata.content)
     files = ng_doc.xpath('//file/@id').map(&:content)
     workspace = DruidTools::Druid.new(dor_item.pid, Settings.sdr.local_workspace_root)
+
+    content_dir = workspace.content_dir(false)
+    return unless Dir.exist?(content_dir) && !Dir.empty?(content_dir)
+
     # This will raise an error if any of the files are missing.
     begin
       workspace.find_filelist_parent('content', files)
     rescue StandardError => e
-      Honeybadger.notify("Not all files staged for #{dor_item.pid} when extracting tech md: #{e}")
+      Honeybadger.notify("Not all files staged for #{dor_item.pid} when extracting tech md: #{e}. This is part of an " \
+        'experiment.')
     end
   end
 


### PR DESCRIPTION
## Why was this change made?
So that notifications are not sent when a content directory is empty. An empty content directory indicates a metadata only update.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
No