### PR TITLE
use assembly-image 2.0 for better jp2 images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,3 +12,6 @@ workflows:
             - run:
                 name: install rsync
                 command: sudo apt update && sudo apt install -y rsync
+            - run:
+                name: Install libvips
+                command: sudo apt-get update && sudo apt-get install -y libvips

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'activesupport', '~> 7.0'
-gem 'assembly-image', '~> 1.7'
+gem 'assembly-image', '~> 2.0' # ruby-vips is used by 2.0.0 for improved image processing
 gem 'assembly-objectfile', '~> 1.10', '>= 1.10.3' # reading order, webarchive-seed, json mimetypes are supported in >=1.10.3
 gem 'config', '~> 2.2'
 gem 'dor-services-client', '~> 12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
-    assembly-image (1.9.0)
+    assembly-image (2.0.0)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
+      ruby-vips (>= 2.0)
     assembly-objectfile (1.12.0)
       activesupport (>= 5.2.0)
       deprecation
@@ -136,6 +137,7 @@ GEM
     faraday-net_http (2.0.3)
     faraday-retry (2.0.0)
       faraday (~> 2.0)
+    ffi (1.15.5)
     hashdiff (1.0.1)
     honeybadger (4.12.1)
     i18n (1.10.0)
@@ -229,6 +231,8 @@ GEM
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -266,7 +270,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.0)
-  assembly-image (~> 1.7)
+  assembly-image (~> 2.0)
   assembly-objectfile (~> 1.10, >= 1.10.3)
   byebug
   capistrano (~> 3.0)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Running a single robot step manually (without checking current workflow status):
 $ ./bin/run_robot --druid druid:12345 --environment production Accession::Publish
 ```
 
+Note that `libvips` is a pre-requisite for running the assemblyWF step that creates derivative JP2s.
+
 ## Running tests
 A simple "rake" should do everything you need
 


### PR DESCRIPTION
## Why was this change made? 🤔

assembly-image v2.0.0 uses `ruby-vips` to use `libvips` for better temporary tiff and better jp2 image creation.

## How was this change tested? 🤨

A branch of this code pointing to a branch of assembly-image PR sul-dlss/assembly-image/pull/65 was vetted by Andrew;  Tony Calavano vetted assembly-image code independently, too.

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


