### PR TITLE
Update dependencies for cocina-models update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     capistrano-one_time_key (0.1.0)
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
-    cocina-models (0.91.0)
+    cocina-models (0.91.1)
       activesupport
       deprecation
       dry-struct (~> 1.0)


### PR DESCRIPTION
# Why was this change made?

To allow dor_indexing_app to use stanford-mods, a small, backwards compatible change was made to cocina-models in PR https://github.com/sul-dlss/cocina-models/pull/623, resulting in release 0.91.1

# How was this change tested?

CI and integration tests will be run
