### PR TITLE
bundle update cocina-models, dor-services-client, and honeybadger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
-    cocina-models (0.56.0)
+    cocina-models (0.56.1)
       activesupport
       dry-struct (~> 1.0)
       dry-types (~> 1.1)
@@ -67,7 +67,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.5)
-    dor-services-client (6.30.0)
+    dor-services-client (6.30.1)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.56.0)
       deprecation
@@ -131,7 +131,7 @@ GEM
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
     hashdiff (1.0.1)
-    honeybadger (4.7.3)
+    honeybadger (4.8.0)
     i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)


### PR DESCRIPTION
skip updating assembly-objectfile, since that broke the build

## Why was this change made?

get to the latest cocina-models, without breaking the build (see #744).

```diff
common-accessioning % git diff upd-deps-again upd-some-deps-again                      upd-some-deps-again
diff --git a/Gemfile.lock b/Gemfile.lock
index c690d8b..c8b1a53 100644
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     assembly-image (1.7.7)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
-    assembly-objectfile (1.10.2)
+    assembly-objectfile (1.10.1)
       activesupport (>= 5.2.0)
       deprecation
       dry-struct (~> 1.0)
```

## How was this change tested?

unit tests

## Which documentation and/or configurations were updated?

n/a
