### PR TITLE
Remove *-complete steps from accession WF

### DIFF
--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -14,26 +14,14 @@ module Robots
           # `#find` returns an instance of a model from the cocina-models gem
           obj = object_client.find
 
-          return skip_steps(druid, 'Not an item/DRO, nothing to do') unless obj.dro?
+          return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'Not an item/DRO, nothing to do') unless obj.dro?
 
           # No files, so do nothing
-          return skip_steps(druid, 'object has no files') if obj.structural.contains.blank?
+          return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'Object has no files') if obj.structural.contains.blank?
 
-          # This is an asynchronous result. It will set the shelve-complete workflow to complete when it is done.
+          # This is an asynchronous result. It will set the shelve workflow to complete when it is done.
           object_client.shelve(lane_id: lane_id(druid))
-        end
-
-        # Objects that aren't items/DROs are not shelved, so set the
-        # shelve-complete step as completed
-        def skip_steps(druid, note)
-          # set the shelve-complete step as completed
-          workflow_service.update_status(druid: druid,
-                                         workflow: 'accessionWF',
-                                         process: 'shelve-complete',
-                                         status: 'completed',
-                                         elapsed: 1,
-                                         note: note)
-          LyberCore::Robot::ReturnState.new(status: :skipped, note: note)
+          LyberCore::Robot::ReturnState.new(status: :noop, note: 'Initiated shelve API call.')
         end
       end
     end

--- a/spec/robots/accession/publish_spec.rb
+++ b/spec/robots/accession/publish_spec.rb
@@ -19,9 +19,7 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
 
     before do
       allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
-      allow(robot.workflow_service).to receive(:update_status)
       allow(robot.workflow_service).to receive(:process).and_return(process)
-      perform
     end
 
     context 'when called on a Collection' do
@@ -34,6 +32,7 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
       end
 
       it 'publishes metadata' do
+        expect(perform.status).to eq 'noop'
         expect(object_client).to have_received(:publish).with(workflow: 'accessionWF', lane_id: 'low')
       end
     end
@@ -48,6 +47,7 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
       end
 
       it 'publishes metadata' do
+        expect(perform.status).to eq 'noop'
         expect(object_client).to have_received(:publish).with(workflow: 'accessionWF', lane_id: 'low')
       end
     end
@@ -62,11 +62,8 @@ RSpec.describe Robots::DorRepo::Accession::Publish do
       end
 
       it 'does not publish metadata' do
+        expect(perform.status).to eq 'skipped'
         expect(object_client).not_to have_received(:publish)
-      end
-
-      it 'sets publish-complete to completed' do
-        expect(robot.workflow_service).to have_received(:update_status).with(druid: druid, workflow: 'accessionWF', process: 'publish-complete', status: 'completed', elapsed: 1, note: 'APOs are not published, so marking completed.')
       end
     end
   end

--- a/spec/robots/accession/shelve_spec.rb
+++ b/spec/robots/accession/shelve_spec.rb
@@ -19,10 +19,6 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
 
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: object, shelve: nil) }
 
-    before do
-      allow(robot.workflow_service).to receive(:update_status)
-    end
-
     context 'when called on a non-item' do
       let(:object) do
         Cocina::Models::Collection.new(externalIdentifier: 'druid:bc123df4567',
@@ -32,16 +28,9 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
                                        version: 1)
       end
 
-      it 'sets the shelve-complete step to completed' do
-        perform
+      it 'sets the status to skipped' do
+        expect(perform.status).to eq 'skipped'
         expect(object_client).not_to have_received(:shelve)
-        expect(robot.workflow_service).to have_received(:update_status)
-          .with(druid: druid,
-                workflow: 'accessionWF',
-                process: 'shelve-complete',
-                status: 'completed',
-                elapsed: 1,
-                note: 'Not an item/DRO, nothing to do')
       end
     end
 
@@ -65,7 +54,7 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
       end
 
       it 'shelves the item' do
-        perform
+        expect(perform.status).to eq 'noop'
         expect(object_client).to have_received(:shelve).with(lane_id: 'low')
       end
     end
@@ -83,15 +72,8 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
       end
 
       it 'does not shelve the item' do
-        perform
+        expect(perform.status).to eq 'skipped'
         expect(object_client).not_to have_received(:shelve)
-        expect(robot.workflow_service).to have_received(:update_status)
-          .with(druid: druid,
-                workflow: 'accessionWF',
-                process: 'shelve-complete',
-                status: 'completed',
-                elapsed: 1,
-                note: 'object has no files')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?

We can now use 'noop' and have dor-services-app set these steps to complete. This follows what we're doing in the technical metadata step

Ref https://github.com/sul-dlss/argo/issues/1789
Ref https://github.com/sul-dlss/dor-services-app/pull/850
Ref https://github.com/sul-dlss/workflow-server-rails/pull/377


## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

no

## Does this change affect how this application integrates with other services?

Yes. Was tested on stage.
