### PR TITLE
Retry goobi-notify immediately if we get an apparently bogus error

### DIFF
--- a/lib/robots/dor_repo/goobi/goobi_notify.rb
+++ b/lib/robots/dor_repo/goobi/goobi_notify.rb
@@ -15,6 +15,9 @@ module Robots
         # @param [String] druid -- the Druid identifier for the object to process
         def perform_work
           object_client.notify_goobi
+        rescue Dor::Services::Client::BadRequestError => e
+          # NOTE: We don't know why this error is occurring, but the condition seems to go away momentarily, so retry automatically.
+          retry if e.message.match?(/Process template Example_Workflow does not exist/)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

Connects to #1043

This commit allows the goobi-notify robot to retry automatically when DSC raises a bad request error with a particular body.


## How was this change tested? 🤨

CI
