### PR TITLE
Notify if rights-metadata robot finds xml

### DIFF
--- a/lib/robots/dor_repo/accession/rights_metadata.rb
+++ b/lib/robots/dor_repo/accession/rights_metadata.rb
@@ -14,6 +14,8 @@ module Robots
           path = object.find_metadata('rightsMetadata.xml')
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'No rightsMetadata.xml was provided') unless path
 
+          Honeybadger.notify("[WARN] We don't think that anything uses this robot. It is slated for removal", context: { druid: druid })
+
           object_client = Dor::Services::Client.object(druid)
           object_client.metadata.legacy_update(
             rights: {


### PR DESCRIPTION


## Why was this change made?
We don't think this is used, but we'd like to confirm this by monitoring in prod


## How was this change tested?



## Which documentation and/or configurations were updated?



