### PR TITLE
add a test for member service

### DIFF
--- a/spec/lib/dor/release/member_services_spec.rb
+++ b/spec/lib/dor/release/member_services_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dor::Release::MemberService do
+  let(:member_service) { described_class.new(druid: 'druid:oo000oo0001') }
+  let(:item_member) { Dor::Services::Client::Members::Member.new(externalIdentifier: 'druid:xx828xx3282', type: 'item') }
+  let(:collection_member) { Dor::Services::Client::Members::Member.new(externalIdentifier: 'druid:xx222xx3282', type: 'collection') }
+  let(:response) do
+    [
+      collection_member,
+      item_member,
+      Dor::Services::Client::Members::Member.new(externalIdentifier: 'druid:xx828xx4444', type: nil)
+    ]
+  end
+
+  before { allow(member_service).to receive(:members).and_return(response) }
+
+  describe '#sub_collections' do
+    it 'returns only the sub collections in the collection' do
+      expect(member_service.sub_collections).to eq([collection_member])
+    end
+  end
+
+  describe '#items' do
+    it 'returns only the items in the collection' do
+      expect(member_service.items).to eq([item_member])
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made?

~~(continues to) fixes sul-dlss/argo#2243~~

~~Basically we still have an issue with identifying members of a collection.  Object type is in a multivalued solr field, so that when dor-services-client parses this result from dor-services app here: https://github.com/sul-dlss/dor-services-client/blob/master/lib/dor/services/client/members.rb it makes the `type` an array in the response, and not a string. Thus, determining if a member is an item or a collection needs to be done assuming this value is an array, else you will always get an empty set when asking for items or collections regardless of how many members are returned.  We also need to guard against a nil type, as this may occur in some solr documents.~~

Add a new test for a class that had no test before.

Also see sul-dlss/dor-services-app#1058 and sul-dlss/dor-services-app#1060

## How was this change tested?

Test suite


## Which documentation and/or configurations were updated?



