### PR TITLE
Generate descriptive metadata for etds

### DIFF
--- a/lib/robots/dor_repo/etd_submit/other_metadata.rb
+++ b/lib/robots/dor_repo/etd_submit/other_metadata.rb
@@ -31,16 +31,16 @@ module Robots
 
         # create metadata in the repository for the given etd object
         def create_metadata(etd, druid)
+          object_client = Dor::Services::Client.object(druid)
+          object_client.refresh_metadata
           content_md = Dor::Etd::ContentMetadataGenerator.generate(etd)
           identity_md = Dor::Etd::IdentityMetadataGenerator.generate(etd)
           rights_md = Dor::Etd::RightsMetadataGenerator.generate(etd)
           version_md = Dor::Etd::VersionMetadataGenerator.generate(etd.pid)
-          create_legacy_metadata(druid, content_md, identity_md, rights_md, version_md)
+          create_legacy_metadata(object_client, content_md, identity_md, rights_md, version_md)
         end
 
-        def create_legacy_metadata(druid, content_md, identity_md, rights_md, version_md)
-          object_client = Dor::Services::Client.object(druid)
-
+        def create_legacy_metadata(object_client, content_md, identity_md, rights_md, version_md)
           # legacy_update will create the metadata
           object_client.metadata.legacy_update(
             content: {

--- a/spec/robots/accession/descriptive_metadata_spec.rb
+++ b/spec/robots/accession/descriptive_metadata_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Robots::DorRepo::Accession::DescriptiveMetadata do
 
     let(:druid) { 'druid:ab123cd4567' }
     let(:object_client) do
-      instance_double(Dor::Services::Client::Object, refresh_metadata: true, metadata: metadata_client)
+      instance_double(Dor::Services::Client::Object, metadata: metadata_client)
     end
     let(:metadata_client) do
       instance_double(Dor::Services::Client::Metadata, legacy_update: true)

--- a/spec/robots/accession/provenance_metadata_spec.rb
+++ b/spec/robots/accession/provenance_metadata_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Robots::DorRepo::Accession::ProvenanceMetadata do
     subject(:perform) { robot.perform(druid) }
 
     let(:object_client) do
-      instance_double(Dor::Services::Client::Object, refresh_metadata: true, metadata: metadata_client)
+      instance_double(Dor::Services::Client::Object, metadata: metadata_client)
     end
     let(:metadata_client) do
       instance_double(Dor::Services::Client::Metadata, legacy_update: true)

--- a/spec/robots/accession/rights_metadata_spec.rb
+++ b/spec/robots/accession/rights_metadata_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Robots::DorRepo::Accession::RightsMetadata do
   let(:apo_id) { 'druid:mx121xx1234' }
 
   let(:object_client) do
-    instance_double(Dor::Services::Client::Object, refresh_metadata: true, metadata: metadata_client)
+    instance_double(Dor::Services::Client::Object, metadata: metadata_client)
   end
   let(:metadata_client) do
     instance_double(Dor::Services::Client::Metadata, legacy_update: true)

--- a/spec/robots/etd_submit/other_metadata_spec.rb
+++ b/spec/robots/etd_submit/other_metadata_spec.rb
@@ -7,12 +7,10 @@ RSpec.describe Robots::DorRepo::EtdSubmit::OtherMetadata do
 
   let(:druid) { 'druid:mj151qw9093' }
   let(:object) { Etd.new(pid: druid) }
-  let(:obj_client) { instance_double(Dor::Services::Client::Object) }
-  let(:metadata_obj) { instance_double(Dor::Services::Client::Metadata) }
+  let(:obj_client) { instance_double(Dor::Services::Client::Object, metadata: metadata_obj, refresh_metadata: true) }
+  let(:metadata_obj) { instance_double(Dor::Services::Client::Metadata, legacy_update: true) }
 
   before do
-    allow(metadata_obj).to receive(:legacy_update)
-    allow(obj_client).to receive(:metadata).and_return(metadata_obj)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(obj_client)
   end
 


### PR DESCRIPTION

## Why was this change made?

After getting a catkey (check_marc), we need to generate the descMetadata for ETDs.  Previously this was in the accessionWF, but this was removed as we didn't think anything used it.  Howeveer it appears that ETDs were depending on it..


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
n/a


## Does this change affect how this application integrates with other services?

n/a
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
