### PR TITLE
Avoid LyberCore::Robot.step_to_classname

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following workflows are supported by this repository:
 * Dissemination - cleans up the workspace after accessioning
 * Release - Moves files to PURL and updates the marc record in the ILS
 * Goobi notify - informs goobi there are new items
-* ETD Submit - Starts accessioning for ETD objects and updates the ILS 
+* ETD Submit - Starts accessioning for ETD objects and updates the ILS
 
 ## For developers
 It's possible to invoke the jobs manually or have an interactive shell:
@@ -29,7 +29,7 @@ $ ROBOT_ENVIRONMENT=production ./bin/console
 
 Running a single robot step manually (without checking current workflow status):
 ```console
-$ ./bin/run_robot --druid druid:12345 --environment production dor:accessionWF:publish
+$ ./bin/run_robot --druid druid:12345 --environment production Accession::Publish
 ```
 
 ## Running tests

--- a/bin/run_robot
+++ b/bin/run_robot
@@ -5,12 +5,12 @@
 #
 # To run With Options
 # Options must be placed AFTER workflow and robot name
-# robot_root$ ./bin/run_robot dor:accessionWF:shelve -e test -d druid:aa12bb1234
+# robot_root$ ./bin/run_robot Accession::Publish -e test -d druid:aa12bb1234
 require 'bundler/setup'
 require 'slop'
 
 slop = Slop.parse do |o|
-  o.banner = 'Usage: ./bin/run_robot repo:workflow:step [options]'
+  o.banner = 'Usage: ./bin/run_robot class_name [options]'
   o.string '-e', '--environment', 'Environment to run in (i.e. test, production). Defaults to development', default: 'development'
   o.string '-d', '--druid', 'One druid to run the robot with', required: true
   o.string '-f', '--file', 'One file containing a druid per line'
@@ -28,11 +28,8 @@ opts = slop.to_h
 ENV['ROBOT_ENVIRONMENT'] = opts[:environment] unless opts[:environment].nil?
 require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 
-# generate the robot job class name
-class_name = LyberCore::Robot.step_to_classname robot
-
 # instantiate a Robot object using the name
-klazz = class_name.split('::').inject(Object) { |o, c| o.const_get c }
+klazz = robot.split('::').inject(Robots::DorRepo) { |o, c| o.const_get c }
 bot = klazz.new
 bot.check_queued_status = false # skipping the queued workflow status check
 

--- a/bin/run_robot_cron
+++ b/bin/run_robot_cron
@@ -7,14 +7,11 @@
 # Assumes robot suite was intalled with capistrano with bundler running in deployment mode
 #
 # From cron
-# 0 * * * * bash -l -c 'cd /path/to/robot_root && ROBOT_ENVIRONMENT=lyberservices-dev ruby ./bin/run_robot_cron etdSubmitWF:submit-marc' > /home/deploy/crondebug.log 2>&1
+# 0 * * * * bash -l -c 'cd /path/to/robot_root && ROBOT_ENVIRONMENT=lyberservices-dev ruby ./bin/run_robot_cron EtdSubmit::SubmitMarc' > /home/deploy/crondebug.log 2>&1
 
 require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 
-robot = ARGV.shift
-
-# Parse the module and robot file name from the command line
-robot_name = LyberCore::Robot.step_to_classname robot
+robot_name = ARGV.shift
 
 # See if the robot is already running
 procs_running = `ps -ef | grep #{robot_name} | grep -v 'grep' | wc -l`.strip.to_i
@@ -25,6 +22,6 @@ end
 
 # Instantiate the robot class and start it
 puts "Trying to load #{robot_name}"
-klazz = robot_name.split('::').inject(Object) { |o, c| o.const_get c }
+klazz = robot_name.split('::').inject(Robots::DorRepo) { |o, c| o.const_get c }
 robot = klazz.new check_queued_status: false
 robot.start

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -6,7 +6,7 @@ set :environment_variable, 'ROBOT_ENVIRONMENT'
 job_type :robot_cron, 'cd :path && :environment_variable=:environment :bundle_command bin/run_robot_cron :task :output'
 
 every :day, at: '9:10pm' do
-  robot_cron 'dor:etdSubmitWF:submit-marc'
+  robot_cron 'EtdSubmit::SubmitMarc'
 end
 
 every :day, at: '10:10pm' do
@@ -15,9 +15,9 @@ end
 
 every :hour, at: 40 do
   # This polls symphony to see if it has the data from submit-marc
-  robot_cron 'dor:etdSubmitWF:check-marc'
+  robot_cron 'EtdSubmit::CheckMarc'
 end
 
 every :hour, at: 41 do
-  robot_cron 'dor:etdSubmitWF:catalog-status'
+  robot_cron 'EtdSubmit::CatalogStatus'
 end


### PR DESCRIPTION


## Why was this change made?
It's deprecated because it's a lot more indirection than is required


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
