### PR TITLE
bump version of assembly-objectfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'activesupport', '~> 5.2'
 gem 'assembly-image', '~> 1.7'
-gem 'assembly-objectfile', '>=1.6.6'
+gem 'assembly-objectfile', '~> 1.10', '>= 1.10.1' # webarchive-seed is supported in 1.10.1 and better
 gem 'config', '~> 2.2'
 gem 'dor-services-client', '~> 6.27'
 gem 'dor-workflow-client', '~> 3.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     assembly-image (1.7.7)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
-    assembly-objectfile (1.10.0)
+    assembly-objectfile (1.10.1)
       activesupport (>= 5.2.0)
       deprecation
       dry-struct (~> 1.0)
@@ -262,7 +262,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.2)
   assembly-image (~> 1.7)
-  assembly-objectfile (>= 1.6.6)
+  assembly-objectfile (~> 1.10, >= 1.10.1)
   byebug
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)


### PR DESCRIPTION
## Why was this change made?

The new version of assembly-objectfile supports the new webarchive-seed content metadata generation.


## How was this change tested?



## Which documentation and/or configurations were updated?



