### PR TITLE
Refactor RightsMetadata robot to not depend on DatastreamBuilder

### DIFF
--- a/lib/robots/dor_repo/accession/rights_metadata.rb
+++ b/lib/robots/dor_repo/accession/rights_metadata.rb
@@ -10,17 +10,34 @@ module Robots
         end
 
         def perform(druid)
-          obj = Dor.find(druid)
-          builder = DatastreamBuilder.new(datastream: obj.rightsMetadata)
+          object = DruidTools::Druid.new(druid, Dor::Config.stacks.local_workspace_root)
+          path = object.find_metadata('rightsMetadata.xml')
+          object_client = Dor::Services::Client.object(druid)
+          if path
+            object_client.metadata.legacy_update(
+              rights: {
+                updated: File.mtime(path),
+                content: File.read(path)
+              }
+            )
+          elsif has_no_rights_metadata?(druid)
+            Honeybadger.notify("I don't think this ever happens because rights is created when registering. This is an experiment")
 
-          builder.build do |datastream|
-            build_datastream(obj, datastream)
+            # TODO: Fetch admin_policy_object without involving Fedora 3 concepts
+            apo = Dor.find(druid).admin_policy_object
+            object_client.metadata.legacy_update(
+              rights: {
+                updated: Time.now,
+                content: apo.defaultObjectRights.content
+              }
+            )
           end
         end
 
-        def build_datastream(obj, datastream)
-          datastream.dsLabel = 'Rights Metadata'
-          datastream.ng_xml = obj.admin_policy_object.defaultObjectRights.ng_xml.clone
+        # TODO: for now we're looking for the presence of the datastream, but eventually
+        # we need to do this without involving Fedora 3 concepts
+        def has_no_rights_metadata?(druid)
+          Dor.find(druid).rightsMetadata.new?
         end
       end
     end

--- a/spec/robots/accession/descriptive_metadata_spec.rb
+++ b/spec/robots/accession/descriptive_metadata_spec.rb
@@ -49,7 +49,6 @@ RSpec.describe Robots::DorRepo::Accession::DescriptiveMetadata do
     end
 
     context 'when descMetadata file is found' do
-      let(:path) { 'spec/fixtures/ab123cd4567_descMetadata.xml' }
       let(:finder) { instance_double(DruidTools::Druid, find_metadata: 'spec/fixtures/ab123cd4567_descMetadata.xml') }
 
       before do

--- a/spec/robots/accession/rights_metadata_spec.rb
+++ b/spec/robots/accession/rights_metadata_spec.rb
@@ -3,24 +3,67 @@
 require 'spec_helper'
 
 RSpec.describe Robots::DorRepo::Accession::RightsMetadata do
-  let(:robot) { described_class.new }
+  subject(:perform) { robot.perform(druid) }
 
-  let(:item) do
-    instantiate_fixture('druid:ab123cd4567', Dor::Item)
+  let(:robot) { described_class.new }
+  let(:druid) { 'druid:ab123cd4567' }
+
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object, refresh_metadata: true, metadata: metadata_client)
+  end
+  let(:metadata_client) do
+    instance_double(Dor::Services::Client::Metadata, legacy_update: true)
   end
 
-  describe '#build_datastream' do
-    let(:apo) { instantiate_fixture('druid:fg890hi1234', Dor::AdminPolicyObject) }
-    let(:rights_md) { apo.defaultObjectRights.content }
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+  end
+
+  context 'when no rightsMetadata file is found' do
+    before do
+      allow(Dor).to receive(:find).and_return(fedora_obj)
+    end
+
+    let(:fedora_obj) { instance_double(Dor::Item, rightsMetadata: datastream, admin_policy_object: apo) }
+    let(:apo) { instance_double(Dor::AdminPolicyObject, defaultObjectRights: default_ds) }
+    let(:default_ds) { instance_double(Dor::DefaultObjectRightsDS, content: 'this is default') }
+
+    context "when rightsMetadata doesn't exist" do
+      let(:datastream) { instance_double(Dor::RightsMetadataDS, new?: true) }
+
+      it 'builds a datastream from the remote service call' do
+        perform
+        expect(metadata_client).to have_received(:legacy_update)
+      end
+    end
+
+    context 'when rightsMetadata exists' do
+      let(:datastream) { instance_double(Dor::RightsMetadataDS, new?: false) }
+
+      it 'does nothing' do
+        perform
+        expect(metadata_client).not_to have_received(:legacy_update)
+      end
+    end
+  end
+
+  context 'when rightsMetadata file is found' do
+    let(:finder) { instance_double(DruidTools::Druid, find_metadata: 'spec/fixtures/ab123cd4567_descMetadata.xml') }
 
     before do
-      allow(item).to receive(:admin_policy_object).and_return(apo)
+      allow(DruidTools::Druid).to receive(:new).and_return(finder)
     end
 
-    it 'copies the default object rights' do
-      expect(item.rightsMetadata.ng_xml.to_s).not_to be_equivalent_to(rights_md)
-      robot.send(:build_datastream, item, item.rightsMetadata)
-      expect(item.rightsMetadata.ng_xml.to_s).to be_equivalent_to(rights_md)
+    # rubocop:disable RSpec/ExampleLength
+    it 'reads the file in' do
+      perform
+      expect(metadata_client).to have_received(:legacy_update).with(
+        rights: {
+          updated: Time,
+          content: /first book in Latin/
+        }
+      )
     end
+    # rubocop:enable RSpec/ExampleLength
   end
 end


### PR DESCRIPTION

## Why was this change made?

We're trying to move to using the API methods for updating metadata rather than directly communicating with Fedora


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a