### PR TITLE
Skip update-doi robot when object is in graveyard APO

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,3 +1,7 @@
+# Graveyard Admin Policy
+graveyard_admin_policy:
+  druid: 'druid:kg712km1576' # This value varies by environment and is managed in shared_configs
+
 dor_services:
   url:  'https://dor-services-test.stanford.test'
   token: secret-token

--- a/lib/robots/dor_repo/accession/update_doi.rb
+++ b/lib/robots/dor_repo/accession/update_doi.rb
@@ -17,6 +17,7 @@ module Robots
 
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'DOIs are not supported on non-Item objects') unless cocina_object.dro?
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'Object does not have a DOI') unless cocina_object.identification&.doi
+          return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'Object belongs to the SDR graveyard APO') if cocina_object.administrative.hasAdminPolicy == Settings.graveyard_admin_policy.druid
 
           # This is an asynchronous result. It will set the publish workflow to complete when it is done.
           object_client.update_doi_metadata

--- a/spec/robots/accession/update_doi_spec.rb
+++ b/spec/robots/accession/update_doi_spec.rb
@@ -44,6 +44,26 @@ RSpec.describe Robots::DorRepo::Accession::UpdateDoi do
           perform
           expect(object_client).to have_received(:update_doi_metadata)
         end
+
+        context 'when in the graveyard APO' do
+          let(:object) do
+            build(:dro).new(
+              identification: {
+                doi: '10.25740/bc123df4567',
+                sourceId: 'sul:1234'
+              },
+              administrative: {
+                hasAdminPolicy: Settings.graveyard_admin_policy.druid
+              }
+            )
+          end
+
+          it 'does not call the API' do
+            expect(perform.status).to eq('skipped')
+            expect(perform.note).to eq('Object belongs to the SDR graveyard APO')
+            expect(object_client).not_to have_received(:update_doi_metadata)
+          end
+        end
       end
 
       context 'without a doi' do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes sul-dlss/happy-heron#2750

This commit adds a new check to the accessioning robot: if the object is in the SDR Graveyard APO, skip the step entirely. This has the effect of making sure not to publish DOIs of decommissioned (soft-deleted) objects.


## How was this change tested? 🤨

CI, + successfully tested in stage
