### PR TITLE
reduce common-accessioning worker allocation by 1 per VM

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,2 @@
-"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 5
+"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 4
 "assemblyWF_jp2": 1


### PR DESCRIPTION
## Why was this change made?

trying to reduce load on fedora during periods of peak demand.

per discussion on slack last friday and in standup today.

see also https://github.com/sul-dlss/common-accessioning/issues/758

## How was this change tested?

😅 

## Which documentation and/or configurations were updated?

resque-pool config change only