### PR TITLE
Use mounted /dor/workspace/etdSubmitWF path for sumit marc generation

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -61,6 +61,7 @@ symphony:
 
 # location where marc output will be dumped
 marc_output_directory: ~
+marc_workspace: ~
 
 binder_dropbox:
   host: ~

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -17,3 +17,5 @@ symphony:
   url: 'http://lyberservices-dev.stanford.edu/cgi-bin/holdings.php?flexkey='
 
 marc_output_directory: /tmp
+
+marc_workspace: tmp

--- a/lib/robots/dor_repo/etd_submit/build_symphony_marc.rb
+++ b/lib/robots/dor_repo/etd_submit/build_symphony_marc.rb
@@ -13,7 +13,7 @@ LyberCore::Log.set_logfile(File.join(ROBOT_ROOT, 'log', 'build_symphony_marc.log
 
 filename = File.join(MARC_OUTPUT_DIRECTORY, Time.now.strftime('%Y%m%d-%H%M%S%u'))
 
-marc_files = Dir[File.join(ROBOT_ROOT, 'tmp', Time.now.strftime('%Y%m%d'), '*.marc')]
+marc_files = Dir[File.join(Settings.marc_workspace, Time.now.strftime('%Y%m%d'), '*.marc')]
 if marc_files.empty?
   LyberCore::Log.info('No marc files from today to process')
   exit

--- a/lib/robots/dor_repo/etd_submit/submit_marc.rb
+++ b/lib/robots/dor_repo/etd_submit/submit_marc.rb
@@ -14,8 +14,8 @@ module Robots
         def initialize(opts = {})
           super('etdSubmitWF', 'submit-marc', opts)
 
-          FileUtils.mkdir(ROBOT_ROOT + '/tmp') unless File.exist?(ROBOT_ROOT + '/tmp')
-          @day_working_dir = File.join(ROBOT_ROOT, 'tmp', Time.now.strftime('%Y%m%d'))
+          FileUtils.mkdir(Settings.marc_workspace) unless File.exist?(Settings.marc_workspace)
+          @day_working_dir = File.join(Settings.marc_workspace, Time.now.strftime('%Y%m%d'))
           @prerequisites = ['dor:etdSubmitWF:registrar-approval']
         end
 

--- a/spec/robots/etd_submit/submit_marc_spec.rb
+++ b/spec/robots/etd_submit/submit_marc_spec.rb
@@ -25,9 +25,9 @@ describe Robots::DorRepo::EtdSubmit::SubmitMarc do
         expect(r).to be_instance_of(described_class)
       end
 
-      it "creates a tmp directory in ROBOT_ROOT if it doesn't exist" do
-        expect(File).to receive(:exist?).with(ROBOT_ROOT + '/tmp').and_return(false)
-        expect(FileUtils).to receive(:mkdir).with(ROBOT_ROOT + '/tmp')
+      it "creates a tmp directory in marc_workspace if it doesn't exist" do
+        expect(File).to receive(:exist?).with(Settings.marc_workspace).and_return(false)
+        expect(FileUtils).to receive(:mkdir).with(Settings.marc_workspace)
 
         described_class.new
       end


### PR DESCRIPTION
## Why was this change made?

Fixes #616 

Corresponding shared_configs updates have been applied.

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

N/A


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

No.