### PR TITLE
[refactor] Remove unused styles for generating contentMetadata

### DIFF
--- a/lib/dor/assembly/content_metadata.rb
+++ b/lib/dor/assembly/content_metadata.rb
@@ -2,7 +2,7 @@
 
 module Dor
   module Assembly
-    VALID_STYLES = %i[simple_image simple_book file map document 3d webarchive-seed].freeze
+    VALID_STYLES = %i[simple_image simple_book file map 3d].freeze
 
     # This class generates content metadata for image files
     class ContentMetadata

--- a/lib/dor/assembly/content_metadata/file_set.rb
+++ b/lib/dor/assembly/content_metadata/file_set.rb
@@ -34,7 +34,6 @@ module Dor
 
         attr_reader :resource_files, :style
 
-        # rubocop:disable Metrics/CyclomaticComplexity
         # use style attribute to determine the resource_type_description
         def resource_type_descriptions
           # grab all of the file types within a resource into an array so we can decide what the resource type should be
@@ -42,18 +41,12 @@ module Dor
           resource_has_non_images = !(resource_file_types - [:image]).empty?
 
           case style
-          when :simple_image, :map, :'webarchive-seed'
+          when :simple_image, :map
             'image'
           when :file
             'file'
           when :simple_book # in a simple book project, all resources are pages unless they are *all* non-images -- if so, switch the type to object
             resource_has_non_images && resource_file_types.include?(:image) == false ? 'object' : 'page'
-          when :book_as_image # same as simple book, but all resources are images instead of pages, unless we need to switch them to object type
-            resource_has_non_images && resource_file_types.include?(:image) == false ? 'object' : 'image'
-          when :book_with_pdf # in book with PDF type, if we find a resource with *any* non images, switch it's type from book to object
-            resource_has_non_images ? 'object' : 'page'
-          when :document
-            'document'
           when :'3d'
             resource_extensions = resource_files.collect(&:ext)
             if (resource_extensions & VALID_THREE_DIMENSION_EXTENTIONS).empty? # if this resource contains no known 3D file extensions, the resource type is file
@@ -63,7 +56,6 @@ module Dor
             end
           end
         end
-        # rubocop:enable Metrics/CyclomaticComplexity
       end
     end
   end

--- a/spec/lib/dor/assembly/content_metadata_spec.rb
+++ b/spec/lib/dor/assembly/content_metadata_spec.rb
@@ -285,32 +285,6 @@ RSpec.describe Dor::Assembly::ContentMetadata do
       end
     end
 
-    context 'when using style=document' do
-      let(:objects) do
-        [[Assembly::ObjectFile.new(TEST_PDF_FILE)]]
-      end
-
-      let(:style) { :document }
-
-      it 'generates valid content metadata' do
-        expect(xml.errors.size).to eq 0
-        expect(xml.xpath('//contentMetadata')[0].attributes['type'].value).to eq('document')
-        expect(xml.xpath('//bookData').length).to eq 0
-        expect(xml.xpath('//resource').length).to eq 1
-        expect(xml.xpath('//resource/file').length).to eq 1
-        expect(xml.xpath('//label').length).to eq 1
-        expect(xml.xpath('//label')[0].text).to match(/Document 1/)
-        expect(xml.xpath('//resource/file/imageData').length).to eq 0
-        file = xml.xpath('//resource/file').first
-        expect(file.attributes['size']).to be_nil
-        expect(file.attributes['mimetype']).to be_nil
-        expect(file.attributes['publish']).to be_nil
-        expect(file.attributes['preserve']).to be_nil
-        expect(file.attributes['shelve']).to be_nil
-        expect(xml.xpath('//resource')[0].attributes['type'].value).to eq('document')
-      end
-    end
-
     context 'when using user supplied checksums for two tifs and style=simple_book' do
       it 'generates valid content metadata with no exif' do
         obj1 = Assembly::ObjectFile.new(TEST_TIF_INPUT_FILE)


### PR DESCRIPTION
## Why was this change made? 🤔

These styles are never created in the StubContentMetadataParser, the only consumer of this code.

## How was this change tested? 🤨
CI

