### PR TITLE
some of us prefer pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ group :development do
 end
 
 group :development, :test do
-  gem 'byebug'
+  gem 'pry-byebug'
   gem 'rubocop', '~> 0.77.0'
   gem 'rubocop-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -402,7 +402,6 @@ DEPENDENCIES
   activesupport (~> 5.2)
   assembly-image (~> 1.7)
   assembly-objectfile (>= 1.6.6)
-  byebug
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
   capistrano-resque-pool

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ ENV['ROBOT_ENVIRONMENT'] = 'test'
 require 'simplecov'
 require 'coveralls'
 require 'byebug'
+require 'pry-byebug'
 
 SimpleCov.formatter = Coveralls::SimpleCov::Formatter
 SimpleCov.start do


### PR DESCRIPTION
## Why was this change made?

some of us prefer `pry-byebug`, and it doesn't preclude the use of `byebug`


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

na

## Does this change affect how this application integrates with other services?

na