### PR TITLE
Remove unnecessary stubs

### DIFF
--- a/spec/robots/accession/end_accession_spec.rb
+++ b/spec/robots/accession/end_accession_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
   let(:workspace_client) { instance_double(Dor::Services::Client::Workspace, cleanup: true) }
 
   before do
-    allow(Dor).to receive(:find).with(druid).and_return(object)
     allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     allow(Dor::Services::Client).to receive(:object).with(apo_id).and_return(apo_object_client)

--- a/spec/robots/assembly/exif_collect_spec.rb
+++ b/spec/robots/assembly/exif_collect_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
     let(:exif) { double('result', mimetype: nil, image_width: 7, image_height: 9) }
 
     before do
-      allow(Dor).to receive(:find).and_return(double('Fedora obj'))
       allow(item).to receive(:item?).and_return(true)
       allow(item).to receive(:load_content_metadata)
       allow(item).to receive(:cm).and_return(Nokogiri::XML(xml))


### PR DESCRIPTION
## Why was this change made?

we don't depend on these stubs anymore.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

n/a

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
