### PR TITLE
Adds prioritization when requesting techmd.

### DIFF
--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -25,15 +25,15 @@ module Robots
 
           verify_files_exist(druid, file_uris.filepaths)
 
-          invoke_techmd_service(druid, file_uris.uris)
+          invoke_techmd_service(druid, file_uris.uris, lane_id(druid))
 
           LyberCore::Robot::ReturnState.new(status: :noop, note: 'Initiated technical metadata generation from technical-metadata-service.')
         end
 
         private
 
-        def invoke_techmd_service(druid, file_uris)
-          req = JSON.generate(druid: druid, files: file_uris)
+        def invoke_techmd_service(druid, file_uris, lane_id)
+          req = JSON.generate(druid: druid, files: file_uris, 'lane-id': lane_id)
           resp = Faraday.post("#{Settings.tech_md_service.url}/v1/technical-metadata", req,
                               'Content-Type' => 'application/json',
                               'Authorization' => "Bearer #{Settings.tech_md_service.token}")

--- a/lib/robots/dor_repo/base.rb
+++ b/lib/robots/dor_repo/base.rb
@@ -10,7 +10,7 @@ module Robots
       end
 
       def lane_id(druid)
-        workflow_service.process(pid: druid, workflow_name: @workflow_name, process: @step_name).lane_id
+        workflow_service.process(pid: druid, workflow_name: workflow_name, process: process).lane_id
       end
     end
   end

--- a/spec/robots/accession/technical_metadata_spec.rb
+++ b/spec/robots/accession/technical_metadata_spec.rb
@@ -14,8 +14,17 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
       instance_double(Dor::Services::Client::Object, find: object)
     end
 
+    let(:workflow_client) do
+      instance_double(Dor::Workflow::Client, process: process)
+    end
+
+    let(:process) do
+      instance_double(Dor::Workflow::Response::Process, lane_id: 'low')
+    end
+
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      allow(WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     end
 
     context 'when a DRO with files' do
@@ -59,7 +68,7 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
         before do
           stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
             .with(
-              body: "{\"druid\":\"druid:dd116zh0343\",\"files\":[\"file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt\"]}",
+              body: "{\"druid\":\"druid:dd116zh0343\",\"files\":[\"file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt\"],\"lane-id\":\"low\"}",
               headers: {
                 'Content-Type' => 'application/json',
                 'Authorization' => 'Bearer rake-generate-token-me'
@@ -77,7 +86,7 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
         before do
           stub_request(:post, 'https://dor-techmd-test.stanford.test/v1/technical-metadata')
             .with(
-              body: "{\"druid\":\"druid:dd116zh0343\",\"files\":[\"file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt\"]}",
+              body: "{\"druid\":\"druid:dd116zh0343\",\"files\":[\"file://#{workspace}/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story1u.txt\"],\"lane-id\":\"low\"}",
               headers: {
                 'Content-Type' => 'application/json',
                 'Authorization' => 'Bearer rake-generate-token-me'


### PR DESCRIPTION
refs https://github.com/sul-dlss/technical-metadata-service/issues/129

## Why was this change made?
To pass the lane-id to techmd service to support prioritization.


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?
No.


## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
Yes.