### PR TITLE
Refactor end-accession robot to use cocina api rather than Fedora

### DIFF
--- a/spec/robots/accession/end_accession_spec.rb
+++ b/spec/robots/accession/end_accession_spec.rb
@@ -5,18 +5,34 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::Accession::EndAccession do
   subject(:robot) { described_class.new }
 
-  let(:object) { instance_double(Dor::Item, admin_policy_object: apo) }
-  let(:apo) { Dor::AdminPolicyObject.new }
+  let(:object) do
+    Cocina::Models::DRO.new(externalIdentifier: '123',
+                            type: Cocina::Models::DRO::TYPES.first,
+                            label: 'my repository object',
+                            version: 1,
+                            administrative: { hasAdminPolicy: apo_id })
+  end
+  let(:apo) do
+    Cocina::Models::AdminPolicy.new(externalIdentifier: '123',
+                                    type: Cocina::Models::AdminPolicy::TYPES.first,
+                                    label: 'my apo object',
+                                    version: 1,
+                                    administrative: {})
+  end
+
   let(:druid) { 'druid:oo000oo0001' }
+  let(:apo_id) { 'druid:mx121xx1234' }
   let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'default') }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil, process: process) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, find: object) }
+  let(:apo_object_client) { instance_double(Dor::Services::Client::Object, find: apo) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
 
   before do
     allow(Dor).to receive(:find).with(druid).and_return(object)
     allow(Dor::Config.workflow).to receive(:client).and_return(workflow_client)
-    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+    allow(Dor::Services::Client).to receive(:object).with(apo_id).and_return(apo_object_client)
   end
 
   describe '#perform' do
@@ -31,18 +47,12 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
     end
 
     context 'when there is a special dissemniation workflow' do
-      before do
-        apo.administrativeMetadata.content = xml
-      end
-
-      let(:xml) do
-        <<~XML
-          <administrativeMetadata>
-            <dissemination>
-              <workflow id="wasDisseminationWF"/>
-            </dissemination>
-          </administrativeMetadata>
-        XML
+      let(:apo) do
+        Cocina::Models::AdminPolicy.new(externalIdentifier: '123',
+                                        type: Cocina::Models::AdminPolicy::TYPES.first,
+                                        label: 'my apo object',
+                                        version: 1,
+                                        administrative: { registration_workflow: 'wasDisseminationWF' })
       end
 
       it 'kicks off both dissemination workflows' do


### PR DESCRIPTION
## Why was this change made?

We are trying to remove the calls to Fedora 3

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a