### PR TITLE
try decreasing by one worker per VM again

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,2 @@
-"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 4
+"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 3
 "assemblyWF_jp2": 1


### PR DESCRIPTION
per https://github.com/sul-dlss/common-accessioning/issues/758#issuecomment-899630759

## Why was this change made?

continuing to experiment with fewer common-accessioning workers to try reducing pressure on fedora to prevent DSA using up all its outgoing connections due to slow fedora responses.

## How was this change tested?

we'll see once deployed whether it helps alleviate connection issues when lots of accessioning activity is happening at once

## Which documentation and/or configurations were updated?

resque-pool to adjust worker count

