### PR TITLE
Remove env-specific honeybadger servers

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -10,5 +10,3 @@ Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)
-
-set :honeybadger_server, primary(:cron)

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -7,4 +7,3 @@ Capistrano::OneTimeKey.generate_one_time_key!
 
 set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)
-set :honeybadger_server, primary(:cron)


### PR DESCRIPTION
This setting was overriding the one set in config/deploy.rb.

HB deployments were broken in https://github.com/sul-dlss/common-accessioning/pull/622 when the `:cron` capistrano role was removed.

