### PR TITLE
Only generate technical metadata for preserved files

### DIFF
--- a/lib/preserved_file_uris.rb
+++ b/lib/preserved_file_uris.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-# Builds the list of URIs for files in an object
-class FileUris
+# Builds the list of URIs for the preserved files in an object
+class PreservedFileUris
   # @param [String] druid
   # @param [Cocina::Models::DRO]
   def initialize(druid, obj)
@@ -27,16 +27,15 @@ class FileUris
   end
 
   def filenames
-    @filenames ||= begin
-      filenames = []
-      obj.structural.contains.each do |fileset|
-        next if fileset.structural.contains.blank?
-
-        fileset.structural.contains.each do |file|
-          filenames << file.label
-        end
-      end
-      filenames
+    @filenames ||= obj.structural.contains.flat_map do |fileset|
+      preserved_filenames(fileset)
     end
+  end
+
+  def preserved_filenames(fileset)
+    contains = fileset.structural.contains
+    return [] if contains.blank?
+
+    contains.filter { |file| file.administrative.sdrPreserve }.map(&:label)
   end
 end

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -18,7 +18,7 @@ module Robots
           # skip if no files
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'object has no files') if obj.structural.nil? || obj.structural.contains.blank?
 
-          file_uris = FileUris.new(druid, obj)
+          file_uris = PreservedFileUris.new(druid, obj)
 
           # skip if metadata-only change
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'change is metadata-only') if metadata_only?(file_uris.filepaths)

--- a/spec/lib/file_uri_spec.rb
+++ b/spec/lib/file_uri_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+RSpec.describe FileUri do
+  let(:workspace) { File.absolute_path('spec/fixtures/workspace') }
+  let(:druid) { 'druid:dd116zh0343' }
+  let(:root) { File.absolute_path(Settings.sdr.local_workspace_root) }
+
+  let(:content_dir) do
+    workspace = DruidTools::Druid.new(druid, root)
+    workspace.content_dir(false)
+  end
+
+  before do
+    # For File URIs, need to use absolute paths
+    allow(Settings.sdr).to receive(:local_workspace_root).and_return(workspace)
+  end
+
+  describe '.to_s' do
+    subject { described_class.new(filename).to_s }
+
+    context 'with a sub folder' do
+      let(:filename) { "#{content_dir}/folder1PuSu/story1u.txt" }
+
+      it { is_expected.to eq "file://#{root}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt" }
+    end
+
+    context 'with a space' do
+      let(:filename) { "#{content_dir}/file with space.txt" }
+
+      it { is_expected.to eq "file://#{root}/dd/116/zh/0343/dd116zh0343/content/file%20with%20space.txt" }
+    end
+
+    context 'with a diacritic' do
+      let(:filename) { "#{content_dir}/Garges-lès-Gonesse.docx" }
+
+      it { is_expected.to eq "file://#{root}/dd/116/zh/0343/dd116zh0343/content/Garges-l%C3%A8s-Gonesse.docx" }
+    end
+  end
+end

--- a/spec/lib/preserved_file_uris_spec.rb
+++ b/spec/lib/preserved_file_uris_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe FileUris do
+RSpec.describe PreservedFileUris do
   let(:workspace) { File.absolute_path('spec/fixtures/workspace') }
   let(:druid) { 'druid:dd116zh0343' }
   let(:root) { File.absolute_path(Settings.sdr.local_workspace_root) }
@@ -20,7 +20,25 @@ RSpec.describe FileUris do
                                   contains: [
                                     {
                                       externalIdentifier: '222-1',
-                                      label: filename,
+                                      label: filename1,
+                                      type: Cocina::Models::Vocab.file,
+                                      version: 1,
+                                      access: {},
+                                      administrative: { sdrPreserve: true, shelve: true },
+                                      hasMessageDigests: []
+                                    },
+                                    {
+                                      externalIdentifier: '222-2',
+                                      label: 'not-this.pdf',
+                                      type: Cocina::Models::Vocab.file,
+                                      version: 1,
+                                      access: {},
+                                      administrative: { sdrPreserve: false, shelve: true },
+                                      hasMessageDigests: []
+                                    },
+                                    {
+                                      externalIdentifier: '222-1',
+                                      label: filename2,
                                       type: Cocina::Models::Vocab.file,
                                       version: 1,
                                       access: {},
@@ -41,30 +59,21 @@ RSpec.describe FileUris do
   describe '.uris' do
     subject { described_class.new(druid, object).uris }
 
-    context 'with a sub folder' do
-      let(:filename) { 'folder1PuSu/story1u.txt' }
+    let(:prefix) { "file://#{root}/dd/116/zh/0343/dd116zh0343/content/" }
 
-      it { is_expected.to eq ["file://#{root}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt"] }
-    end
+    let(:filename1) { 'folder1PuSu/story1u.txt' }
+    let(:filename2) { 'folder1PuSu/story2u.txt' }
 
-    context 'with a space' do
-      let(:filename) { 'file with space.txt' }
-
-      it { is_expected.to eq ["file://#{root}/dd/116/zh/0343/dd116zh0343/content/file%20with%20space.txt"] }
-    end
-
-    context 'with a diacritic' do
-      let(:filename) { 'Garges-lès-Gonesse.docx' }
-
-      it { is_expected.to eq ["file://#{root}/dd/116/zh/0343/dd116zh0343/content/Garges-l%C3%A8s-Gonesse.docx"] }
-    end
+    it { is_expected.to eq ["#{prefix}#{filename1}", "#{prefix}#{filename2}"] }
   end
 
   describe '.filepaths' do
     subject { described_class.new(druid, object).filepaths }
 
-    let(:filename) { 'folder1PuSu/story1u.txt' }
+    let(:filename1) { 'folder1PuSu/story1u.txt' }
+    let(:filename2) { 'folder1PuSu/story2u.txt' }
+    let(:prefix) { "#{root}/dd/116/zh/0343/dd116zh0343/content/" }
 
-    it { is_expected.to eq ["#{root}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt"] }
+    it { is_expected.to eq ["#{prefix}#{filename1}", "#{prefix}#{filename2}"] }
   end
 end


### PR DESCRIPTION
## Why was this change made?

Fixes #646

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
no


## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
