### PR TITLE
Refactor the technical metadata robot not to use DatastreamBuilder

### DIFF
--- a/spec/lib/datastream_builder_spec.rb
+++ b/spec/lib/datastream_builder_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe DatastreamBuilder do
   subject(:builder) do
-    described_class.new(datastream: ds, force: true)
+    described_class.new(datastream: ds)
   end
 
   let(:ds) { item.technicalMetadata }

--- a/spec/robots/accession/technical_metadata_spec.rb
+++ b/spec/robots/accession/technical_metadata_spec.rb
@@ -18,12 +18,53 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
     context 'on an item' do
       let(:object) { Dor::Item.new(pid: druid) }
 
-      it 'builds a datastream' do
-        expect(DatastreamBuilder).to receive(:new)
-          .with(datastream: Dor::TechnicalMetadataDS, force: true)
-          .and_return(builder)
-        expect(builder).to receive(:build)
-        perform
+      let(:object_client) do
+        instance_double(Dor::Services::Client::Object, refresh_metadata: true, metadata: metadata_client)
+      end
+      let(:metadata_client) do
+        instance_double(Dor::Services::Client::Metadata, legacy_update: true)
+      end
+
+      before do
+        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      end
+
+      context 'when no technicalMetadata file is found' do
+        before do
+          allow(TechnicalMetadataService).to receive(:add_update_technical_metadata).and_return('tech md')
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        it 'creates new metadata' do
+          perform
+          expect(metadata_client).to have_received(:legacy_update).with(
+            technical: {
+              updated: Time,
+              content: /tech md/
+            }
+          )
+        end
+        # rubocop:enable RSpec/ExampleLength
+      end
+
+      context 'when technicalMetadata file is found' do
+        let(:finder) { instance_double(DruidTools::Druid, find_metadata: 'spec/fixtures/ab123cd4567_descMetadata.xml') }
+
+        before do
+          allow(DruidTools::Druid).to receive(:new).and_return(finder)
+        end
+
+        # rubocop:disable RSpec/ExampleLength
+        it 'creates new metadata' do
+          perform
+          expect(metadata_client).to have_received(:legacy_update).with(
+            technical: {
+              updated: Time,
+              content: /first book in Latin/
+            }
+          )
+        end
+        # rubocop:enable RSpec/ExampleLength
       end
     end
 


### PR DESCRIPTION
## Why was this change made?
Instead use the API methods. This positions the project to remove the Fedora dependency


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a