### PR TITLE
fix coveralls hookup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'zeitwerk', '~> 2.1'
 group :test do
   gem 'coveralls', require: false
   gem 'rspec', '~> 3.0'
-  gem 'simplecov' # simplecov 0.17 puts coveralls at 0.7 release (was 0.8); shrug
+  gem 'simplecov', '~> 0.17.1' # 0.18 breaks reporting to coveralls `undefined method `coverage' for #<SimpleCov::SourceFile:0x0000561b4563cd18>`
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
       resque-pool
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina-models (0.22.2)
+    cocina-models (0.25.0)
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
       zeitwerk (~> 2.1)
@@ -109,9 +109,9 @@ GEM
       solrizer (~> 3.0)
       stanford-mods (>= 2.3.1)
       stanford-mods-normalizer (~> 0.1)
-    dor-services-client (4.14.0)
+    dor-services-client (4.15.0)
       activesupport (>= 4.2, < 7)
-      cocina-models (~> 0.22.2)
+      cocina-models (~> 0.25.0)
       deprecation
       faraday (~> 0.15)
       moab-versioning (~> 4.0)
@@ -245,7 +245,7 @@ GEM
       nokogiri (>= 1.4.2)
       solrizer (~> 3.3)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.0.3)
       ast (~> 2.4.0)
     pony (1.13.1)
       mail (>= 2.0)
@@ -340,10 +340,11 @@ GEM
       rest-client
     safe_yaml (1.0.5)
     scrub_rb (1.0.1)
-    simplecov (0.18.3)
+    simplecov (0.17.1)
       docile (~> 1.1)
-      simplecov-html (~> 0.11)
-    simplecov-html (0.12.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -428,7 +429,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 0.77.0)
   rubocop-rspec
-  simplecov
+  simplecov (~> 0.17.1)
   slop
   systemu (~> 2.6)
   uuidtools

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/sul-dlss/common-accessioning.svg?branch=master)](https://travis-ci.org/sul-dlss/common-accessioning) [![Coverage Status](https://coveralls.io/repos/sul-dlss/common-accessioning/badge.svg?branch=master&service=github)](https://coveralls.io/github/sul-dlss/common-accessioning?branch=master)
+[![Build Status](https://travis-ci.org/sul-dlss/common-accessioning.svg?branch=master)](https://travis-ci.org/sul-dlss/common-accessioning)
+[![Coverage Status](https://coveralls.io/repos/github/sul-dlss/common-accessioning/badge.svg?branch=master)](https://coveralls.io/github/sul-dlss/common-accessioning?branch=master)
 
 # DOR consolidated robots
 


### PR DESCRIPTION
## Why was this change made?

Our last code coverage data was from Jan 31, 2020.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
updated badge on README

## Does this change affect how this application integrates with other services?

n/a

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
