### PR TITLE
checksum_compute: fix error message when checksums do not agree

### DIFF
--- a/lib/robots/dor_repo/assembly/checksum_compute.rb
+++ b/lib/robots/dor_repo/assembly/checksum_compute.rb
@@ -23,12 +23,10 @@ module Robots
 
         def compute_checksums(assembly_item, cocina_model)
           LyberCore::Log.info("Computing checksums for #{assembly_item.druid.id}")
-
           file_sets = cocina_model.structural.to_h.fetch(:contains) # make this a mutable hash
 
           file_sets.each do |file_set|
             files = file_set.dig(:structural, :contains)
-
             files.each do |file|
               object_file = ::Assembly::ObjectFile.new(assembly_item.path_finder.path_to_content_file(file.fetch(:filename)))
 
@@ -41,12 +39,12 @@ module Robots
 
               # if we have any existing checksum nodes, compare them all against the checksums we just computed, and raise an error if any fail
               if md5_node
-                raise %(Checksums disagree: type="md5", file="#{fn['id']}", computed="#{checksums[:md5]}, provided="#{md5_node[:digest]}".) unless checksums_equal?(md5_node, checksums[:md5])
+                raise %(Checksums disagree: type="md5", file="#{file[:filename]}", computed="#{checksums[:md5]}, provided="#{md5_node[:digest]}".) unless checksums_equal?(md5_node, checksums[:md5])
               else
                 file[:hasMessageDigests] << { type: 'md5', digest: checksums[:md5] }
               end
               if sha1_node
-                raise %(Checksums disagree: type="sha1", file="#{fn['id']}", computed="#{checksums[:sha1]}", provided="#{sha1_node[:digest]}".) unless checksums_equal?(sha1_node, checksums[:sha1])
+                raise %(Checksums disagree: type="sha1", file="#{file[:filename]}", computed="#{checksums[:sha1]}", provided="#{sha1_node[:digest]}".) unless checksums_equal?(sha1_node, checksums[:sha1])
               else
                 file[:hasMessageDigests] << { type: 'sha1', digest: checksums[:sha1] }
               end

--- a/spec/robots/assembly/checksum_compute_spec.rb
+++ b/spec/robots/assembly/checksum_compute_spec.rb
@@ -130,5 +130,11 @@ RSpec.describe Robots::DorRepo::Assembly::ChecksumCompute do
         ]
       ]
     end
+
+    it 'errors with a useful message when checksums do not match' do
+      structural[:contains].first[:structural][:contains].first[:hasMessageDigests].first[:digest] = '666'
+      cocina_object = build(:dro, id: druid).new(structural: structural)
+      expect { robot.send(:compute_checksums, assembly_item, cocina_object) }.to raise_error(RuntimeError, /Checksums disagree: type="md5", file="image111.tif"/)
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Closes #941, a production problem.

PR #919 had a mistake where the error message checksums not agreeing had variable that had been removed.  This fixes that problem.

## How was this change tested? 🤨

I wrote a spec for this.  (codeclimate is in lululand)

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


