### PR TITLE
add 4 new worker VMs to the prod cap deploy config

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -4,6 +4,10 @@ server 'common-accessioning-prod-a.stanford.edu', user: 'lyberadmin', roles: %w[
 server 'common-accessioning-prod-b.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 server 'common-accessioning-prod-c.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 server 'common-accessioning-prod-d.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
+server 'common-accessioning-prod-e.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
+server 'common-accessioning-prod-f.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
+server 'common-accessioning-prod-g.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
+server 'common-accessioning-prod-h.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 
 Capistrano::OneTimeKey.generate_one_time_key!
 


### PR DESCRIPTION
in conjunction with a change to the prod sidekiq configs that halves the number of worker threads on each VM, this will allow us to effectively double the compute resources given to each worker thread while keeping the total number of worker threads the same.

see https://github.com/sul-dlss/common-accessioning/issues/1069

## Why was this change made? 🤔

part of #1069

## How was this change tested? 🤨

🙊 

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


