### PR TITLE
[refactor] Simplify to only support prebundled types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ config/certs
 .ruby-gemset
 .pry_history
 
+# rspec failure tracking
+.rspec_status
+
 /tmp/*
 !/tmp/.keep
 

--- a/lib/dor/assembly/content_metadata.rb
+++ b/lib/dor/assembly/content_metadata.rb
@@ -23,10 +23,6 @@ module Dor
       #                 :map, like simple_image, but with contentMetadata type="map", resource type="image"
       #                 :3d, contentMetadata type="3d", ".obj" and other configured 3d extension files go into resource_type="3d", everything else into resource_type="file"
       #                 :webarchive-seed, contentMetadata type="webarchive-seed", resource type="image"
-      #   :bundle = optional - a symbol containing the method of bundling files into resources, allowed values are
-      #                 :default = all files get their own resources (default)
-      #                 :filename = files with the same filename but different extensions get bundled together in a single resource
-      #                 :prebundlded = this option requires you to prebundled the files passed in as an array of arrays, indicating how files are bundlded into resources; this is the most flexible option since it gives you full control
       #   :add_exif = optional - a boolean to indicate if exif data should be added (mimetype, filesize, image height/width, etc.) to each file, defaults to false and is not required if project goes through assembly
       #   :add_file_attributes = optional - a boolean to indicate if publish/preserve/shelve/role attributes should be added using defaults or by supplied override by mime/type, defaults to false and is not required if project goes through assembly
       #   :file_attributes = optional - a hash of file attributes by mimetype to use instead of defaults, only used if add_file_attributes is also true,
@@ -42,14 +38,13 @@ module Dor
       # Example:
       #    Assembly::ContentMetadata.create_content_metadata(:druid=>'druid:nx288wh8889',:style=>:simple_image,:objects=>object_files,:add_file_attributes=>false)
       def self.create_content_metadata(druid:, objects:, auto_labels: true,
-                                       add_exif: false, bundle: :default, style: :simple_image,
+                                       add_exif: false, style: :simple_image,
                                        add_file_attributes: false, file_attributes: {},
                                        preserve_common_paths: false, include_root_xml: nil,
                                        reading_order: 'ltr')
-
         common_path = find_common_path(objects) unless preserve_common_paths # find common paths to all files provided if needed
 
-        filesets = FileSetBuilder.build(bundle: bundle, objects: objects, style: style)
+        filesets = FileSetBuilder.build(objects: objects, style: style)
         config = Config.new(auto_labels: auto_labels,
                             add_file_attributes: add_file_attributes,
                             file_attributes: file_attributes,

--- a/lib/dor/assembly/content_metadata/file_set_builder.rb
+++ b/lib/dor/assembly/content_metadata/file_set_builder.rb
@@ -5,48 +5,27 @@ module Dor
     class ContentMetadata
       # Builds a groups of related Files, based on bundle
       class FileSetBuilder
-        # @param [Symbol] bundle one of: :default, :filename, or :prebundled
         # @param [Array<Assembly::ObjectFile>] objects
         # @param [Symbol] style one of: :simple_image, :file, :simple_book, :book_as_image, :book_with_pdf, :map, or :'3d'
-        def self.build(bundle:, objects:, style:)
-          new(bundle: bundle, objects: objects, style: style).build
+        def self.build(objects:, style:)
+          new(objects: objects, style: style).build
         end
 
-        def initialize(bundle:, objects:, style:)
-          @bundle = bundle
+        def initialize(objects:, style:)
           @objects = objects
           @style = style
         end
 
         # @return [Array<FileSet>] a list of filesets in the object
         def build
-          case bundle
-          when :default # one resource per object
-            objects.collect { |obj| FileSet.new(resource_files: [obj], style: style) }
-          when :filename # one resource per distinct filename (excluding extension)
-            build_for_filename
-          when :prebundled
-            # if the user specifies this method, they will pass in an array of arrays, indicating resources, so we don't need to bundle in the gem
-            # This is used by the assemblyWF if you have stubContentMetadata.xml
-            objects.map { |inner| FileSet.new(resource_files: inner, style: style) }
-          else
-            raise 'Invalid bundle method'
-          end
+          # if the user specifies this method, they will pass in an array of arrays, indicating resources, so we don't need to bundle in the gem
+          # This is used by the assemblyWF if you have stubContentMetadata.xml
+          objects.map { |inner| FileSet.new(resource_files: inner, style: style) }
         end
 
         private
 
-        attr_reader :bundle, :objects, :style
-
-        def build_for_filename
-          # loop over distinct filenames, this determines how many resources we will have and
-          # create one resource node per distinct filename, collecting the relevant objects with the distinct filename into that resource
-          distinct_filenames = objects.collect(&:filename_without_ext).uniq # find all the unique filenames in the set of objects, leaving off extensions and base paths
-          distinct_filenames.map do |distinct_filename|
-            FileSet.new(resource_files: objects.collect { |obj| obj if obj.filename_without_ext == distinct_filename }.compact,
-                        style: style)
-          end
-        end
+        attr_reader :objects, :style
       end
     end
   end

--- a/lib/dor/assembly/stub_content_metadata_parser.rb
+++ b/lib/dor/assembly/stub_content_metadata_parser.rb
@@ -25,7 +25,7 @@ module Dor
           end
         end
 
-        ContentMetadata.create_content_metadata(druid: @druid.druid, style: gem_content_metadata_style, objects: cm_resources, bundle: :prebundled, add_file_attributes: true, reading_order: book_reading_order)
+        ContentMetadata.create_content_metadata(druid: @druid.druid, style: gem_content_metadata_style, objects: cm_resources, add_file_attributes: true, reading_order: book_reading_order)
       end
 
       def stub_content_metadata_exists?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,6 +27,9 @@ TMP_ROOT_DIR = 'tmp/test_input'
 RSpec.configure do |config|
   config.order = :random
   config.default_formatter = 'doc' if config.files_to_run.one?
+
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = '.rspec_status'
 end
 
 # Use rsync to create a copy of the test_input directory that we can modify.


### PR DESCRIPTION


## Why was this change made? 🤔

We no longer need the other code which was only used by pre-assembly

## How was this change tested? 🤨
ci

