### PR TITLE
Update the config gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'activesupport', '~> 5.2'
 gem 'assembly-image', '~> 1.7'
 gem 'assembly-objectfile', '>=1.6.6'
-gem 'config', '~> 1.7'
+gem 'config', '~> 2.2'
 gem 'dor-fetcher', '~> 1.3'
 gem 'dor-services', '~> 8.0'
 gem 'dor-services-client', '~> 4.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,10 +67,9 @@ GEM
       zeitwerk (~> 2.1)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
-    config (1.7.1)
-      activesupport (>= 3.0)
-      deep_merge (~> 1.2.1)
-      dry-validation (>= 0.12.2)
+    config (2.2.1)
+      deep_merge (~> 1.2, >= 1.2.1)
+      dry-validation (~> 1.0, >= 1.0.0)
     coveralls (0.7.1)
       multi_json (~> 1.3)
       rest-client
@@ -412,7 +411,7 @@ DEPENDENCIES
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
   capistrano-resque-pool
-  config (~> 1.7)
+  config (~> 2.2)
   coveralls
   dlss-capistrano (~> 3.1)
   dor-fetcher (~> 1.3)


### PR DESCRIPTION
## Why was this change made?

This will allow ruby 2.7 compatibility

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a