### PR TITLE
Do dependency injection for TechnicalMetadataService

### DIFF
--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -28,7 +28,7 @@ module Robots
           else
             # Otherwise (re)generate technical metadata
             xml = obj.technicalMetadata.content unless obj.technicalMetadata.new?
-            tech_md = TechnicalMetadataService.add_update_technical_metadata(obj, tech_metadata: xml)
+            tech_md = TechnicalMetadataService.add_update_technical_metadata(obj, pid: druid, tech_metadata: xml)
             if tech_md
               object_client.metadata.legacy_update(
                 technical: {

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -27,8 +27,7 @@ module Robots
             )
           else
             # Otherwise (re)generate technical metadata
-            xml = obj.technicalMetadata.content unless obj.technicalMetadata.new?
-            tech_md = TechnicalMetadataService.add_update_technical_metadata(obj, pid: druid, tech_metadata: xml)
+            tech_md = generate_technical_metadata(obj, druid)
             if tech_md
               object_client.metadata.legacy_update(
                 technical: {
@@ -38,6 +37,14 @@ module Robots
               )
             end
           end
+        end
+
+        private
+
+        def generate_technical_metadata(obj, druid)
+          tech_xml = obj.technicalMetadata.content unless obj.technicalMetadata.new?
+          content_xml = obj.contentMetadata.content
+          TechnicalMetadataService.add_update_technical_metadata(content_metadata: content_xml, pid: druid, tech_metadata: tech_xml)
         end
       end
     end

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -27,7 +27,8 @@ module Robots
             )
           else
             # Otherwise (re)generate technical metadata
-            tech_md = TechnicalMetadataService.add_update_technical_metadata(obj)
+            xml = obj.technicalMetadata.content unless obj.technicalMetadata.new?
+            tech_md = TechnicalMetadataService.add_update_technical_metadata(obj, tech_metadata: xml)
             if tech_md
               object_client.metadata.legacy_update(
                 technical: {

--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -12,13 +12,15 @@ require 'jhove_service'
 # the Work metadata will allow us to simplify this greatly.
 class TechnicalMetadataService
   # @param [Dor::Item] dor_item The DOR item being processed by the technical metadata robot
+  # @param [String,NilClass] tech_metadata The xml tech metadata from DOR or nil if there is none
   # @return [String,NilClass] The finalized technicalMetadata datastream contents for the new object version, or nil if no changes.
-  def self.add_update_technical_metadata(dor_item)
-    new(dor_item).add_update_technical_metadata
+  def self.add_update_technical_metadata(dor_item, tech_metadata:)
+    new(dor_item, tech_metadata: tech_metadata).add_update_technical_metadata
   end
 
-  def initialize(dor_item)
+  def initialize(dor_item, tech_metadata:)
     @dor_item = dor_item
+    @dor_techmd = tech_metadata
   end
 
   def add_update_technical_metadata
@@ -40,7 +42,7 @@ class TechnicalMetadataService
 
   private
 
-  attr_reader :dor_item
+  attr_reader :dor_item, :dor_techmd
 
   def check_all_files_staged
     content_metadata = dor_item.contentMetadata
@@ -99,10 +101,6 @@ class TechnicalMetadataService
   # @return [String] The technicalMetadata datastream from the previous version of the digital object (fetched from DOR fedora).
   #   The data is updated to the latest format.
   def dor_technical_metadata
-    ds = 'technicalMetadata'
-    return nil unless dor_item.datastreams.key?(ds) && !dor_item.datastreams[ds].new?
-
-    dor_techmd = dor_item.datastreams[ds].content
     return dor_techmd if dor_techmd =~ /<technicalMetadata/
     return ::JhoveService.new.upgrade_technical_metadata(dor_techmd) if dor_techmd =~ /<jhove/
 

--- a/spec/lib/technical_metadata_service_spec.rb
+++ b/spec/lib/technical_metadata_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe TechnicalMetadataService do
   let(:object_ids) { %w[dd116zh0343 du000ps9999 jq937jp0017] }
   let(:druid_tool) { {} }
   let(:tech_metadata) { nil }
-  let(:instance) { described_class.new(dor_item, tech_metadata: tech_metadata) }
-  let(:dor_item) { instance_double(Dor::Item, pid: druid, contentMetadata: nil) }
+  let(:instance) { described_class.new(dor_item, pid: druid, tech_metadata: tech_metadata) }
+  let(:dor_item) { instance_double(Dor::Item, contentMetadata: nil) }
   let(:druid) { 'druid:dd116zh0343' }
 
   before do
@@ -24,7 +24,7 @@ RSpec.describe TechnicalMetadataService do
 
     object_ids.each do |id|
       druid = "druid:#{id}"
-      instance = described_class.new(instance_double(Dor::Item, pid: druid), tech_metadata: nil)
+      instance = described_class.new(instance_double(Dor::Item), pid: druid, tech_metadata: nil)
       druid_tool[id] = DruidTools::Druid.new(druid, Pathname(wsfixtures).to_s)
       repo_content_pathname = fixtures.join('sdr_repo', id, 'v0001', 'data', 'content')
       work_content_pathname = Pathname(druid_tool[id].content_dir)
@@ -401,7 +401,7 @@ RSpec.describe TechnicalMetadataService do
 
   specify '#new_technical_metadata' do
     object_ids.each do |id|
-      allow(dor_item).to receive(:pid).and_return("druid:#{id}")
+      allow(instance).to receive(:pid).and_return("druid:#{id}")
       new_techmd = instance.send(:new_technical_metadata, @deltas[id])
       file_nodes = Nokogiri::XML(new_techmd).xpath('//file')
       case id
@@ -563,7 +563,7 @@ RSpec.describe TechnicalMetadataService do
 
   specify '#build_technical_metadata' do
     object_ids.each do |id|
-      instance = described_class.new(instance_double(Dor::Item, pid: "druid:#{id}"), tech_metadata: nil)
+      instance = described_class.new(instance_double(Dor::Item), pid: "druid:#{id}", tech_metadata: nil)
       old_techmd = @repo_techmd[id]
       new_techmd = @new_file_techmd[id]
       deltas = @deltas[id]

--- a/spec/lib/technical_metadata_service_spec.rb
+++ b/spec/lib/technical_metadata_service_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe TechnicalMetadataService do
   let(:object_ids) { %w[dd116zh0343 du000ps9999 jq937jp0017] }
   let(:druid_tool) { {} }
   let(:tech_metadata) { nil }
-  let(:instance) { described_class.new(dor_item, pid: druid, tech_metadata: tech_metadata) }
-  let(:dor_item) { instance_double(Dor::Item, contentMetadata: nil) }
+  let(:content_metadata) { '' }
+  let(:instance) { described_class.new(content_metadata: content_metadata, pid: druid, tech_metadata: tech_metadata) }
   let(:druid) { 'druid:dd116zh0343' }
 
   before do
@@ -24,7 +24,7 @@ RSpec.describe TechnicalMetadataService do
 
     object_ids.each do |id|
       druid = "druid:#{id}"
-      instance = described_class.new(instance_double(Dor::Item), pid: druid, tech_metadata: nil)
+      instance = described_class.new(content_metadata: '', pid: druid, tech_metadata: nil)
       druid_tool[id] = DruidTools::Druid.new(druid, Pathname(wsfixtures).to_s)
       repo_content_pathname = fixtures.join('sdr_repo', id, 'v0001', 'data', 'content')
       work_content_pathname = Pathname(druid_tool[id].content_dir)
@@ -51,9 +51,7 @@ RSpec.describe TechnicalMetadataService do
   describe '.add_update_technical_metadata' do
     # Note: This test is for an experiment and will be removed.
     context 'when all files are not staged' do
-      let(:dor_item) { instance_double(Dor::Item, pid: druid, contentMetadata: contentMetadata) }
-      let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, content: contentMetadataContent) }
-      let(:contentMetadataContent) do
+      let(:content_metadata) do
         <<~EOF
           <?xml version="1.0"?>
           <contentMetadata type="sample" objectId="druid:dd116zh0343">
@@ -131,10 +129,7 @@ RSpec.describe TechnicalMetadataService do
 
     # Note: This test is for an experiment and will be removed.
     context 'when all files are staged' do
-      let(:technicalMetadata) { instance_double(Dor::TechnicalMetadataDS, new?: true, :dsLabel= => true, :content= => true, save: true) }
-      let(:dor_item) { instance_double(Dor::Item, pid: druid, contentMetadata: contentMetadata, datastreams: { 'technicalMetadata' => technicalMetadata }) }
-      let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, content: contentMetadataContent) }
-      let(:contentMetadataContent) do
+      let(:content_metadata) do
         <<~EOF
           <?xml version="1.0"?>
           <contentMetadata type="sample" objectId="druid:dd116zh0343">
@@ -213,10 +208,7 @@ RSpec.describe TechnicalMetadataService do
     # Note: This test is for an experiment and will be removed.
     context 'when no files are staged' do
       let(:druid) { 'druid:bb648mk7250' }
-      let(:technicalMetadata) { instance_double(Dor::TechnicalMetadataDS, new?: true, :dsLabel= => true, :content= => true) }
-      let(:dor_item) { instance_double(Dor::Item, pid: druid, contentMetadata: contentMetadata, datastreams: { 'technicalMetadata' => technicalMetadata }) }
-      let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, content: contentMetadataContent) }
-      let(:contentMetadataContent) do
+      let(:content_metadata) do
         <<~EOF
           <?xml version="1.0"?>
           <contentMetadata type="sample" objectId="druid:bb648mk7250">
@@ -266,11 +258,10 @@ RSpec.describe TechnicalMetadataService do
     subject(:content_group_diff) { instance.send(:content_group_diff) }
 
     context 'with contentMetadata' do
-      let(:contentMetadata) { instance_double(Dor::ContentMetadataDS, content: 'foo') }
+      let(:content_metadata) { 'foo' }
       let(:object_id) { 'dd116zh0343' }
       let(:druid) { "druid:#{object_id}" }
       let(:group_diff) { @inventory_differences[object_id] }
-      let(:dor_item) { instance_double(Dor::Item, contentMetadata: contentMetadata, pid: druid) }
       let(:inventory_diff) do
         Moab::FileInventoryDifference.new(
           digital_object_id: druid,
@@ -288,14 +279,6 @@ RSpec.describe TechnicalMetadataService do
         expect(content_group_diff.to_xml).to eq(group_diff.to_xml)
       end
     end
-
-    context 'without contentMetadata' do
-      let(:dor_item) { instance_double(Dor::Item, contentMetadata: nil) }
-
-      it 'has no difference' do
-        expect(content_group_diff.difference_count).to be_zero
-      end
-    end
   end
 
   specify '#new_files' do
@@ -304,8 +287,6 @@ RSpec.describe TechnicalMetadataService do
   end
 
   specify '#old_technical_metadata' do
-    druid = 'druid:dd116zh0343'
-    allow(dor_item).to receive(:pid).and_return(druid)
     tech_md = '<technicalMetadata/>'
     expect(instance).to receive(:preservation_technical_metadata).and_return(tech_md, nil)
     old_techmd = instance.send(:old_technical_metadata)
@@ -563,7 +544,7 @@ RSpec.describe TechnicalMetadataService do
 
   specify '#build_technical_metadata' do
     object_ids.each do |id|
-      instance = described_class.new(instance_double(Dor::Item), pid: "druid:#{id}", tech_metadata: nil)
+      instance = described_class.new(content_metadata: '', pid: "druid:#{id}", tech_metadata: nil)
       old_techmd = @repo_techmd[id]
       new_techmd = @new_file_techmd[id]
       deltas = @deltas[id]


### PR DESCRIPTION
## Why was this change made?

This removes the TechnicalMetadataService's dependency on Fedora

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a