### PR TITLE
Change reset to a noop so DSA can set 'completed' when doing the actual work

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Naming/PredicateName:
 RSpec/MultipleExpectations:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
 RSpec/NestedGroups:
   Max: 5
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 7.0'
 gem 'assembly-image', '~> 2.0' # ruby-vips is used by 2.0.0 for improved image processing
 gem 'assembly-objectfile', '~> 2.1'
 gem 'config', '~> 2.2'
-gem 'dor-services-client', '~> 13.0'
+gem 'dor-services-client', '~> 13.1'
 gem 'dor-workflow-client', '~> 5.0'
 gem 'dry-struct', '~> 1.0'
 gem 'dry-types', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (13.0.1)
+    dor-services-client (13.1.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.91.0)
       deprecation
@@ -306,7 +306,7 @@ GEM
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
-    thor (1.2.2)
+    thor (1.3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -330,7 +330,7 @@ DEPENDENCIES
   capistrano-bundler (~> 1.1)
   config (~> 2.2)
   dlss-capistrano
-  dor-services-client (~> 13.0)
+  dor-services-client (~> 13.1)
   dor-workflow-client (~> 5.0)
   druid-tools (~> 2.1)
   dry-struct (~> 1.0)

--- a/lib/robots/dor_repo/accession/reset_workspace.rb
+++ b/lib/robots/dor_repo/accession/reset_workspace.rb
@@ -11,7 +11,11 @@ module Robots
         end
 
         def perform_work
-          object_client.workspace.reset
+          # Reset workspace is performed async by dor-services-app.
+          object_client.workspace.reset(workflow: 'accessionWF', lane_id:)
+
+          # dor-services-app will update the workflow step, do don't do it here.
+          LyberCore::ReturnState.new(status: :noop, note: 'Initiated reset API call.')
         end
       end
     end

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -25,9 +25,11 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
   describe '#perform' do
     subject(:perform) { test_perform(robot, druid) }
 
+    let(:return_status) { perform.status }
+
     context 'when there is no special dissemniation workflow' do
       it 'cleans up' do
-        perform
+        expect(return_status).to eq 'noop'
         expect(workspace_client).to have_received(:cleanup).with(workflow: 'accessionWF', lane_id: 'default')
       end
     end

--- a/spec/robots/dor_repo/accession/reset_workspace_spec.rb
+++ b/spec/robots/dor_repo/accession/reset_workspace_spec.rb
@@ -7,20 +7,22 @@ RSpec.describe Robots::DorRepo::Accession::ResetWorkspace do
   let(:robot) { described_class.new }
   let(:object_client) { instance_double(Dor::Services::Client::Object, workspace: workspace_client) }
   let(:workspace_client) { instance_double(Dor::Services::Client::Workspace, reset: nil) }
+  let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'default') }
+  let(:workflow_client) { instance_double(Dor::Workflow::Client, process:) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+    allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
   end
 
   describe '#perform' do
     subject(:perform) { test_perform(robot, druid) }
 
-    before do
-      perform
-    end
+    let(:return_status) { perform.status }
 
     it 'resets the workspace' do
-      expect(workspace_client).to have_received(:reset)
+      expect(return_status).to eq 'noop'
+      expect(workspace_client).to have_received(:reset).with(workflow: 'accessionWF', lane_id: 'default')
     end
   end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/4634

## Why was this change made? 🤔
To prevent the workflow from proceeding until reset is actually completed by DSA job.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit, stage
