### PR TITLE
Remove unnecessary check

### DIFF
--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -64,8 +64,6 @@ class TechnicalMetadataService
 
   # @return [FileGroupDifference] The differences between two versions of a group of files
   def content_group_diff
-    raise Dor::ParameterError, 'Missing Dor::Config.stacks.local_workspace_root' if Dor::Config.stacks.local_workspace_root.nil?
-
     inventory_diff = Preservation::Client.objects.content_inventory_diff(druid: pid, content_metadata: content_metadata)
     inventory_diff.group_difference('content')
   end


### PR DESCRIPTION

## Why was this change made?

This was originally here: https://github.com/sul-dlss/dor-services/blob/9e72fb39facf55fa84d0de6348000b2cd4932b4a/lib/dor/models/concerns/itemizable.rb#L34
Which was copied to here: https://github.com/sul-dlss/dor-services/commit/9e72fb39facf55fa84d0de6348000b2cd4932b4a#diff-7eb9eefd909d64459102b2c923082a19R37
and eventually made it's way into common-accessioning.  However, this no longer seems to serve any purpose if it ever did.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a