### PR TITLE
Make provenance-metadata a no op

### DIFF
--- a/lib/robots/dor_repo/accession/provenance_metadata.rb
+++ b/lib/robots/dor_repo/accession/provenance_metadata.rb
@@ -8,33 +8,8 @@ module Robots
           super('accessionWF', 'provenance-metadata')
         end
 
-        def perform(druid)
-          workflow_provenance = create_workflow_provenance(druid)
-          object_client = Dor::Services::Client.object(druid)
-          object_client.metadata.legacy_update(
-            provenance: {
-              updated: Time.now,
-              content: workflow_provenance
-            }
-          )
-        end
-
-        private
-
-        # @return [String]
-        def create_workflow_provenance(druid, time: Time.new.iso8601)
-          builder = Nokogiri::XML::Builder.new do |xml|
-            xml.provenanceMetadata(objectId: druid) do
-              xml.agent(name: 'DOR') do
-                xml.what(object: druid) do
-                  xml.event(who: 'DOR-accessionWF', when: time) do
-                    xml.text('DOR Common Accessioning completed')
-                  end
-                end
-              end
-            end
-          end
-          builder.doc.to_s
+        def perform(_druid)
+          LyberCore::Robot::ReturnState.new(status: :skipped, note: 'This robot no longer does anything')
         end
       end
     end

--- a/spec/robots/accession/provenance_metadata_spec.rb
+++ b/spec/robots/accession/provenance_metadata_spec.rb
@@ -9,41 +9,8 @@ RSpec.describe Robots::DorRepo::Accession::ProvenanceMetadata do
   describe '#perform' do
     subject(:perform) { robot.perform(druid) }
 
-    let(:object_client) do
-      instance_double(Dor::Services::Client::Object, metadata: metadata_client)
-    end
-    let(:metadata_client) do
-      instance_double(Dor::Services::Client::Metadata, legacy_update: true)
-    end
-
-    before do
-      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-      allow(robot).to receive(:create_workflow_provenance).and_return('<provenance/>')
-    end
-
-    it 'generates provenance' do
-      perform
-      expect(metadata_client).to have_received(:legacy_update).with(
-        provenance: {
-          updated: Time,
-          content: '<provenance/>'
-        }
-      )
-    end
-  end
-
-  describe '#create_workflow_provenance' do
-    subject(:build) { robot.send(:create_workflow_provenance, druid, time: '2020-01-28T11:24:26-06:00') }
-
-    it 'make the xml' do
-      expect(build).to be_equivalent_to '<?xml version="1.0"?>
-       <provenanceMetadata objectId="druid:aa123bb4567">
-         <agent name="DOR">
-           <what object="druid:aa123bb4567">
-             <event who="DOR-accessionWF" when="2020-01-28T11:24:26-06:00">DOR Common Accessioning completed</event>
-           </what>
-         </agent>
-       </provenanceMetadata>'
+    it 'skips' do
+      expect(perform.status).to eq('skipped')
     end
   end
 end


### PR DESCRIPTION

## Why was this change made?
In a meeting today, Andrew agreed this step is not useful as this data is duplicative of what is recorded in the events service.  This will reduce the load on DSA and Fedora.



## How was this change tested?



## Which documentation and/or configurations were updated?



