### PR TITLE
Update dependencies (manually)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,7 +180,7 @@ GEM
     openapi3_parser (0.9.0)
       commonmarker (~> 0.17)
       psych (~> 3.1)
-    openapi_parser (0.14.1)
+    openapi_parser (0.15.0)
     parallel (1.21.0)
     parser (3.0.2.0)
       ast (~> 2.4.1)
@@ -299,4 +299,4 @@ DEPENDENCIES
   zeitwerk (~> 2.1)
 
 BUNDLED WITH
-   2.2.15
+   2.2.27


### PR DESCRIPTION
## Why was this change made?

to update dependencies (wasn't triggered by jenkins for some reason -- maybe the `openapi_parser` gem updated more recently)

## How was this change tested?



## Which documentation and/or configurations were updated?



