### PR TITLE
Refactor technical_metadata_service

### DIFF
--- a/lib/technical_metadata_service.rb
+++ b/lib/technical_metadata_service.rb
@@ -39,7 +39,7 @@ class TechnicalMetadataService
     check_all_files_staged
 
     deltas = content_group_diff.file_deltas
-    old_techmd = old_technical_metadata
+    old_techmd = preserved_or_dor_technical_metadata
     new_techmd = new_technical_metadata(deltas)
     # this is version 1 or previous technical metadata was not saved
     return new_techmd if old_techmd.nil?
@@ -76,11 +76,8 @@ class TechnicalMetadataService
   end
 
   # @return [String] The technicalMetadata datastream from the previous version of the digital object
-  def old_technical_metadata
-    pres_techmd = upgraded_preservation_technical_metadata
-    return pres_techmd unless pres_techmd.nil?
-
-    dor_technical_metadata
+  def preserved_or_dor_technical_metadata
+    upgraded_preservation_technical_metadata.presence || dor_technical_metadata
   end
 
   # @return [String] The technicalMetadata datastream from the previous version of the digital object (fetched from preservation)

--- a/spec/lib/technical_metadata_service_spec.rb
+++ b/spec/lib/technical_metadata_service_spec.rb
@@ -125,13 +125,13 @@ RSpec.describe TechnicalMetadataService do
     expect(new_files).to eq(['page-2.jpg', 'page-1.jpg'])
   end
 
-  specify '#old_technical_metadata' do
+  specify '#preserved_or_dor_technical_metadata' do
     tech_md = '<technicalMetadata/>'
     expect(instance).to receive(:preservation_technical_metadata).and_return(tech_md, nil)
-    old_techmd = instance.send(:old_technical_metadata)
+    old_techmd = instance.send(:preserved_or_dor_technical_metadata)
     expect(old_techmd).to eq(tech_md)
     expect(instance).to receive(:dor_technical_metadata).and_return(tech_md)
-    old_techmd = instance.send(:old_technical_metadata)
+    old_techmd = instance.send(:preserved_or_dor_technical_metadata)
     expect(old_techmd).to eq(tech_md)
   end
 


### PR DESCRIPTION


## Why was this change made?

This gives more descriptive names to methods and makes the logic simpler

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a
