### PR TITLE
if //bookData/@readingOrder is missing, don't raise exception

### DIFF
--- a/lib/dor/structural_metadata.rb
+++ b/lib/dor/structural_metadata.rb
@@ -64,7 +64,6 @@ module Dor
     def create_member_order
       reading_direction = ng_xml.xpath('//bookData/@readingOrder').first&.value
       viewing_direction = ViewingDirectionHelper.viewing_direction(reading_direction)
-      viewing_direction ||= 'left-to-right'
 
       [{ viewingDirection: viewing_direction }]
     end

--- a/lib/dor/viewing_direction_helper.rb
+++ b/lib/dor/viewing_direction_helper.rb
@@ -20,7 +20,9 @@ module Dor
       when 'rtl'
         'right-to-left'
       else
-        raise "can't find reading direction in contentMetadata.xml"
+        message = "reading direction in contentMetadata.xml is '#{reading_direction}'; defaulting to ltr"
+        Honeybadger.notify("[WARNING] #{message}")
+        'left-to-right'
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Part of #866, this will allow accessioning to continue.  Andrew has requested this change;  furthermore, he has said there is a way to fix an incorrect viewing direction.

Another PR to avoid this problem in the first place via pre-assembly is in the works.

## How was this change tested? 🤨

unit tests

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


