### PR TITLE
Ensure that dark objects do not try to publish or shelve

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,9 @@ Naming/PredicateName:
   ForbiddenPrefixes:
     - is_
 
+RSpec/NestedGroups:
+  Max: 5
+
 Gemspec/DateAssignment: # new in 1.10
   Enabled: true
 Gemspec/RequireMFA: # new in 1.23

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -74,10 +74,6 @@ RSpec/MultipleExpectations:
 RSpec/MultipleMemoizedHelpers:
   Max: 11
 
-# Offense count: 13
-RSpec/NestedGroups:
-  Max: 4
-
 # Offense count: 16
 # Configuration parameters: IgnoreNameless, IgnoreSymbolicNames.
 RSpec/VerifiedDoubles:


### PR DESCRIPTION


## Why was this change made?

Fixes #841

## How was this change tested?



## Which documentation and/or configurations were updated?



