### PR TITLE
Update assembly-objectfile to 2.1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'activesupport', '~> 7.0'
 gem 'assembly-image', '~> 2.0' # ruby-vips is used by 2.0.0 for improved image processing
-gem 'assembly-objectfile', '~> 2.0'
+gem 'assembly-objectfile', '~> 2.1'
 gem 'config', '~> 2.2'
 gem 'dor-services-client', '~> 12.0'
 gem 'dor-workflow-client', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -252,7 +252,7 @@ GEM
       patience_diff
     thor (1.2.1)
     tilt (2.0.10)
-    tzinfo (2.0.4)
+    tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.2.0)
     webmock (3.14.0)
@@ -268,7 +268,7 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 7.0)
   assembly-image (~> 2.0)
-  assembly-objectfile (~> 2.0)
+  assembly-objectfile (~> 2.1)
   byebug
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)


### PR DESCRIPTION
## Why was this change made? 🤔

Latest assembly-objectfile gem is needed to avoid errors with accessioning ISO files.  Analog to https://github.com/sul-dlss/pre-assembly/pull/1061/files which bumped this gem for pre-assembly.

Should fix errors like this: https://app.honeybadger.io/projects/52894/faults/86871920, in objects like this: https://argo.stanford.edu/view/druid:pk733ww1123 

## How was this change tested? 🤨

Existing tests