### PR TITLE
Prefer model type-checking methods over `#is_a?`

### DIFF
--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -16,11 +16,12 @@ module Dor
       end
 
       def cocina_model
+        # `#find` returns an instance of a model from the cocina-models gem
         @cocina_model ||= Dor::Services::Client.object(druid.druid).find
       end
 
       def item?
-        cocina_model.is_a?(Cocina::Models::DRO)
+        cocina_model.dro?
       end
 
       # @param [String] the mimetype of the file

--- a/lib/robots/dor_repo/accession/content_metadata.rb
+++ b/lib/robots/dor_repo/accession/content_metadata.rb
@@ -11,10 +11,11 @@ module Robots
 
         def perform(druid)
           object_client = Dor::Services::Client.object(druid)
-          obj = object_client.find
 
-          # non-items don't attach contentMetadata
-          return unless obj.is_a?(Cocina::Models::DRO)
+          # `#find` returns an instance of a model from the cocina-models gem
+          #
+          # Objects that aren't items/DROs do not have content metadata attached
+          return unless object_client.find.dro?
 
           object = DruidTools::Druid.new(druid, Dor::Config.stacks.local_workspace_root)
           path = object.find_metadata('contentMetadata.xml')

--- a/lib/robots/dor_repo/accession/publish.rb
+++ b/lib/robots/dor_repo/accession/publish.rb
@@ -12,10 +12,12 @@ module Robots
 
         def perform(druid)
           object_client = Dor::Services::Client.object(druid)
-          obj = object_client.find
 
-          # Since not being published, need to set publish-complete so that will proceed with wf.
-          if obj.is_a?(Cocina::Models::AdminPolicy)
+          # `#find` returns an instance of a model from the cocina-models gem
+          if object_client.find.admin_policy?
+            # Since admin policies are not published, we need to manually set
+            # the publish-complete step to completed so that the workflow will
+            # proceed.
             workflow_service.update_status(druid: druid, workflow: @workflow_name, process: 'publish-complete', status: 'completed', elapsed: 1, note: 'APOs are not published, so marking completed.')
             return
           end

--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -11,20 +11,20 @@ module Robots
 
         def perform(druid)
           object_client = Dor::Services::Client.object(druid)
-          obj = object_client.find
 
-          # non-items don't shelve anything
-          if obj.is_a?(Cocina::Models::DRO)
-            # This is an async result and it will have a callback.
-            Dor::Services::Client.object(druid).shelve
+          # `#find` returns an instance of a model from the cocina-models gem
+          if object_client.find.dro?
+            # This is an asynchronous result and it will have a callback.
+            object_client.shelve
           else
-            # Just set the callback step as complete
+            # Objects that aren't items/DROs are not shelved, so set the
+            # shelve-complete step as completed
             workflow_service.update_status(druid: druid,
                                            workflow: 'accessionWF',
                                            process: 'shelve-complete',
                                            status: 'completed',
                                            elapsed: 1,
-                                           note: 'Non-item, nothing to do')
+                                           note: 'Not an item/DRO, nothing to do')
           end
         end
       end

--- a/lib/robots/dor_repo/release/release_members.rb
+++ b/lib/robots/dor_repo/release/release_members.rb
@@ -16,9 +16,8 @@ module Robots
         def perform(druid)
           LyberCore::Log.debug "release-members working on #{druid}"
 
-          cocina_model = Dor::Services::Client.object(@druid).find
-
-          return unless cocina_model.is_a?(Cocina::Models::Collection)
+          # `#find` returns an instance of a model from the cocina-models gem
+          return unless Dor::Services::Client.object(@druid).find.collection?
 
           publish_collection(druid)
         end

--- a/spec/robots/accession/shelve_spec.rb
+++ b/spec/robots/accession/shelve_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
                 process: 'shelve-complete',
                 status: 'completed',
                 elapsed: 1,
-                note: 'Non-item, nothing to do')
+                note: 'Not an item/DRO, nothing to do')
       end
     end
 

--- a/spec/robots/release/release_members_spec.rb
+++ b/spec/robots/release/release_members_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
   end
 
   context 'when the model is an item' do
-    let(:cocina_model) { instance_double(Cocina::Models::DRO) }
+    let(:cocina_model) { instance_double(Cocina::Models::DRO, collection?: false) }
 
     it 'does nothing' do
       expect(robot).not_to receive(:item_members) # we won't bother looking for item members if this is an item
@@ -31,7 +31,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
   end
 
   context 'when the model is an apo' do
-    let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy) }
+    let(:cocina_model) { instance_double(Cocina::Models::AdminPolicy, collection?: false) }
 
     it 'does nothing' do
       expect(robot).not_to receive(:item_members) # we won't bother looking for item members if this is an item


### PR DESCRIPTION
## Why was this change made?

These methods are available as of cocina-models 0.9.0. This is a refactoring and thus should not need test changes. As part of this work, improve code comments.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

Code comments, yes.