### PR TITLE
simplecov no longer needs version restricted

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem 'equivalent-xml'
   gem 'rspec', '~> 3.0'
   gem 'rspec_junit_formatter' # needed for test coverage in CircleCI
-  gem 'simplecov', '~> 0.17.0', require: 'false' # See https://github.com/codeclimate/test-reporter/issues/413
+  gem 'simplecov', require: 'false'
   gem 'webmock'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,6 @@ GEM
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
     jaro_winkler (1.5.4)
-    json (2.6.1)
     lyber-core (6.1.1)
     method_source (1.0.0)
     mime-types (3.4.1)
@@ -232,11 +231,12 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     sinatra (2.1.0)
       mustermann (~> 1.0)
       rack (~> 2.2)
@@ -288,7 +288,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop (~> 0.77.0)
   rubocop-rspec
-  simplecov (~> 0.17.0)
+  simplecov
   slop
   webmock
   zeitwerk (~> 2.1)


### PR DESCRIPTION
## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



