### PR TITLE
Shut down common-accessioning workers

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,2 @@
-"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 3
-"assemblyWF_jp2": 1
+"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 0
+"assemblyWF_jp2": 0


### PR DESCRIPTION
## Why was this change made?

So that no work gets picked up by techmd while we migrate it to Ubuntu

## How was this change tested?

Tested in stage

## Which documentation and/or configurations were updated?

N/A

