### PR TITLE
Re-use existing checksums for targeted file update.

### DIFF
--- a/lib/robots/dor_repo/assembly/checksum_compute.rb
+++ b/lib/robots/dor_repo/assembly/checksum_compute.rb
@@ -12,6 +12,7 @@ module Robots
           return unless check_assembly_item
 
           cocina_model = assembly_item.cocina_model
+          logger.info("Computing checksums for #{druid}")
           file_sets = compute_checksums(assembly_item, cocina_model)
 
           # Save the modified metadata
@@ -22,36 +23,44 @@ module Robots
         private
 
         def compute_checksums(assembly_item, cocina_model)
-          logger.info("Computing checksums for #{druid}")
           file_sets = cocina_model.structural.to_h.fetch(:contains) # make this a mutable hash
 
           file_sets.each do |file_set|
             files = file_set.dig(:structural, :contains)
             files.each do |file|
-              object_file = ::Assembly::ObjectFile.new(assembly_item.path_finder.path_to_content_file(file.fetch(:filename)))
-
-              # compute checksums
-              checksums = { md5: object_file.md5, sha1: object_file.sha1 }
-
-              # find any existing checksum nodes
-              md5_node = file[:hasMessageDigests].find { |digest| digest[:type] == 'md5' }
-              sha1_node = file[:hasMessageDigests].find { |digest| digest[:type] == 'sha1' }
-
-              # if we have any existing checksum nodes, compare them all against the checksums we just computed, and raise an error if any fail
-              if md5_node
-                raise %(Checksums disagree: type="md5", file="#{file[:filename]}", computed="#{checksums[:md5]}, provided="#{md5_node[:digest]}".) unless checksums_equal?(md5_node, checksums[:md5])
-              else
-                file[:hasMessageDigests] << { type: 'md5', digest: checksums[:md5] }
-              end
-              if sha1_node
-                raise %(Checksums disagree: type="sha1", file="#{file[:filename]}", computed="#{checksums[:sha1]}", provided="#{sha1_node[:digest]}".) unless checksums_equal?(sha1_node, checksums[:sha1])
-              else
-                file[:hasMessageDigests] << { type: 'sha1', digest: checksums[:sha1] }
-              end
+              compute_checksum(assembly_item, file)
             end
           end
 
           file_sets
+        end
+
+        def compute_checksum(assembly_item, file)
+          # find any existing checksum nodes
+          md5_node = file[:hasMessageDigests].find { |digest| digest[:type] == 'md5' }
+          sha1_node = file[:hasMessageDigests].find { |digest| digest[:type] == 'sha1' }
+
+          filepath = assembly_item.path_finder.path_to_content_file(file.fetch(:filename))
+
+          # File is not changing, so use existing checksums
+          return if md5_node && sha1_node && !File.exist?(filepath)
+
+          object_file = ::Assembly::ObjectFile.new(filepath)
+
+          # compute checksums
+          checksums = { md5: object_file.md5, sha1: object_file.sha1 }
+
+          # if we have any existing checksum nodes, compare them all against the checksums we just computed, and raise an error if any fail
+          if md5_node
+            raise %(Checksums disagree: type="md5", file="#{file[:filename]}", computed="#{checksums[:md5]}, provided="#{md5_node[:digest]}".) unless checksums_equal?(md5_node, checksums[:md5])
+          else
+            file[:hasMessageDigests] << { type: 'md5', digest: checksums[:md5] }
+          end
+          if sha1_node
+            raise %(Checksums disagree: type="sha1", file="#{file[:filename]}", computed="#{checksums[:sha1]}", provided="#{sha1_node[:digest]}".) unless checksums_equal?(sha1_node, checksums[:sha1])
+          else
+            file[:hasMessageDigests] << { type: 'sha1', digest: checksums[:sha1] }
+          end
         end
 
         # compare existing checksum nodes with computed checksum, return false if there are any mismatches, otherwise return true

--- a/spec/robots/assembly/checksum_compute_spec.rb
+++ b/spec/robots/assembly/checksum_compute_spec.rb
@@ -86,6 +86,21 @@ RSpec.describe Robots::DorRepo::Assembly::ChecksumCompute do
                                                 version: 1,
                                                 hasMessageDigests: [],
                                                 access: { view: 'dark', download: 'none', controlledDigitalLending: false },
+                                                administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
+                   # This file does not exist in the workspace.
+                   { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                     externalIdentifier: 'bb222cc3333_4',
+                     label: 'Image 4',
+                     version: 1,
+                     structural: { contains: [{ type: 'https://cocina.sul.stanford.edu/models/file',
+                                                externalIdentifier: 'https://cocina.sul.stanford.edu/file/ced39e5f-ff5d-4b76-b688-22369e410f4c',
+                                                label: 'image114.tif',
+                                                filename: 'image114.tif',
+                                                size: 1234,
+                                                version: 1,
+                                                hasMessageDigests: [{ type: 'md5', digest: 'bd440802bd590ce0899dafecc5a5ab2c' },
+                                                                    { type: 'sha1', digest: '6d9f6dc2ca4fd3329619b54a2c6f99a08c088455' }],
+                                                access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                 administrative: { publish: false, sdrPreserve: true, shelve: false } }] } }],
         hasMemberOrders: [],
         isMemberOf: [] }
@@ -126,6 +141,16 @@ RSpec.describe Robots::DorRepo::Assembly::ChecksumCompute do
           {
             type: 'sha1',
             digest: '5c9f6dc2ca4fd3329619b54a2c6f99a08c088444'
+          }
+        ],
+        [
+          {
+            type: 'md5',
+            digest: 'bd440802bd590ce0899dafecc5a5ab2c'
+          },
+          {
+            type: 'sha1',
+            digest: '6d9f6dc2ca4fd3329619b54a2c6f99a08c088455'
           }
         ]
       ]


### PR DESCRIPTION
closes #1091

## Why was this change made? 🤔
With targeted file updates, a file may not exist in the workspace.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit
