### PR TITLE
bump assembly-objectfile gem to get json mimetypes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'activesupport', '~> 5.2'
 gem 'assembly-image', '~> 1.7'
-gem 'assembly-objectfile', '~> 1.10', '>= 1.10.2' # webarchive-seed and reading order is supported in 1.10.2 and better
+gem 'assembly-objectfile', '~> 1.10', '>= 1.10.3' # reading order, webarchive-seed, json mimetypes are supported in >=1.10.3
 gem 'config', '~> 2.2'
 gem 'dor-services-client', '~> 6.30'
 gem 'dor-workflow-client', '~> 3.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     assembly-image (1.7.7)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
-    assembly-objectfile (1.10.2)
+    assembly-objectfile (1.10.3)
       activesupport (>= 5.2.0)
       deprecation
       dry-struct (~> 1.0)
@@ -266,7 +266,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.2)
   assembly-image (~> 1.7)
-  assembly-objectfile (~> 1.10, >= 1.10.2)
+  assembly-objectfile (~> 1.10, >= 1.10.3)
   byebug
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)


### PR DESCRIPTION
## Why was this change made?

To get the change in sul-dlss/assembly-objectfile#50 working (it sets json mimetypes correctly)

## How was this change tested?



## Which documentation and/or configurations were updated?



