### PR TITLE
Add a timestamp to crondebug.log

### DIFF
--- a/bin/run_robot_cron
+++ b/bin/run_robot_cron
@@ -13,16 +13,18 @@ require File.expand_path(File.dirname(__FILE__) + '/../config/boot')
 
 robot_name = ARGV.shift
 
+timestamp = DateTime.now.strftime('%Y%m%d-%H%M%S')
+
 # See if the robot is already running.
 # This list is going to detect this process.
 procs_running = `ps -ef | grep #{robot_name} | grep -v 'grep' | wc -l`.strip.to_i
 if procs_running > 1
-  puts "#{robot_name} already running.  Skipping invocation"
+  puts "#{timestamp}: #{robot_name} already running.  Skipping invocation"
   exit
 end
 
 # Instantiate the robot class and start it
-puts "Trying to load #{robot_name}"
+puts "#{timestamp}: Trying to load #{robot_name}"
 klazz = robot_name.split('::').inject(Robots::DorRepo) { |o, c| o.const_get c }
 robot = klazz.new check_queued_status: false
 robot.start


### PR DESCRIPTION
## Why was this change made?

Add a simple timestamp to the `crondebug.log` output to assist in debugging.
