### PR TITLE
Return no-op from sdr_ingest_transfer

### DIFF
--- a/lib/robots/dor_repo/accession/sdr_ingest_transfer.rb
+++ b/lib/robots/dor_repo/accession/sdr_ingest_transfer.rb
@@ -10,6 +10,7 @@ module Robots
 
         def perform(druid)
           Dor::Services::Client.object(druid).preserve(lane_id: lane_id(druid))
+          LyberCore::Robot::ReturnState.new(status: :noop, note: 'Initiated preserve API call.')
         end
       end
     end

--- a/spec/robots/accession/sdr_ingest_transfer_spec.rb
+++ b/spec/robots/accession/sdr_ingest_transfer_spec.rb
@@ -15,13 +15,15 @@ RSpec.describe Robots::DorRepo::Accession::SdrIngestTransfer do
   end
 
   describe '#perform' do
+    subject(:perform) { robot.perform(druid) }
+
     before do
       allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
       allow(robot.workflow_service).to receive(:process).and_return(process)
     end
 
     it 'is successful' do
-      robot.perform(druid)
+      expect(perform.status).to eq 'noop'
       expect(object_client).to have_received(:preserve).with(lane_id: 'low')
     end
   end


### PR DESCRIPTION

## Why was this change made?
This step is completed by dor-services-app

Part of sul-dlss/argo#1789


## How was this change tested?
integration test on stage.



## Which documentation and/or configurations were updated?
n/a
