### PR TITLE
update-marc step expects to queue a job (in dor-services-app) that actually does the work of updating the marc in Folio

### DIFF
--- a/lib/robots/dor_repo/release/update_marc.rb
+++ b/lib/robots/dor_repo/release/update_marc.rb
@@ -13,8 +13,12 @@ module Robots
         #
         # @param [String] druid -- the Druid identifier for the object to process
         def perform_work
-          logger.debug "update_marc working on #{druid}"
+          logger.debug "update_marc handing off to dor-services-app job for update to #{druid}"
           object_client.update_marc_record
+
+          # Since the actual update work is completed by dor-services-app in a job,
+          # workflow logging (marking step completed or failed) is done there.
+          LyberCore::ReturnState.new(status: :noop, note: 'Initiated update_marc_record API call.')
         end
       end
     end

--- a/spec/robots/release/update_marc_spec.rb
+++ b/spec/robots/release/update_marc_spec.rb
@@ -6,11 +6,21 @@ RSpec.describe Robots::DorRepo::Release::UpdateMarc do
   let(:druid) { 'bb222cc3333' }
   let(:robot) { described_class.new }
 
-  it 'posts to the update marc record api' do
+  before do
     stub_request(:post, 'https://dor-services-test.stanford.test/v1/objects/bb222cc3333/update_marc_record')
       .to_return(status: 201, body: '', headers: {})
+  end
+
+  it 'posts to the update marc record api' do
     # NOTE: Until I wrapped the `#perform` call in the `expect...not_to raise_error`,
     #       there were no expectations in this spec. What do we *really* expect here?
     expect { test_perform(robot, druid) }.not_to raise_error
+  end
+
+  it 'returns a noop ReturnState' do
+    result = test_perform(robot, druid)
+    expect(result).to be_a(LyberCore::ReturnState)
+    expect(result.status).to eq('noop')
+    expect(result.note).to eq('Initiated update_marc_record API call.')
   end
 end


### PR DESCRIPTION
done as a job because it could take a while to complete, and because we're single threading the jobs to prevent concurrent updates to work around mysterious Folio issues

## Why was this change made? 🤔

part of the workaround for https://github.com/sul-dlss/dor-services-app/issues/4454

see also https://stanfordlib.slack.com/archives/C09M7P91R/p1691769829144859?thread_ts=1691702965.586219&cid=C09M7P91R

_TODO_: add a helpful note about this in cap deploy configs?

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


