### PR TITLE
Turn off publish and shelve when dark in missed spots

### DIFF
--- a/lib/dor/assembly/content_metadata_from_stub/structural_builder.rb
+++ b/lib/dor/assembly/content_metadata_from_stub/structural_builder.rb
@@ -34,11 +34,11 @@ module Dor
         end
         private_class_method :find_common_path
 
-        def self.administrative(file_attributes)
+        def self.administrative(file_attributes, object_access)
           {
             sdrPreserve: file_attributes[:preserve] == 'yes',
-            publish: file_attributes[:publish] == 'yes',
-            shelve: file_attributes[:shelve] == 'yes'
+            publish: object_access.view == 'dark' ? false : file_attributes[:publish] == 'yes',
+            shelve: object_access.view == 'dark' ? false : file_attributes[:shelve] == 'yes'
           }
         end
         private_class_method :administrative
@@ -82,7 +82,7 @@ module Dor
             label: filename,
             filename: filename,
             version: cocina_model.version,
-            administrative: administrative(assembly_objectfile.file_attributes),
+            administrative: administrative(assembly_objectfile.file_attributes, cocina_model.access),
             access: Dor::FileSets.file_access(cocina_model.access)
           }
           file_attributes[:use] = assembly_objectfile.file_attributes[:role] if assembly_objectfile.file_attributes[:role]

--- a/lib/dor/file_sets.rb
+++ b/lib/dor/file_sets.rb
@@ -120,7 +120,7 @@ module Dor
     end
 
     def file_administrative(node)
-      default_administrative = self.class.default_administrative_attributes(node['mimetype'])
+      default_administrative = self.class.default_administrative_attributes(node['mimetype'], object_access: dro_access)
 
       publish = (node['publish'] || default_administrative[:publish]) == 'yes'
       preserve = (node['preserve'] || default_administrative[:preserve]) == 'yes'

--- a/spec/fixtures/workspace/ab/123/cd/4567/content_metadata.xml
+++ b/spec/fixtures/workspace/ab/123/cd/4567/content_metadata.xml
@@ -4,14 +4,14 @@
       <attr name="pageNumber">3</attr>
       <attr name="pageLabel">ii</attr>
       <attr name="googlePageTag">IMAGE_ON_PAGE,IMPLICIT_PAGE_NUMBER</attr>
-      <file id="00000001.jp2" format="JPEG2000" mimetype="image/jp2" size="169627" shelve="no" deliver="no" preserve="yes">
+      <file id="00000001.jp2" format="JPEG2000" mimetype="image/jp2" size="169627" shelve="no" publish="yes" preserve="yes">
          <imageData height="800" width="1200"/>
          <location type="url">http://service/druid/00000001.jp2</location>
          <location type="path">/dor/workspace/...</location>
          <checksum type="md5">56dd37697f05073168b9b58ddaccad0a</checksum>
          <checksum type="sha1">884b7650725011de8a390800200c9a66</checksum>
       </file>
-      <file id="1.html" format="text" mimetype="text/html" encoding="UTF-8" dataType="hocr" size="734" shelve="yes" deliver="no" preserve="yes">
+      <file id="1.html" format="text" mimetype="text/html" encoding="UTF-8" dataType="hocr" size="734" shelve="yes" publish="no" preserve="yes">
          <location type="url">http://service/druid/00000001.jp2</location>
          <checksum type="md5">60dd37697f05073168b9b58ddaccad0a</checksum>
          <checksum type="sha1">324b7650725011de8a390800200c9a66</checksum>
@@ -22,14 +22,14 @@
        <attr name="pageNumber">3</attr>
        <attr name="pageLabel">ii</attr>
        <attr name="googlePageTag">IMAGE_ON_PAGE,IMPLICIT_PAGE_NUMBER</attr>
-       <file id="00000001.jp2" format="JPEG2000" mimetype="image/jp2" size="169627" shelve="no" deliver="no" preserve="yes">
+       <file id="00000001.jp2" format="JPEG2000" mimetype="image/jp2" size="169627" shelve="no" publish="yes" preserve="yes">
           <imageData height="800" width="1200"/>
           <location type="url">http://service/druid/00000001.jp2</location>
           <location type="path">/dor/workspace/...</location>
           <checksum type="md5">56dd37697f05073168b9b58ddaccad0a</checksum>
           <checksum type="sha1">884b7650725011de8a390800200c9a66</checksum>
        </file>
-       <file id="2.html" format="text" mimetype="text/html" encoding="UTF-8" dataType="hocr" size="734" shelve="yes" deliver="no" preserve="yes">
+       <file id="2.html" format="text" mimetype="text/html" encoding="UTF-8" dataType="hocr" size="734" shelve="yes" publish="no" preserve="yes">
           <location type="url">http://service/druid/00000001.jp2</location>
           <checksum type="md5">60dd37697f05073168b9b58ddaccad0a</checksum>
           <checksum type="sha1">324b7650725011de8a390800200c9a66</checksum>

--- a/spec/lib/dor/assembly/content_metadata_from_stub/structural_builder_spec.rb
+++ b/spec/lib/dor/assembly/content_metadata_from_stub/structural_builder_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     version: 1,
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
-                                                    administrative: { publish: true, sdrPreserve: true, shelve: true } }] } },
+                                                    administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
                        { type: 'https://cocina.sul.stanford.edu/models/resources/image',
                          externalIdentifier: 'nx288wh8889_3',
                          label: 'Image 3',
@@ -268,7 +268,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     version: 1,
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
-                                                    administrative: { publish: true, sdrPreserve: false, shelve: false } }] } },
+                                                    administrative: { publish: false, sdrPreserve: false, shelve: false } }] } },
                        { type: 'https://cocina.sul.stanford.edu/models/resources/image',
                          externalIdentifier: 'nx288wh8889_2',
                          label: 'Image 2',
@@ -280,7 +280,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     version: 1,
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
-                                                    administrative: { publish: true, sdrPreserve: true, shelve: true } }] } }],
+                                                    administrative: { publish: false, sdrPreserve: true, shelve: false } }] } }],
             hasMemberOrders: [],
             isMemberOf: [] }
         end

--- a/spec/robots/accession/content_metadata_spec.rb
+++ b/spec/robots/accession/content_metadata_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe Robots::DorRepo::Accession::ContentMetadata do
         end
 
         context 'with dark access' do
-          it 'builds the structual metadata and casts files to preserve only' do
+          let(:access) { { view: 'dark', download: 'none' } }
+
+          it 'builds the structural metadata and casts files to preserve only' do
             perform
 
             expect(object_client).to have_received(:update).with(params: Cocina::Models::DRO) do |model|
@@ -50,7 +52,7 @@ RSpec.describe Robots::DorRepo::Accession::ContentMetadata do
         context 'with non-dark access' do
           let(:access) { { view: 'world', download: 'stanford' } }
 
-          it 'builds a the structual metadata and retains the original publish/shelve/preserve' do
+          it 'builds the structural metadata and retains the original publish/shelve/preserve' do
             perform
 
             expect(object_client).to have_received(:update).with(params: Cocina::Models::DRO) do |model|

--- a/spec/test_input/bb/111/bb/5555/stubContentMetadata.xml
+++ b/spec/test_input/bb/111/bb/5555/stubContentMetadata.xml
@@ -8,7 +8,7 @@
    <resource>
       <label>optional page 2 label</label>
       <file name="page2.tif"/>
-      <file name="some_filename.txt" role="transcription"/>
+      <file name="some_filename.txt" role="transcription"  publish="yes" preserve="yes" shelve="yes"/>
    </resource>
    <resource>
       <file name="whole_book.pdf" preserve="no" random_ignored_attribute="cheeseburger"/>


### PR DESCRIPTION
## Why was this change made? 🤔

This commit patches more code paths that set the publish and shelve attributes, ensuring that dark objects have *no* files set to publish or shelve EVEN IF the stub content metadata says so. This is a problem with some Goobi objects, and this patch allows those items to continue accessioning.


## How was this change tested? 🤨

CI, and will test in a deployed env with @andrewjbtw
