### PR TITLE
decrease the number of common-accessioning workers

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,2 @@
-"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 10
+"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 7
 "assemblyWF_jp2": 1


### PR DESCRIPTION
## Why was this change made?

This is an attempt to reduce the maximum load we put on Fedora.

This is not exactly the same as the originally proposed elimination of 1 VM:  no `assemblyWF_jp2` workers are cut (still 4 total), and we cut 30% of the other workers (3/10 on each of 4 boxes) instead of 25% (10 of the 40 total).  This is a 27% reduction in overall worker count (3/11).

A possible advantage compared to the original plan is that decreasing the number of workers on each box decreases the max possible demand for simultaneous connections on each box, and the failures we're seeing are usually with an exhaustion of available outbound connections.

connects to #758
connects to sul-dlss/dor-services-app#2559

## How was this change tested?

I think we're assuming that we can't reproduce this in stage, and since this is safe (worst consequence is accessioning piling up?), and since it's easily revertible, I think we feel comfortable just decreasing the worker count in prod and babysitting.

## Which documentation and/or configurations were updated?

config only change