### PR TITLE
[refactor] Move ATTRIBUTES_FOR_TYPE out of assembly

### DIFF
--- a/lib/dor/assembly/content_metadata/file.rb
+++ b/lib/dor/assembly/content_metadata/file.rb
@@ -7,26 +7,6 @@ module Dor
     class ContentMetadata
       # Represents a single File
       class File
-        # default publish/preserve/shelve attributes used in content metadata
-        # if no mimetype specific attributes are specified for a given file, define some defaults, and override for specific mimetypes below
-        ATTRIBUTES_FOR_TYPE = {
-          'default' => { preserve: 'yes', shelve: 'no', publish: 'no' },
-          'image/tif' => { preserve: 'yes', shelve: 'no', publish: 'no' },
-          'image/tiff' => { preserve: 'yes', shelve: 'no', publish: 'no' },
-          'image/jp2' => { preserve: 'no', shelve: 'yes', publish: 'yes' },
-          'image/jpeg' => { preserve: 'yes', shelve: 'no', publish: 'no' },
-          'audio/wav' => { preserve: 'yes', shelve: 'no', publish: 'no' },
-          'audio/x-wav' => { preserve: 'yes', shelve: 'no', publish: 'no' },
-          'audio/mp3' => { preserve: 'no', shelve: 'yes', publish: 'yes' },
-          'audio/mpeg' => { preserve: 'no', shelve: 'yes', publish: 'yes' },
-          'application/pdf' => { preserve: 'yes', shelve: 'yes', publish: 'yes' },
-          'plain/text' => { preserve: 'yes', shelve: 'yes', publish: 'yes' },
-          'text/plain' => { preserve: 'yes', shelve: 'yes', publish: 'yes' },
-          'image/png' => { preserve: 'yes', shelve: 'yes', publish: 'no' },
-          'application/zip' => { preserve: 'yes', shelve: 'no', publish: 'no' },
-          'application/json' => { preserve: 'yes', shelve: 'yes', publish: 'yes' }
-        }.freeze
-
         # @param [Symbol] bundle
         # @param [Assembly::ObjectFile] file
         # @param style

--- a/lib/dor/assembly/item.rb
+++ b/lib/dor/assembly/item.rb
@@ -28,12 +28,6 @@ module Dor
       def item?
         cocina_model.dro?
       end
-
-      # @param [String] the mimetype of the file
-      # @return [Hash<Symbol,String>] the default file attributes hash
-      def self.default_file_attributes(mimetype)
-        ContentMetadata::File::ATTRIBUTES_FOR_TYPE.fetch(mimetype) { ContentMetadata::File::ATTRIBUTES_FOR_TYPE.fetch('default') }
-      end
     end
   end
 end

--- a/lib/dor/assembly/stub_content_metadata_parser.rb
+++ b/lib/dor/assembly/stub_content_metadata_parser.rb
@@ -19,7 +19,7 @@ module Dor
             obj_file = ::Assembly::ObjectFile.new(File.join(path_finder.path_to_content_folder, filename(file)))
             # set the default file attributes here (instead of in the create_content_metadata step in the gem below)
             #  so they can overridden/added to by values coming from the stub content metadata
-            obj_file.file_attributes = Dor::Assembly::Item.default_file_attributes(obj_file.mimetype).merge(stub_file_attributes(file))
+            obj_file.file_attributes = Dor::FileSets.default_administrative_attributes(obj_file.mimetype).merge(stub_file_attributes(file))
             obj_file.label = resource_label(resource)
             obj_file
           end


### PR DESCRIPTION


## Why was this change made? 🤔
Because it's also used by accessioning


## How was this change tested? 🤨
CI
