### PR TITLE
Use the local copy of ContentMetadata

### DIFF
--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -32,7 +32,7 @@ module Dor
       # @param [String] the mimetype of the file
       # @return [Hash<Symbol,String>] the default file attributes hash
       def self.default_file_attributes(mimetype)
-        ::Assembly::ContentMetadata::File::ATTRIBUTES_FOR_TYPE.fetch(mimetype) { ::Assembly::ContentMetadata::File::ATTRIBUTES_FOR_TYPE.fetch('default') }
+        ContentMetadata::File::ATTRIBUTES_FOR_TYPE.fetch(mimetype) { ContentMetadata::File::ATTRIBUTES_FOR_TYPE.fetch('default') }
       end
     end
   end

--- a/lib/dor/assembly/stub_content_metadata_parser.rb
+++ b/lib/dor/assembly/stub_content_metadata_parser.rb
@@ -25,7 +25,7 @@ module Dor
           end
         end
 
-        ::Assembly::ContentMetadata.create_content_metadata(druid: @druid.druid, style: gem_content_metadata_style, objects: cm_resources, bundle: :prebundled, add_file_attributes: true, reading_order: book_reading_order)
+        ContentMetadata.create_content_metadata(druid: @druid.druid, style: gem_content_metadata_style, objects: cm_resources, bundle: :prebundled, add_file_attributes: true, reading_order: book_reading_order)
       end
 
       def stub_content_metadata_exists?

--- a/lib/dor/file_sets.rb
+++ b/lib/dor/file_sets.rb
@@ -94,7 +94,7 @@ module Dor
     end
 
     def default_administrative_attributes(mimetype)
-      attrs = ::Assembly::ContentMetadata::File::ATTRIBUTES_FOR_TYPE
+      attrs = Assembly::ContentMetadata::File::ATTRIBUTES_FOR_TYPE
 
       attrs.fetch(mimetype) { attrs.fetch('default') }
     end


### PR DESCRIPTION


## Why was this change made? 🤔
Rather than the copy in assembly-objectfile


## How was this change tested? 🤨
CI

