### PR TITLE
Use dlss-capistrano to manage resque-pool

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -27,8 +27,8 @@ require 'capistrano/bundler'
 # require 'capistrano/rails/migrations'
 
 require 'dlss/capistrano'
+require 'dlss/capistrano/resque_pool'
 require 'capistrano/honeybadger'
-require 'capistrano-resque-pool'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.cap').each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,7 @@ end
 group :development do
   gem 'capistrano', '~> 3.0'
   gem 'capistrano-bundler', '~> 1.1'
-  gem 'capistrano-resque-pool'
-  gem 'dlss-capistrano', '~> 3.1'
+  gem 'dlss-capistrano', '~> 3.10'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,9 +39,6 @@ GEM
       capistrano (~> 3.1)
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
-    capistrano-resque-pool (0.2.0)
-      capistrano
-      resque-pool
     capistrano-shared_configs (0.2.2)
     cocina-models (0.42.1)
       activesupport
@@ -63,7 +60,7 @@ GEM
     deprecation (1.0.0)
       activesupport
     diff-lcs (1.4.4)
-    dlss-capistrano (3.9.0)
+    dlss-capistrano (3.10.1)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key
@@ -265,9 +262,8 @@ DEPENDENCIES
   byebug
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
-  capistrano-resque-pool
   config (~> 2.2)
-  dlss-capistrano (~> 3.1)
+  dlss-capistrano (~> 3.10)
   dor-services-client (~> 6.13)
   dor-workflow-client (~> 3.18)
   druid-tools (~> 2.1)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -22,7 +22,7 @@ set :log_level, :info
 # set :pty, true
 
 # Default value for :linked_files is []
-set :linked_files, %w[config/honeybadger.yml]
+set :linked_files, %w[config/honeybadger.yml tmp/resque-pool.lock]
 
 # Default value for linked_dirs is []
 # set :linked_dirs, %w{bin log tmp/pids tmp/cache tmp/sockets vendor/bundle public/system}
@@ -46,5 +46,3 @@ set :resque_server_roles, :app
 
 # update shared_configs before restarting app
 before 'deploy:publishing', 'shared_configs:update'
-
-after 'deploy:publishing', 'resque:pool:hot_swap'


### PR DESCRIPTION
This replaces capistrano-resque-pool and works as expected with a hot-swappable pool.

Also includes:

Store resque-pool lockfile in shared dir
This allows the resque:pool:hot_swap capistrano task to do what we expect it to do.


