### PR TITLE
Accession workflow:  remove noise comments

### DIFF
--- a/lib/robots/dor_repo/accession/content_metadata.rb
+++ b/lib/robots/dor_repo/accession/content_metadata.rb
@@ -4,15 +4,14 @@ module Robots
   module DorRepo
     module Accession
       # Creates structural metadata based on contentMetadata.xml
-      # Needed by https://github.com/sul-dlss/gis-robot-suite/blob/main/lib/robots/dor_repo/gis_assembly/generate_content_metadata.rb
-      # and https://github.com/sul-dlss/was_robot_suite/blob/2575d1d43e3c99a7e6cef28886b433f5a41e14ad/lib/robots/dor_repo/was_seed_preassembly/content_metadata_generator.rb#L12-L13
+      # Needed by https://github.com/sul-dlss/was_robot_suite/blob/main/lib/robots/dor_repo/was_seed_preassembly/content_metadata_generator.rb#L12-L13
       class ContentMetadata < LyberCore::Robot
         def initialize
           super('accessionWF', 'content-metadata')
         end
 
         def perform_work
-          # Objects that aren't items/DROs do not have content metadata attached
+          # Objects that aren't items/DROs do not have files
           return unless cocina_object.dro?
 
           path = druid_object.find_metadata('contentMetadata.xml')

--- a/lib/robots/dor_repo/accession/end_accession.rb
+++ b/lib/robots/dor_repo/accession/end_accession.rb
@@ -11,11 +11,10 @@ module Robots
         def perform_work
           current_version = object_client.version.current
 
-          # Search for the specialized workflow
+          # Is there a specialized dissemination workflow?  (used by web archive workflow)
           next_dissemination_wf = special_dissemination_wf
           workflow_service.create_workflow_by_name(druid, next_dissemination_wf, version: current_version, lane_id:) if next_dissemination_wf.present?
 
-          # Call cleanup
           # Note that this used to be handled by the disseminationWF, which is no longer used.
           object_client.workspace.cleanup(workflow: 'accessionWF', lane_id:)
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated cleanup API call.')
@@ -23,7 +22,7 @@ module Robots
 
         private
 
-        # This returns any optional workflow such as wasDisseminationWF
+        # This returns any optional dissemination workflow such as wasDisseminationWF
         def special_dissemination_wf
           apo_id = cocina_object.administrative.hasAdminPolicy
           raise "#{cocina_object.externalIdentifier} doesn't have a valid apo" if apo_id.nil?

--- a/lib/robots/dor_repo/accession/publish.rb
+++ b/lib/robots/dor_repo/accession/publish.rb
@@ -13,7 +13,7 @@ module Robots
         def perform_work
           return LyberCore::ReturnState.new(status: :skipped, note: 'Admin policy objects are not published') if cocina_object.admin_policy?
 
-          # This is an asynchronous result. It will set the publish workflow to complete when it is done.
+          # Calls asynchronous process, which will set the publish workflow step to complete when it is done.
           object_client.publish(workflow: 'accessionWF', lane_id:)
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated publish API call.')
         end

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -10,15 +10,11 @@ module Robots
         end
 
         def perform_work
-          # non-items don't generate technical metadata
           return LyberCore::ReturnState.new(status: :skipped, note: 'object is not an item') unless cocina_object.dro?
-
-          # skip if no files
           return LyberCore::ReturnState.new(status: :skipped, note: 'object has no files') if cocina_object.structural.nil? || cocina_object.structural.contains.blank?
 
           file_uris = PreservedFileUris.new(druid, cocina_object)
 
-          # skip if metadata-only change
           return LyberCore::ReturnState.new(status: :skipped, note: 'change is metadata-only') if file_uris.filepaths.empty?
 
           invoke_techmd_service(file_uris)


### PR DESCRIPTION
## Why was this change made? 🤔

from Sandi Metz:

"When you read the next line of code out loud, does it tell you exactly what was in the comment?"

if so, the comment is noise.


## How was this change tested? 🤨

ci, as it's comments only
