### PR TITLE
Notify about a path we think might be dead code

### DIFF
--- a/lib/robots/dor_repo/assembly/jp2_create.rb
+++ b/lib/robots/dor_repo/assembly/jp2_create.rb
@@ -45,6 +45,8 @@ module Robots
             add_jp2_file_node(file_node, img.dpg_jp2_filename, img.path)
           # if we have an existing jp2 with the same basename as the tiff -- don't fail, but do log it
           elsif File.exist?(img.jp2_filename)
+            Honeybadger.notify('Does this path ever get hit in production?  If you see this error, ' \
+                               "please write a test for this case in common-accessioning, presently it's not covered.", { image_path: img.path })
             message = "WARNING: Did not create jp2 for #{img.path} -- file already exists"
             LyberCore::Log.warn(message)
             add_jp2_file_node(file_node, img.jp2_filename, img.path)


### PR DESCRIPTION
## Why was this change made? 🤔

We weren't seeing the messages from this path in the logs. Maybe this never happens?  If we don't see this notification in a few months, we can remove this code.

## How was this change tested? 🤨
it wasn't! It's dead code 💀 
