### PR TITLE
Use passed-in druid in ReleaseMembers robot

### DIFF
--- a/lib/robots/dor_repo/release/release_members.rb
+++ b/lib/robots/dor_repo/release/release_members.rb
@@ -17,7 +17,7 @@ module Robots
           LyberCore::Log.debug "release-members working on #{druid}"
 
           # `#find` returns an instance of a model from the cocina-models gem
-          return unless Dor::Services::Client.object(@druid).find.collection?
+          return unless Dor::Services::Client.object(druid).find.collection?
 
           publish_collection(druid)
         end


### PR DESCRIPTION

## Why was this change made?

Because `@druid` can be undefined. I believe this will fix https://github.com/sul-dlss/argo/issues/1796


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

no