### PR TITLE
bundle install to try to fix out of sync Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   config (~> 2.2)
   dlss-capistrano (~> 3.10)
-  dor-services-client (~> 6.27)
+  dor-services-client (~> 6.30)
   dor-workflow-client (~> 3.18)
   druid-tools (~> 2.1)
   equivalent-xml


### PR DESCRIPTION
deleted `Gemfile.lock` and re-ran `bundle install` locally.


## Why was this change made?

fix the following deployment error:
```
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

The dependencies in your gemfile changed

You have added to the Gemfile:
* dor-services-client (~> 6.30)

You have deleted from the Gemfile:
* dor-services-client (~> 6.27)
	1: from /Users/suntzu/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/sshkit-1.21.2/lib/sshkit/runners/parallel.rb:11:in `block (2 levels) in execute'
/Users/suntzu/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/sshkit-1.21.2/lib/sshkit/runners/parallel.rb:15:in `rescue in block (2 levels) in execute': Exception while executing as lyberadmin@common-accessioning-stage-b.stanford.edu: bundle exit status: 16 (SSHKit::Runner::ExecuteError)
bundle stdout: Nothing written
```

## How was this change tested?

successfully deployed this branch to stage

## Which documentation and/or configurations were updated?

n/a

