### PR TITLE
Fix the robot cron for changes in lyber-core 6

### DIFF
--- a/bin/run_robot_cron
+++ b/bin/run_robot_cron
@@ -13,9 +13,10 @@ require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 
 robot_name = ARGV.shift
 
-# See if the robot is already running
+# See if the robot is already running.
+# This list is going to detect this process.
 procs_running = `ps -ef | grep #{robot_name} | grep -v 'grep' | wc -l`.strip.to_i
-if procs_running.positive?
+if procs_running > 1
   puts "#{robot_name} already running.  Skipping invocation"
   exit
 end

--- a/lib/etd_submit/robot_cron_base.rb
+++ b/lib/etd_submit/robot_cron_base.rb
@@ -2,7 +2,7 @@
 
 module EtdSubmit
   module RobotCronBase
-    attr_reader :repo, :workflow_name, :step_name, :prerequisites
+    attr_reader :prerequisites
 
     def start
       lanes = workflow_service.lane_ids(*qualified_workflow_name.split(/:/))
@@ -22,7 +22,7 @@ module EtdSubmit
     end
 
     def qualified_workflow_name
-      @qualified_workflow_name ||= "#{repo}:#{workflow_name}:#{step_name}"
+      @qualified_workflow_name ||= "dor:#{workflow_name}:#{process}"
     end
   end
 end


### PR DESCRIPTION
## Why was this change made?

The change to lyber-core 6 made the cron suddenly stop working with no output.

### Changes:
1. count the number of processes running correctly

2. removed repo parameter

3. renamed step_name to process

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a

## Does this change affect how this application integrates with other services?

If so, please confirm:
- [ ] change was tested on stage    and/or
- [ ] test added to sul-dlss/infrastructure-integration-test
