### PR TITLE
Items do not skip update-orcid-work

### DIFF
--- a/lib/robots/dor_repo/accession/update_orcid_work.rb
+++ b/lib/robots/dor_repo/accession/update_orcid_work.rb
@@ -11,17 +11,10 @@ module Robots
 
         def perform_work
           return LyberCore::ReturnState.new(status: :skipped, note: 'Orcid works are not supported on non-Item objects') unless cocina_object.dro?
-          return LyberCore::ReturnState.new(status: :skipped, note: 'Object does not cited contributors with Orcid ids') unless has_orcid_ids?
           return LyberCore::ReturnState.new(status: :skipped, note: 'Object belongs to the SDR graveyard APO') if cocina_object.administrative.hasAdminPolicy == Settings.graveyard_admin_policy.druid
 
           # This is an asynchronous operation.
           object_client.update_orcid_work
-        end
-
-        private
-
-        def has_orcid_ids?
-          SulOrcidClient::CocinaSupport.cited_orcidids(cocina_object.description).any?
         end
       end
     end

--- a/spec/robots/accession/update_orcid_work_spec.rb
+++ b/spec/robots/accession/update_orcid_work_spec.rb
@@ -35,14 +35,9 @@ RSpec.describe Robots::DorRepo::Accession::UpdateOrcidWork do
           build(:dro)
         end
 
-        before do
-          allow(SulOrcidClient::CocinaSupport).to receive(:cited_orcidids).and_return(['https://sandbox.orcid.org/0000-0003-3437-349X'])
-        end
-
         it 'calls the api' do
           perform
           expect(object_client).to have_received(:update_orcid_work)
-          expect(SulOrcidClient::CocinaSupport).to have_received(:cited_orcidids).with(object.description)
         end
 
         context 'when in the graveyard APO' do
@@ -54,28 +49,11 @@ RSpec.describe Robots::DorRepo::Accession::UpdateOrcidWork do
             )
           end
 
-          before do
-            allow(SulOrcidClient::CocinaSupport).to receive(:cited_orcidids).and_return(['https://sandbox.orcid.org/0000-0003-3437-349X'])
-          end
-
           it 'does not call the API' do
             expect(perform.status).to eq('skipped')
             expect(perform.note).to eq('Object belongs to the SDR graveyard APO')
             expect(object_client).not_to have_received(:update_orcid_work)
           end
-        end
-      end
-
-      context 'without a cited orcid id' do
-        let(:object) { build(:dro) }
-
-        before do
-          allow(SulOrcidClient::CocinaSupport).to receive(:cited_orcidids).and_return([])
-        end
-
-        it 'does not call the api' do
-          expect(perform.status).to eq 'skipped'
-          expect(object_client).not_to have_received(:update_orcid_work)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔
Send all items through update-orcid-work step since we need to make sure removed ORCID authors' works get updated in ORCID. 

## How was this change tested? 🤨
Unit and deploy/testing to stage, integration tests

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


