### PR TITLE
Add QA deployment target

### DIFF
--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+server 'common-accessioning-qa-a.stanford.edu', user: 'lyberadmin', roles: %w[app]
+server 'common-accessioning-qa-b.stanford.edu', user: 'lyberadmin', roles: %w[app]
+
+Capistrano::OneTimeKey.generate_one_time_key!
+
+set :deploy_environment, 'production'
+set :default_env, robot_environment: fetch(:deploy_environment)
+# See https://github.com/honeybadger-io/honeybadger-ruby/issues/129 &
+# https://github.com/honeybadger-io/honeybadger-ruby/blob/7eea24a47d44aed663e315be970e501b7cf092fc/vendor/capistrano-honeybadger/README.md
+set :honeybadger_server, primary(:app)


### PR DESCRIPTION
I can confirm this works because I've successfully deployed common-accessioning to QA and it has QA configs from shared_configs (which I just pushed). And a honeybadger deployment was recorded and labeled as being in the QA environment.