### PR TITLE
Skip techmd for files that are not in workspace.

### DIFF
--- a/lib/preserved_file_uris.rb
+++ b/lib/preserved_file_uris.rb
@@ -35,7 +35,10 @@ class PreservedFileUris
   end
 
   def filepath_uris
-    @filepath_uris ||= filename_uris.map { |filename_uri| FilepathUri.new(File.join(content_dir, filename_uri.filename), filename_uri.uri) }
+    @filepath_uris ||= filename_uris
+                       .map { |filename_uri| FilepathUri.new(File.join(content_dir, filename_uri.filename), filename_uri.uri) }
+                       # Skip if file doesn't exist indicating it is not being changed.
+                       .select { |filepath_uri| File.exist?(filepath_uri.filepath) }
   end
 
   def filename_uris

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -19,7 +19,7 @@ module Robots
           file_uris = PreservedFileUris.new(druid, cocina_object)
 
           # skip if metadata-only change
-          return LyberCore::ReturnState.new(status: :skipped, note: 'change is metadata-only') if metadata_only?(file_uris.filepaths)
+          return LyberCore::ReturnState.new(status: :skipped, note: 'change is metadata-only') if file_uris.filepaths.empty?
 
           invoke_techmd_service(file_uris)
 
@@ -35,11 +35,6 @@ module Robots
                               'Content-Type' => 'application/json',
                               'Authorization' => "Bearer #{Settings.tech_md_service.token}")
           raise "Technical-metadata-service returned #{resp.status} when requesting techmd for #{druid}: #{resp.body}" unless resp.status == 200
-        end
-
-        def metadata_only?(filepaths)
-          # Assume metadata only if no files exist
-          filepaths.all? { |filepath| !File.exist?(filepath) }
         end
       end
     end

--- a/spec/lib/preserved_file_uris_spec.rb
+++ b/spec/lib/preserved_file_uris_spec.rb
@@ -27,8 +27,8 @@ RSpec.describe PreservedFileUris do
               },
               {
                 externalIdentifier: '222-2',
-                label: 'not-this.pdf',
-                filename: 'not-this.pdf',
+                label: 'not preserved',
+                filename: 'folder1PuSu/story5a.txt',
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 access: {},
@@ -44,6 +44,16 @@ RSpec.describe PreservedFileUris do
                 access: {},
                 administrative: { publish: true, sdrPreserve: true, shelve: true },
                 hasMessageDigests: []
+              },
+              {
+                externalIdentifier: '222-2',
+                label: 'not in workspace',
+                filename: 'not-in-workdspace.pdf',
+                type: Cocina::Models::ObjectType.file,
+                version: 1,
+                access: {},
+                administrative: { publish: true, sdrPreserve: true, shelve: true },
+                hasMessageDigests: []
               }
             ]
           }
@@ -53,7 +63,7 @@ RSpec.describe PreservedFileUris do
   end
 
   let(:filename1) { 'folder1PuSu/story1u.txt' } # rubocop:disable RSpec/IndexedLet
-  let(:filename2) { 'folder1PuSu/story2u.txt' } # rubocop:disable RSpec/IndexedLet
+  let(:filename2) { 'folder1PuSu/story2rr.txt' } # rubocop:disable RSpec/IndexedLet
 
   before do
     # For File URIs, need to use absolute paths


### PR DESCRIPTION
closes https://github.com/sul-dlss/technical-metadata-service/issues/485

## Why was this change made? 🤔
To handle the case in which files are omitted from the workspace because they are not changing.

Previously, techmd service was being told to generate techmd for them, but they didn't exist.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit