### PR TITLE
remove unused jhove setting

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
 
 # External application locations
-JHOVE_HOME = File.join(ENV['HOME'], 'jhoveToolkit')
-
 REDIS_URL = Settings.redis.url


### PR DESCRIPTION
## Why was this change made?

b/c cruft makes maintenance harder

## How was this change tested?

we stopped using jhove when we switch to techmd-service

## Which documentation and/or configurations were updated?

checked and no jhove setting in shared_configs.


