### PR TITLE
Remove a Dor.find from rightsMetadata in favor of the cocina api

### DIFF
--- a/lib/robots/dor_repo/accession/rights_metadata.rb
+++ b/lib/robots/dor_repo/accession/rights_metadata.rb
@@ -23,12 +23,14 @@ module Robots
           elsif has_no_rights_metadata?(druid)
             Honeybadger.notify("I don't think this ever happens because rights is created when registering. This is an experiment")
 
-            # TODO: Fetch admin_policy_object without involving Fedora 3 concepts
-            apo = Dor.find(druid).admin_policy_object
+            object = Dor::Services::Client.object(druid).find
+            apo_id = object.administrative.hasAdminPolicy
+            apo = Dor::Services::Client.object(apo_id).find
+
             object_client.metadata.legacy_update(
               rights: {
                 updated: Time.now,
-                content: apo.defaultObjectRights.content
+                content: apo.administrative.default_object_rights
               }
             )
           end

--- a/spec/robots/accession/rights_metadata_spec.rb
+++ b/spec/robots/accession/rights_metadata_spec.rb
@@ -7,26 +7,41 @@ RSpec.describe Robots::DorRepo::Accession::RightsMetadata do
 
   let(:robot) { described_class.new }
   let(:druid) { 'druid:ab123cd4567' }
+  let(:apo_id) { 'druid:mx121xx1234' }
+  let(:object) do
+    Cocina::Models::DRO.new(externalIdentifier: '123',
+                            type: Cocina::Models::DRO::TYPES.first,
+                            label: 'my repository object',
+                            version: 1,
+                            administrative: { hasAdminPolicy: apo_id })
+  end
 
   let(:object_client) do
-    instance_double(Dor::Services::Client::Object, refresh_metadata: true, metadata: metadata_client)
+    instance_double(Dor::Services::Client::Object, refresh_metadata: true, metadata: metadata_client, find: object)
   end
   let(:metadata_client) do
     instance_double(Dor::Services::Client::Metadata, legacy_update: true)
   end
 
   before do
-    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
   end
 
   context 'when no rightsMetadata file is found' do
+    let(:apo_object_client) { instance_double(Dor::Services::Client::Object, find: apo) }
+    let(:apo) do
+      Cocina::Models::AdminPolicy.new(externalIdentifier: '123',
+                                      type: Cocina::Models::AdminPolicy::TYPES.first,
+                                      label: 'my apo object',
+                                      version: 1,
+                                      administrative: {})
+    end
+    let(:fedora_obj) { instance_double(Dor::Item, rightsMetadata: datastream) }
+
     before do
       allow(Dor).to receive(:find).and_return(fedora_obj)
+      allow(Dor::Services::Client).to receive(:object).with(apo_id).and_return(apo_object_client)
     end
-
-    let(:fedora_obj) { instance_double(Dor::Item, rightsMetadata: datastream, admin_policy_object: apo) }
-    let(:apo) { instance_double(Dor::AdminPolicyObject, defaultObjectRights: default_ds) }
-    let(:default_ds) { instance_double(Dor::DefaultObjectRightsDS, content: 'this is default') }
 
     context "when rightsMetadata doesn't exist" do
       let(:datastream) { instance_double(Dor::RightsMetadataDS, new?: true) }


### PR DESCRIPTION


## Why was this change made?

This decouples common-accessioning from Fedora

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a