### PR TITLE
When there is no contentMetadata.xml mark the step as skipped

### DIFF
--- a/lib/robots/dor_repo/accession/content_metadata.rb
+++ b/lib/robots/dor_repo/accession/content_metadata.rb
@@ -20,7 +20,7 @@ module Robots
           object = DruidTools::Druid.new(druid, Settings.stacks.local_workspace_root)
           path = object.find_metadata('contentMetadata.xml')
 
-          return unless path
+          return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'No contentMetadata.xml was provided') unless path
 
           object_client.metadata.legacy_update(
             content: {


### PR DESCRIPTION
## Why was this change made?

This aligns the content-metadata robot with the way the rights-metadata and desc-metadata robots work.  It allows the users to see when this functionality is used and when it isn't.

## How was this change tested?

tested locally

## Which documentation and/or configurations were updated?

none


