### PR TITLE
Noop the release publish

### DIFF
--- a/lib/robots/dor_repo/release/release_publish.rb
+++ b/lib/robots/dor_repo/release/release_publish.rb
@@ -18,6 +18,8 @@ module Robots
           LyberCore::Log.debug "release-publish working on #{druid}"
           # This is an async result and it will have a callback.
           Dor::Services::Client.object(druid).publish(workflow: 'releaseWF')
+
+          LyberCore::Robot::ReturnState.new(status: :noop, note: 'Initiated publish API call.')
         end
       end
     end

--- a/spec/robots/release/release_publish_spec.rb
+++ b/spec/robots/release/release_publish_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe Robots::DorRepo::Release::ReleasePublish do
+  subject(:perform) { robot.perform(druid) }
+
   let(:druid) { 'aa222cc3333' }
   let(:robot) { described_class.new }
   let(:object_client) { instance_double(Dor::Services::Client::Object, publish: true) }
@@ -12,7 +14,7 @@ RSpec.describe Robots::DorRepo::Release::ReleasePublish do
   end
 
   it 'calls the publish metadata service with the dor item' do
-    robot.perform(druid)
+    expect(perform.status).to eq 'noop'
     expect(object_client).to have_received(:publish)
   end
 end


### PR DESCRIPTION
## Why was this change made?

This prevents the release-publish step from being set to complete until the api is done. This step gets updated by dor-services-app in PublishJob

