### PR TITLE
use assembly-image with libvips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'activesupport', '~> 7.0'
-gem 'assembly-image', '~> 1.0' # don't use libvips (v2.0.0)
+gem 'assembly-image', '~> 2.0' # ruby-vips is used by 2.0.0 for improved image processing
 gem 'assembly-objectfile', '~> 1.10', '>= 1.10.3' # reading order, webarchive-seed, json mimetypes are supported in >=1.10.3
 gem 'config', '~> 2.2'
 gem 'dor-services-client', '~> 12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     airbrussh (1.4.0)
       sshkit (>= 1.6.1, != 1.7.0)
-    assembly-image (1.9.0)
+    assembly-image (2.0.0)
       assembly-objectfile (>= 1.6.4)
       mini_exiftool (>= 1.6, < 3)
+      ruby-vips (>= 2.0)
     assembly-objectfile (1.12.0)
       activesupport (>= 5.2.0)
       deprecation
@@ -136,6 +137,7 @@ GEM
     faraday-net_http (2.0.3)
     faraday-retry (2.0.0)
       faraday (~> 2.0)
+    ffi (1.15.5)
     hashdiff (1.0.1)
     honeybadger (4.12.1)
     i18n (1.10.0)
@@ -231,6 +233,8 @@ GEM
     rubocop-rspec (2.12.1)
       rubocop (~> 1.31)
     ruby-progressbar (1.11.0)
+    ruby-vips (2.1.4)
+      ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     simplecov (0.21.2)
       docile (~> 1.1)
@@ -268,7 +272,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 7.0)
-  assembly-image (~> 1.0)
+  assembly-image (~> 2.0)
   assembly-objectfile (~> 1.10, >= 1.10.3)
   byebug
   capistrano (~> 3.0)


### PR DESCRIPTION
## Why was this change made? 🤔

Andrew gave 👍🏻 to using libvips in prod again as the changes for TMPDIR in stage (plus VIPS_DISC_THRESHOLD?) made it so he couldn't recreate the problem in stage.

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


