### PR TITLE
add note about libvips to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Running a single robot step manually (without checking current workflow status):
 $ ./bin/run_robot --druid druid:12345 --environment production Accession::Publish
 ```
 
+Note that `libvips` is a pre-requisite for running the assemblyWF step that creates derivative JP2s.
+
 ## Running tests
 A simple "rake" should do everything you need
 


### PR DESCRIPTION
## Why was this change made? 🤔

because common-accessioning now requires libvips.  (it used to require ImageMagick, but that was never documented.  Yay us.)

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


