### PR TITLE
Don't make jp2 derivatives for dark objects

### DIFF
--- a/lib/robots/dor_repo/assembly/jp2_create.rb
+++ b/lib/robots/dor_repo/assembly/jp2_create.rb
@@ -11,6 +11,8 @@ module Robots
         def perform(druid)
           with_item(druid) do |assembly_item|
             cocina_model = assembly_item.cocina_model
+            return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'object is dark, no derivatives required') if cocina_model.access.view == 'dark'
+
             file_sets = create_jp2s(assembly_item, cocina_model)
             # Save the modified metadata
             updated = cocina_model.new(structural: cocina_model.structural.new(contains: file_sets))

--- a/spec/robots/assembly/jp2_create_spec.rb
+++ b/spec/robots/assembly/jp2_create_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)
   end
-  let(:cocina_model) { build(:dro, id: "druid:#{bare_druid}").new(structural: structural, access: { view: 'world' }) }
+  let(:access) { { view: 'world' } }
+  let(:cocina_model) { build(:dro, id: "druid:#{bare_druid}").new(structural: structural, access: access) }
 
   let(:structural) do
     { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
@@ -71,10 +72,22 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
     context 'with an item' do
       let(:object) { build(:dro, id: "druid:#{bare_druid}") }
 
+      before do
+        allow(assembly_item).to receive(:item?).and_call_original
+      end
+
       it 'creates jp2' do
-        expect(assembly_item).to receive(:item?).and_call_original
         allow(robot).to receive(:create_jp2s).with(assembly_item, cocina_model).and_return([])
         perform
+        expect(assembly_item).to have_received(:item?)
+      end
+
+      context 'with dark access' do
+        let(:access) { { view: 'dark' } }
+
+        it 'does not create jp2' do
+          expect(perform.status).to eq 'skipped'
+        end
       end
     end
 


### PR DESCRIPTION


## Why was this change made? 🤔
Fixes #935
Having derivatives on objects with dark access causes the object to fail cocina validation.

## How was this change tested? 🤨

CI
