### PR TITLE
Always run the shelve step

### DIFF
--- a/lib/robots/dor_repo/accession/shelve.rb
+++ b/lib/robots/dor_repo/accession/shelve.rb
@@ -16,9 +16,8 @@ module Robots
 
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'Not an item/DRO, nothing to do') unless obj.dro?
 
-          # No files, so do nothing
-          return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'Object has no files') if obj.structural.contains.blank?
-
+          # Shelving must be done whether an object has files or not, because the shelve call
+          # also plays a role in decommissioning an object where the files are removed from stacks.
           # This is an asynchronous result. It will set the shelve workflow to complete when it is done.
           object_client.shelve(lane_id: lane_id(druid))
           LyberCore::Robot::ReturnState.new(status: :noop, note: 'Initiated shelve API call.')

--- a/spec/robots/accession/shelve_spec.rb
+++ b/spec/robots/accession/shelve_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe Robots::DorRepo::Accession::Shelve do
                                 administrative: { hasAdminPolicy: 'druid:xx999xx9999' })
       end
 
-      it 'does not shelve the item' do
-        expect(perform.status).to eq 'skipped'
-        expect(object_client).not_to have_received(:shelve)
+      it 'calls shelve (for the deaccession use case)' do
+        expect(perform.status).to eq 'noop'
+        expect(object_client).to have_received(:shelve)
       end
     end
   end


### PR DESCRIPTION
Even if there are no files present. The deaccession use case depends on shelve being called with no files, which causes stacks to remove the files.

## Why was this change made?

Fixes #715 

## How was this change tested?



## Which documentation and/or configurations were updated?



