### PR TITLE
Adds basepath to techmd call.

### DIFF
--- a/lib/preserved_file_uris.rb
+++ b/lib/preserved_file_uris.rb
@@ -22,13 +22,16 @@ class PreservedFileUris
     @filepaths ||= filepath_uris.map(&:filepath)
   end
 
+  def content_dir
+    @content_dir ||= DruidTools::Druid.new(druid, local_workspace_root).content_dir(false)
+  end
+
   private
 
   attr_reader :obj, :druid
 
-  def content_dir
-    workspace = DruidTools::Druid.new(druid, File.absolute_path(Settings.sdr.local_workspace_root))
-    workspace.content_dir(false)
+  def local_workspace_root
+    @local_workspace_root ||= File.absolute_path(Settings.sdr.local_workspace_root)
   end
 
   def filepath_uris

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -23,7 +23,7 @@ module Robots
           # skip if metadata-only change
           return LyberCore::Robot::ReturnState.new(status: :skipped, note: 'change is metadata-only') if metadata_only?(file_uris.filepaths)
 
-          invoke_techmd_service(druid, file_uris.uris, lane_id(druid))
+          invoke_techmd_service(druid, file_uris, lane_id(druid))
 
           LyberCore::Robot::ReturnState.new(status: :noop, note: 'Initiated technical metadata generation from technical-metadata-service.')
         end
@@ -31,8 +31,8 @@ module Robots
         private
 
         def invoke_techmd_service(druid, file_uris, lane_id)
-          files = file_uris.map { |uri_md5| { uri: uri_md5.uri, md5: uri_md5.md5 } }
-          req = JSON.generate(druid: druid, files: files, 'lane-id': lane_id)
+          files = file_uris.uris.map { |uri_md5| { uri: uri_md5.uri, md5: uri_md5.md5 } }
+          req = JSON.generate(druid: druid, files: files, 'lane-id': lane_id, basepath: file_uris.content_dir)
           resp = Faraday.post("#{Settings.tech_md_service.url}/v1/technical-metadata", req,
                               'Content-Type' => 'application/json',
                               'Authorization' => "Bearer #{Settings.tech_md_service.token}")

--- a/spec/lib/preserved_file_uris_spec.rb
+++ b/spec/lib/preserved_file_uris_spec.rb
@@ -52,6 +52,9 @@ RSpec.describe PreservedFileUris do
     )
   end
 
+  let(:filename1) { 'folder1PuSu/story1u.txt' }
+  let(:filename2) { 'folder1PuSu/story2u.txt' }
+
   before do
     # For File URIs, need to use absolute paths
     allow(Settings.sdr).to receive(:local_workspace_root).and_return(workspace)
@@ -61,9 +64,6 @@ RSpec.describe PreservedFileUris do
     let(:uris) { described_class.new(druid, object).uris }
 
     let(:prefix) { "file://#{root}/dd/116/zh/0343/dd116zh0343/content/" }
-
-    let(:filename1) { 'folder1PuSu/story1u.txt' }
-    let(:filename2) { 'folder1PuSu/story2u.txt' }
 
     it {
       expect(uris).to eq [
@@ -76,10 +76,14 @@ RSpec.describe PreservedFileUris do
   describe '.filepaths' do
     subject { described_class.new(druid, object).filepaths }
 
-    let(:filename1) { 'folder1PuSu/story1u.txt' }
-    let(:filename2) { 'folder1PuSu/story2u.txt' }
     let(:prefix) { "#{root}/dd/116/zh/0343/dd116zh0343/content/" }
 
     it { is_expected.to eq ["#{prefix}#{filename1}", "#{prefix}#{filename2}"] }
+  end
+
+  describe '.content_dir' do
+    subject { described_class.new(druid, object).content_dir }
+
+    it { is_expected.to eq "#{root}/dd/116/zh/0343/dd116zh0343/content" }
   end
 end

--- a/spec/robots/accession/technical_metadata_spec.rb
+++ b/spec/robots/accession/technical_metadata_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe Robots::DorRepo::Accession::TechnicalMetadata do
               md5: '123'
             }
           ],
-          'lane-id' => 'low'
+          'lane-id' => 'low',
+          basepath: "#{workspace}/dd/116/zh/0343/dd116zh0343/content"
         }
       end
 


### PR DESCRIPTION
refs https://github.com/sul-dlss/technical-metadata-service/issues/398

## Why was this change made? 🤔
To call techmd service with the now required basepath param.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit
