### PR TITLE
[Refactor] move populate_datastream to the robot where it is used

### DIFF
--- a/lib/models/etd_metadata.rb
+++ b/lib/models/etd_metadata.rb
@@ -5,34 +5,6 @@ require 'uuidtools'
 require 'active_support/core_ext'
 
 module EtdMetadata
-  # create a datastream in the repository for the given etd object
-  def populate_datastream(ds_name)
-    label = case ds_name
-            when 'identityMetadata' then 'Identity Metadata'
-            when 'contentMetadata' then 'Content Metadata'
-            when 'rightsMetadata' then 'Rights Metadata'
-            when 'versionMetadata' then 'Version Metadata'
-            else ''
-            end
-    metadata = case ds_name
-               when 'identityMetadata' then generate_identity_metadata_xml
-               when 'contentMetadata' then generate_content_metadata_xml
-               when 'rightsMetadata' then Dor::Etd::RightsMetadataGenerator.generate(self)
-               when 'versionMetadata' then generate_version_metadata_xml
-               end
-    return if metadata.nil?
-
-    populate_datastream_in_repository(ds_name, label, metadata)
-  end
-
-  # create a datastream for the given etd object with the given datastream name, label, and metadata blob
-  def populate_datastream_in_repository(ds_name, label, metadata)
-    attrs = { mimeType: 'application/xml', dsLabel: label, content: metadata }
-    datastream = ActiveFedora::Datastream.new(inner_object, ds_name, attrs)
-    datastream.controlGroup = 'M'
-    datastream.save
-  end
-
   def content_path
     druid = DruidTools::Druid.new(pid, Settings.sdr.local_workspace_root)
 

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -19,23 +19,6 @@ RSpec.describe Etd do
     end
   end
 
-  describe '#populate_datastream' do
-    subject(:populate) { etd.populate_datastream(ds_name) }
-
-    context 'when called on rightsMetadata' do
-      let(:ds_name) { 'rightsMetadata' }
-
-      before do
-        allow(Dor::Etd::RightsMetadataGenerator).to receive(:generate)
-      end
-
-      it 'calls the generator' do
-        populate
-        expect(Dor::Etd::RightsMetadataGenerator).to have_received(:generate).with(etd)
-      end
-    end
-  end
-
   describe '#generate_content_metadata_xml' do
     subject(:generate) { etd.generate_content_metadata_xml }
 

--- a/spec/robots/etd_submit/other_metadata_spec.rb
+++ b/spec/robots/etd_submit/other_metadata_spec.rb
@@ -5,28 +5,49 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::EtdSubmit::OtherMetadata do
   subject(:robot) { described_class.new }
 
+  let(:druid) { 'druid:mj151qw9093' }
+  let(:object) { Etd.new(pid: druid) }
+
   describe '#systemu' do
     # Validate that the stub we use later is valid for this object
     it { is_expected.to respond_to(:systemu) }
   end
 
+  describe '#populate_datastream' do
+    subject(:populate) { robot.populate_datastream(object, ds_name) }
+
+    context 'when called on rightsMetadata' do
+      let(:ds_name) { 'rightsMetadata' }
+
+      before do
+        allow(Dor::Etd::RightsMetadataGenerator).to receive(:generate)
+      end
+
+      it 'calls the generator' do
+        populate
+        expect(Dor::Etd::RightsMetadataGenerator).to have_received(:generate).with(object)
+      end
+    end
+  end
+
   describe '#perform' do
-    let(:druid) { 'druid:mj151qw9093' }
-    let(:object) { Etd.new(pid: druid) }
     let(:druid_tools) { instance_double(DruidTools::Druid, content_dir: '/foo/bar') }
     let(:status) { instance_double(Process::Status, exitstatus: 0) }
 
     before do
       allow(Etd).to receive(:find).and_return(object)
-      allow(object).to receive(:populate_datastream)
+      allow(robot).to receive(:populate_datastream)
       allow(DruidTools::Druid).to receive(:new).and_return(druid_tools)
       allow(robot).to receive(:systemu).and_return([status, nil, nil])
       allow(File).to receive(:exist?).with('/foo/bar').and_return(true)
     end
 
-    it 'invokes Dor::Services::Client with druid and workflow name' do
+    it 'populates the datastreams' do
       robot.perform(druid)
-      # expect(mock_workflow_instance).to have_received(:create).with(wf_name: 'accessionWF')
+      expect(robot).to have_received(:populate_datastream).with(object, 'contentMetadata')
+      expect(robot).to have_received(:populate_datastream).with(object, 'rightsMetadata')
+      expect(robot).to have_received(:populate_datastream).with(object, 'identityMetadata')
+      expect(robot).to have_received(:populate_datastream).with(object, 'versionMetadata')
     end
   end
 end


### PR DESCRIPTION


## Why was this change made?
It doesn't belong on the model as it's business logic and it's only used in one place

Ref #582 


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a