### PR TITLE
The clients have faraday retry logic built in already

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -15,9 +15,6 @@ assembly:
 
 release:
   fetcher_root: http://localhost:3000/
-  max_tries: 1 # the number of attempts to retry service calls before failing
-  max_sleep_seconds: 1  # max sleep seconds between tries
-  base_sleep_seconds: 1 # base sleep seconds between tries
 
 sdr:
   local_workspace_root: /dor/workspace
@@ -25,8 +22,6 @@ sdr:
 preservation_catalog:
   url: 'https://example.org/prescat'
   token: 'mint-token-with-target-preservation-catalog-rake-generate-token'
-
-
 
 fedora:
   url: ~

--- a/lib/dor/release/member_service.rb
+++ b/lib/dor/release/member_service.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'retries'
 require 'dor-fetcher'
 
 module Dor
@@ -35,9 +34,7 @@ module Dor
       end
 
       def members
-        @members || with_retries(max_tries: Settings.release.max_tries, base_sleep_seconds: Settings.release.base_sleep_seconds, max_sleep_seconds: Settings.release.max_sleep_seconds) do |_attempt|
-          @members = fetcher.get_collection(druid) # cache members in an instance variable
-        end
+        @members ||= fetcher.get_collection(druid) # cache members in an instance variable
       end
     end
   end

--- a/lib/robots/dor_repo/goobi/goobi_notify.rb
+++ b/lib/robots/dor_repo/goobi/goobi_notify.rb
@@ -14,11 +14,7 @@ module Robots
         #
         # @param [String] druid -- the Druid identifier for the object to process
         def perform(druid)
-          LyberCore::Log.debug "goobi-notify working on #{druid}"
-
-          with_retries(max_tries: 5, base_sleep_seconds: 10, max_sleep_seconds: 120) do |_attempt|
-            Dor::Services::Client.object(druid).notify_goobi
-          end
+          Dor::Services::Client.object(druid).notify_goobi
         end
       end
     end

--- a/lib/robots/dor_repo/release/release_members.rb
+++ b/lib/robots/dor_repo/release/release_members.rb
@@ -60,10 +60,8 @@ module Robots
           object_client = Dor::Services::Client.object(druid)
 
           # initiate workflow by making workflow service call
-          with_retries(max_tries: Settings.release.max_tries, base_sleep_seconds: Settings.release.base_sleep_seconds, max_sleep_seconds: Settings.release.max_sleep_seconds) do |_attempt|
-            current_version = object_client.version.current
-            Dor::Config.workflow.client.create_workflow_by_name(druid, 'releaseWF', version: current_version, lane_id: lane_id(druid))
-          end
+          current_version = object_client.version.current
+          Dor::Config.workflow.client.create_workflow_by_name(druid, 'releaseWF', version: current_version, lane_id: lane_id(druid))
         end
       end
     end

--- a/lib/robots/dor_repo/release/update_marc.rb
+++ b/lib/robots/dor_repo/release/update_marc.rb
@@ -14,11 +14,7 @@ module Robots
         # @param [String] druid -- the Druid identifier for the object to process
         def perform(druid)
           LyberCore::Log.debug "update_marc working on #{druid}"
-          with_retries(max_tries: Settings.release.max_tries,
-                       base_sleep_seconds: Settings.release.base_sleep_seconds,
-                       max_sleep_seconds: Settings.release.max_sleep_seconds) do |_attempt|
-            Dor::Services::Client.object(druid).update_marc_record
-          end
+          Dor::Services::Client.object(druid).update_marc_record
         end
       end
     end


### PR DESCRIPTION
## Why was this change made?

Furthermore the robots are intended to be restarted if there is an error.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a