### PR TITLE
Removed local_workspace_root

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -21,7 +21,6 @@ Dor::Config.configure do
 
   # Used by Dor::DigitalStacksService, Dor::PublishMetadataService, and Dor::ShelvingService
   stacks do
-    document_cache_host Settings.stacks.document_cache_host
     local_workspace_root Settings.stacks.local_workspace_root
     local_stacks_root Settings.stacks.local_stacks_root
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -37,7 +37,6 @@ suri:
 
 # Used by Dor::DigitalStacksService, Dor::PublishMetadataService, and Dor::ShelvingService
 stacks:
-  document_cache_host: ~
   local_workspace_root: ~
   local_stacks_root: ~
 


### PR DESCRIPTION
## Why was this change made?
To remove unnecessary configuration.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
No.