### PR TITLE
Send all preserved file info to techmd

### DIFF
--- a/lib/preserved_file_uris.rb
+++ b/lib/preserved_file_uris.rb
@@ -37,8 +37,6 @@ class PreservedFileUris
   def filepath_uris
     @filepath_uris ||= filename_uris
                        .map { |filename_uri| FilepathUri.new(File.join(content_dir, filename_uri.filename), filename_uri.uri) }
-                       # Skip if file doesn't exist indicating it is not being changed.
-                       .select { |filepath_uri| File.exist?(filepath_uri.filepath) }
   end
 
   def filename_uris

--- a/lib/robots/dor_repo/accession/technical_metadata.rb
+++ b/lib/robots/dor_repo/accession/technical_metadata.rb
@@ -15,7 +15,7 @@ module Robots
 
           file_uris = PreservedFileUris.new(druid, cocina_object)
 
-          return LyberCore::ReturnState.new(status: :skipped, note: 'change is metadata-only') if file_uris.filepaths.empty?
+          return LyberCore::ReturnState.new(status: :skipped, note: 'change is metadata-only') if metadata_only?(file_uris.filepaths)
 
           invoke_techmd_service(file_uris)
 
@@ -31,6 +31,11 @@ module Robots
                               'Content-Type' => 'application/json',
                               'Authorization' => "Bearer #{Settings.tech_md_service.token}")
           raise "Technical-metadata-service returned #{resp.status} when requesting techmd for #{druid}: #{resp.body}" unless resp.status == 200
+        end
+
+        def metadata_only?(filepaths)
+          # Assume metadata only if no files exist
+          filepaths.all? { |filepath| !File.exist?(filepath) }
         end
       end
     end

--- a/spec/lib/preserved_file_uris_spec.rb
+++ b/spec/lib/preserved_file_uris_spec.rb
@@ -48,12 +48,12 @@ RSpec.describe PreservedFileUris do
               {
                 externalIdentifier: '222-2',
                 label: 'not in workspace',
-                filename: 'not-in-workdspace.pdf',
+                filename: 'not-in-workspace.pdf',
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 access: {},
                 administrative: { publish: true, sdrPreserve: true, shelve: true },
-                hasMessageDigests: []
+                hasMessageDigests: [{ type: 'md5', digest: '789' }]
               }
             ]
           }
@@ -78,7 +78,8 @@ RSpec.describe PreservedFileUris do
     it {
       expect(uris).to eq [
         PreservedFileUris::UriMd5.new("#{prefix}#{filename1}", '123'),
-        PreservedFileUris::UriMd5.new("#{prefix}#{filename2}", '')
+        PreservedFileUris::UriMd5.new("#{prefix}#{filename2}", ''),
+        PreservedFileUris::UriMd5.new("#{prefix}not-in-workspace.pdf", '789')
       ]
     }
   end
@@ -88,7 +89,7 @@ RSpec.describe PreservedFileUris do
 
     let(:prefix) { "#{root}/dd/116/zh/0343/dd116zh0343/content/" }
 
-    it { is_expected.to eq ["#{prefix}#{filename1}", "#{prefix}#{filename2}"] }
+    it { is_expected.to eq ["#{prefix}#{filename1}", "#{prefix}#{filename2}", "#{prefix}not-in-workspace.pdf"] }
   end
 
   describe '.content_dir' do


### PR DESCRIPTION
## Why was this change made? 🤔
Partially addresses https://github.com/sul-dlss/technical-metadata-service/issues/510. Reverts code changes in https://github.com/sul-dlss/common-accessioning/pull/1120/files and sends filepath URIs for all preserved files, whether or not in workspace. 

## How was this change tested? 🤨
Unit, ran with pre-assembly on QA and with integration test branch that checks techmd. 