### PR TITLE
accessioningWF: only generate techMd for preserved files

### DIFF
--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -30,20 +30,20 @@ module Robots
           Dor::Services::Client.object(druid).find
         end
 
-        def extract_filenames(obj)
+        def extract_preserved_filenames(obj)
           filenames = []
           obj.structural.contains.each do |fileset|
             next if fileset.structural.contains.blank?
 
             fileset.structural.contains.each do |file|
-              filenames << file.label
+              filenames << file.label if file.administrative.sdrPreserve
             end
           end
           filenames
         end
 
         def extract_file_uris(druid, obj)
-          filenames = extract_filenames(obj)
+          filenames = extract_preserved_filenames(obj)
 
           workspace = DruidTools::Druid.new(druid, File.absolute_path(Settings.sdr.local_workspace_root))
           content_dir = workspace.find_filelist_parent('content', filenames)

--- a/spec/robots/accession/technical_metadata_spec.rb
+++ b/spec/robots/accession/technical_metadata_spec.rb
@@ -2,6 +2,8 @@
 
 require 'spec_helper'
 
+RSpec::Matchers.define_negated_matcher :excluding, :include
+
 RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
   subject(:robot) { described_class.new }
 
@@ -20,6 +22,7 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
 
     context 'when a DRO with files' do
       let(:workspace) { File.absolute_path('spec/fixtures/workspace') }
+      let(:expected_file) { "file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt" }
 
       let(:object) do
         Cocina::Models::DRO.new(externalIdentifier: 'druid:dd116zh0343',
@@ -37,6 +40,35 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
                                         {
                                           externalIdentifier: '222-1',
                                           label: 'folder1PuSu/story1u.txt',
+                                          type: Cocina::Models::Vocab.file,
+                                          version: 1,
+                                          administrative: {
+                                            sdrPreserve: true,
+                                            shelve: false
+                                          }
+                                        },
+                                        {
+                                          externalIdentifier: '222-2',
+                                          label: 'folder1PuSu/story2r.txt',
+                                          type: Cocina::Models::Vocab.file,
+                                          version: 1,
+                                          administrative: {
+                                            sdrPreserve: false,
+                                            shelve: false
+                                          }
+                                        },
+                                        {
+                                          externalIdentifier: '222-3',
+                                          label: 'folder1PuSu/story3m.txt',
+                                          type: Cocina::Models::Vocab.file,
+                                          version: 1,
+                                          administrative: {
+                                            shelve: true
+                                          }
+                                        },
+                                        {
+                                          externalIdentifier: '222-3',
+                                          label: 'folder1PuSu/story4d.txt',
                                           type: Cocina::Models::Vocab.file,
                                           version: 1
                                         }
@@ -56,7 +88,10 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
         before do
           stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
             .with(
-              body: "{\"druid\":\"druid:dd116zh0343\",\"files\":[\"file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt\"]}",
+              body: {
+                druid: 'druid:dd116zh0343',
+                files: array_including(expected_file)
+              },
               headers: {
                 'Content-Type' => 'application/json',
                 'Authorization' => 'Bearer rake-generate-token-me'
@@ -74,7 +109,10 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
         before do
           stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
             .with(
-              body: "{\"druid\":\"druid:dd116zh0343\",\"files\":[\"file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt\"]}",
+              body: {
+                druid: 'druid:dd116zh0343',
+                files: array_including(expected_file)
+              },
               headers: {
                 'Content-Type' => 'application/json',
                 'Authorization' => 'Bearer rake-generate-token-me'
@@ -88,17 +126,98 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
         end
       end
 
-      context 'when the DRO has no files' do
-        let(:object) do
-          Cocina::Models::DRO.new(externalIdentifier: '123',
-                                  type: Cocina::Models::Vocab.object,
-                                  label: 'my repository object',
-                                  version: 1)
+      context 'when file has true for sdrPreserve' do
+        before do
+          stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
+            .with(
+              body: hash_including(files: array_including(expected_file)),
+              headers: {
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer rake-generate-token-me'
+              }
+            )
+            .to_return(status: 200, body: '', headers: {})
         end
 
-        it 'does not run technical metadata' do
-          expect(perform.status).to eq('skipped')
+        it 'file IS sent to techmd service' do
+          expect(perform.status).to eq('noop')
         end
+      end
+
+      context 'when file has false for sdrPreserve' do
+        before do
+          unexpected_file = "file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story2r.txt"
+          stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
+            .with(
+              body: hash_including(
+                files: array_including(a_string_matching(expected_file).and(excluding(unexpected_file)))
+              ),
+              headers: {
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer rake-generate-token-me'
+              }
+            )
+            .to_return(status: 200, body: '', headers: {})
+        end
+
+        it 'file is NOT sent to techmd service' do
+          expect(perform.status).to eq('noop')
+        end
+      end
+
+      context 'when file has no sdrPreserve setting' do
+        before do
+          unexpected_file = "file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story3m.txt"
+          stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
+            .with(
+              body: hash_including(
+                files: array_including(a_string_matching(expected_file).and(excluding(unexpected_file)))
+              ),
+              headers: {
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer rake-generate-token-me'
+              }
+            )
+            .to_return(status: 200, body: '', headers: {})
+        end
+
+        it 'file is NOT sent to techmd service' do
+          expect(perform.status).to eq('noop')
+        end
+      end
+
+      context 'when file has no administrative metadata' do
+        before do
+          unexpected_file = "file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story4d.txt"
+          stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
+            .with(
+              body: hash_including(
+                files: array_including(a_string_matching(expected_file).and(excluding(unexpected_file)))
+              ),
+              headers: {
+                'Content-Type' => 'application/json',
+                'Authorization' => 'Bearer rake-generate-token-me'
+              }
+            )
+            .to_return(status: 200, body: '', headers: {})
+        end
+
+        it 'file is NOT sent to techmd service' do
+          expect(perform.status).to eq('noop')
+        end
+      end
+    end
+
+    context 'when the DRO has no files' do
+      let(:object) do
+        Cocina::Models::DRO.new(externalIdentifier: '123',
+                                type: Cocina::Models::Vocab.object,
+                                label: 'my repository object',
+                                version: 1)
+      end
+
+      it 'does not run technical metadata' do
+        expect(perform.status).to eq('skipped')
       end
     end
 


### PR DESCRIPTION
## Why was this change made?

Fixes #608

we only want to generate techMd for preserved files.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a

## Does this change affect how this application integrates with other services?

not yet.  :-)

If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
