### PR TITLE
re-enable common-accessioning workers

### DIFF
--- a/config/resque-pool.yml
+++ b/config/resque-pool.yml
@@ -1,4 +1,2 @@
-# "accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 2
-# "assemblyWF_jp2": 1
-"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 0
-"assemblyWF_jp2": 0
+"accessionWF_default,assemblyWF_default,disseminationWF_default,goobiWF_default,releaseWF_default,accessionWF_low,assemblyWF_low,disseminationWF_low,goobiWF_low,releaseWF_low": 2
+"assemblyWF_jp2": 1


### PR DESCRIPTION
## Why was this change made? 🤔

revert temporary stoppage related to last week's power/network outage.  see https://github.com/sul-dlss/preservation_catalog/issues/1896.

i will manually kill the resque pool master processes for common accessioning when this is deployed to prod, so that we can let pres robots work off its backlog first.  (the current plan is to let the `preservationIngestWF` backlog get worked off, before re-enabling common-accessioning robots)

## How was this change tested? 🤨

reverting to original working config

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


