### PR TITLE
Properly escape diacritics in file uris

### DIFF
--- a/lib/file_uri.rb
+++ b/lib/file_uri.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Produces properly URI escaped files
+class FileUri
+  # @param [String] pathname an unescaped path to a file.
+  def initialize(pathname)
+    @raw = pathname
+  end
+
+  def uri
+    URI::File.build(path: escaped_path)
+  end
+
+  delegate :to_s, to: :uri
+
+  private
+
+  def escaped_path
+    File.join(File.dirname(@raw), escaped_filename)
+  end
+
+  def escaped_filename
+    CGI.escape(File.basename(@raw)).gsub(/\+/, '%20')
+  end
+end

--- a/lib/file_uris.rb
+++ b/lib/file_uris.rb
@@ -14,7 +14,7 @@ class FileUris
   end
 
   def uris
-    @uris ||= filepaths.map { |filepath| URI::File.build(path: filepath.gsub(' ', '%20')).to_s }
+    @uris ||= filepaths.map { |filepath| FileUri.new(filepath).to_s }
   end
 
   private

--- a/spec/lib/file_uris_spec.rb
+++ b/spec/lib/file_uris_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe FileUris do
 
       it { is_expected.to eq ["file://#{root}/dd/116/zh/0343/dd116zh0343/content/file%20with%20space.txt"] }
     end
+
+    context 'with a diacritic' do
+      let(:filename) { 'Garges-lès-Gonesse.docx' }
+
+      it { is_expected.to eq ["file://#{root}/dd/116/zh/0343/dd116zh0343/content/Garges-l%C3%A8s-Gonesse.docx"] }
+    end
   end
 
   describe '.filepaths' do


### PR DESCRIPTION
## Why was this change made?

Fixes #639 

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
