### PR TITLE
WAITING is no longer a method

### DIFF
--- a/lib/robots/dor_repo/etd_submit/check_marc.rb
+++ b/lib/robots/dor_repo/etd_submit/check_marc.rb
@@ -28,7 +28,7 @@ module Robots
 
           current_location = symphony_xml.search('/titles/record[home="INTERNET"]/current').first
           catkey_xml = symphony_xml.search('/titles/record[home="INTERNET"]/catkey').first
-          return LyberCore::Robot::ReturnState.WAITING if current_location.nil? || catkey_xml.nil?
+          return LyberCore::Robot::ReturnState.new(status: 'waiting') if current_location.nil? || catkey_xml.nil?
 
           identity_xml = build_identity_xml(etd, catkey_xml)
 


### PR DESCRIPTION


## Why was this change made?
Fixes #603


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?



## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
