### PR TITLE
Update tests for latest ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,7 @@ cache: bundler
 
 rvm:
   - 2.6.5 # deployed
-  - 2.7.0 # latest
-
-jobs:
-  allow_failures:
-  - rvm: 2.7.0
+  - 2.7.1 # latest
 
 env:
   global:


### PR DESCRIPTION


## Why was this change made?

Test on the latest version. No need to allow failures anymore

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

no



## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
