### PR TITLE
Upgrade simplecov to 0.18.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem 'coveralls', require: false
   gem 'equivalent-xml'
   gem 'rspec', '~> 3.0'
-  gem 'simplecov', '~> 0.17.1' # 0.18 breaks reporting to coveralls `undefined method `coverage' for #<SimpleCov::SourceFile:0x0000561b4563cd18>`
+  gem 'simplecov', '~> 0.18.5'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,11 +242,10 @@ GEM
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
     safe_yaml (1.0.5)
-    simplecov (0.17.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -307,7 +306,7 @@ DEPENDENCIES
   rspec (~> 3.0)
   rubocop (~> 0.77.0)
   rubocop-rspec
-  simplecov (~> 0.17.1)
+  simplecov (~> 0.18.5)
   slop
   webmock
   zeitwerk (~> 2.1)


### PR DESCRIPTION
## Why was this change made?

0.17 is far out of date

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
