### PR TITLE
Bump dor-services-client to 13.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (13.1.0)
+    dor-services-client (13.1.1)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.91.0)
       deprecation


### PR DESCRIPTION
# Why was this change made?

This commit bumps DSC to 13.1.1 to pick up a patch that surfaces more exception context when connections to DSA fail.

# How was this change tested?

CI
