### PR TITLE
Include presentation metadata only for select image types

### DIFF
--- a/lib/robots/dor_repo/assembly/exif_collect.rb
+++ b/lib/robots/dor_repo/assembly/exif_collect.rb
@@ -32,7 +32,10 @@ module Robots
               file[:size] = object_file.filesize if !file[:size] || file[:size].zero?
               file[:hasMimeType] ||= object_file.mimetype
 
-              next unless object_file.image?
+              # NOTE: Only include height/width presentation information for
+              #       "valid" images as determined by the assembly-objectfile gem:
+              #       TIFF, PNG, JPEG, JP2
+              next unless object_file.valid_image?
 
               file[:presentation] = { height: object_file.exif.imageheight, width: object_file.exif.imagewidth }
             end

--- a/spec/robots/assembly/exif_collect_spec.rb
+++ b/spec/robots/assembly/exif_collect_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
 
       before do
         allow(Assembly::ObjectFile).to receive(:new).and_return(
-          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_468, image?: true, exif: exif),
-          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_472, image?: true, exif: exif),
-          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_472, image?: true, exif: exif)
+          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_468, valid_image?: true, exif: exif),
+          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_472, valid_image?: true, exif: exif),
+          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_472, valid_image?: true, exif: exif)
         )
       end
 
@@ -164,8 +164,8 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
 
       before do
         allow(Assembly::ObjectFile).to receive(:new).and_return(
-          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_468, image?: true, exif: exif),
-          instance_double(Assembly::ObjectFile, mimetype: 'image/jp2', filesize: 465, image?: false)
+          instance_double(Assembly::ObjectFile, mimetype: 'image/tiff', filesize: 63_468, valid_image?: true, exif: exif),
+          instance_double(Assembly::ObjectFile, mimetype: 'image/jp2', filesize: 465, valid_image?: false)
         )
       end
 


### PR DESCRIPTION
# Why was this change made? 🤔

Fixes sul-dlss/assembly-objectfile#102

This commit further restricts which images receive presentation information (height/width) gathered by exif to the types currently returned by the existing `#valid_image?` method in the public API. These include TIFF, PNG, JPEG, and JP2. This prevents recording (perhaps bogus or nil) presentation information for image types that are unsupported for presentation elsewhere in SDR (e.g., the sul-embed service).


# How was this change tested? 🤨


CI and tested successfully in a deployed env by @andrewjbtw
