### PR TITLE
unpin 3 gems: config, druid-tools and sul_orcid_client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,22 +6,21 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'activesupport', '~> 7.0'
 gem 'assembly-image', '~> 2.0' # ruby-vips is used by 2.0.0 for improved image processing
 gem 'assembly-objectfile', '~> 2.1'
-gem 'config', '~> 2.2'
+gem 'config'
 gem 'dor-services-client', '~> 14.0'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'dry-struct', '~> 1.0'
 gem 'dry-types', '~> 1.1'
-gem 'druid-tools', '~> 2.1'
+gem 'druid-tools'
 gem 'honeybadger'
 gem 'lyber-core', '~> 7.3'
 gem 'nokogiri'
 gem 'preservation-client'
 gem 'pry'
-gem 'pry-byebug', platform: %i[ruby_20 ruby_21]
 gem 'rake'
 gem 'sidekiq', '~> 7.0'
 gem 'slop'
-gem 'sul_orcid_client', '~> 0.3'
+gem 'sul_orcid_client'
 gem 'zeitwerk', '~> 2.1'
 
 source 'https://gems.contribsys.com/' do
@@ -44,6 +43,7 @@ end
 
 group :development, :test do
   gem 'byebug'
+  gem 'pry-byebug', platform: %i[ruby_20 ruby_21]
   gem 'rubocop'
   gem 'rubocop-rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -336,11 +336,11 @@ DEPENDENCIES
   byebug
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
-  config (~> 2.2)
+  config
   dlss-capistrano
   dor-services-client (~> 14.0)
   dor-workflow-client (~> 7.0)
-  druid-tools (~> 2.1)
+  druid-tools
   dry-struct (~> 1.0)
   dry-types (~> 1.1)
   equivalent-xml
@@ -359,7 +359,7 @@ DEPENDENCIES
   sidekiq-pro!
   simplecov
   slop
-  sul_orcid_client (~> 0.3)
+  sul_orcid_client
   webmock
   zeitwerk (~> 2.1)
 


### PR DESCRIPTION
## Why was this change made? 🤔

let's not pin gems without a reason

## How was this change tested? 🤨

I ran integration tests for every type of object / set of robots;  all passed.

