### PR TITLE
temporarily set worker counts to zero, to prevent accessioning

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,2 +1,4 @@
-"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 2
-"assemblyWF_jp2": 1
+# "accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 2
+# "assemblyWF_jp2": 1
+"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 0
+"assemblyWF_jp2": 0


### PR DESCRIPTION
## Why was this change made? 🤔

per https://github.com/sul-dlss/preservation_catalog/issues/1896, stanford is currently experience campus-wide networking issues as a result of an ongoing multi-day electrical power outage/reduction.  per conversation with @andrewjbtw and @julianmorley on slack yesterday, we're pausing the accessioning pipeline until power/network stability is restored.  per conversation with @ndushay and @justinlittman in standup today, we're zeroing the worker count in common-accessioning and preservation_robots, so that monday's FR (@jcoyne) doesn't have to worry about stopping resque-pool when deploying dependency updates, if the outage is still ongoing.

once network stability is restored, we should revert this change.


## How was this change tested? 🤨

we've used this pattern a number of times in the past for stopping workers from picking up jobs? 🤷 (see e.g. preservation catalog storage migrations, fedora VM migration)

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


