### PR TITLE
allow run_robot to work

### DIFF
--- a/bin/run_robot
+++ b/bin/run_robot
@@ -40,5 +40,5 @@ druids = if opts[:file]
          end
 
 druids.each do |druid|
-  bot.work druid
+  bot.perform druid
 end


### PR DESCRIPTION
## Why was this change made?

same change as sul-dlss/preservation_robots#222

the `#work` method in the robot now requires a context to be passed in for reporting to honeybadger, so the run_robot script needs to ~~pass in an extra parameter in the method call to work~~ call the `#perform` method instead, which takes care of the optional parameter

see https://github.com/sul-dlss/lyber-core/blob/master/lib/lyber_core/robot.rb#L40

## Was the usage documentation (e.g. README, DevOpsDocs, wiki, queue specific README) updated?

not needed

## Does this change affect how this application integrates with other services?
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.

no