### PR TITLE
reduce number of accessioning workers to alleviate pressure on fedora

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,2 @@
-"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 7
+"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 5
 "assemblyWF_jp2": 1


### PR DESCRIPTION
## Why was this change made?

we hope that this might reduce or eliminate issues with dor-services-app running out of outbound connections when talking to fedora (the hypothesis being the fedora is slow, and a backlog of requests to it will pile up as load from accessioning and/or indexing increases).

see https://github.com/sul-dlss/common-accessioning/issues/758 and https://github.com/sul-dlss/common-accessioning/pull/759/files

## How was this change tested?

um...

## Which documentation and/or configurations were updated?

worker allocation in resque pool config

