### PR TITLE
Remove unused model

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -12,7 +12,6 @@ ROBOT_LOG.level = Logger::SEV_LABEL.index(ENV['ROBOT_LOG_LEVEL']) || Logger::INF
 
 loader = Zeitwerk::Loader.new
 loader.push_dir(File.absolute_path("#{__FILE__}/../../lib"))
-loader.push_dir(File.absolute_path("#{__FILE__}/../../lib/models"))
 loader.setup
 
 Config.setup do |config|

--- a/lib/models/part.rb
+++ b/lib/models/part.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class Part < Dor::Part
-end


### PR DESCRIPTION


## Why was this change made?
This used to be used for ETD when we modeled part objects in Fedora


## How was this change tested?



## Which documentation and/or configurations were updated?



