### PR TITLE
not using sul_orcid_client in this code?

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem 'pry'
 gem 'rake'
 gem 'sidekiq', '~> 7.0'
 gem 'slop'
-gem 'sul_orcid_client'
 gem 'zeitwerk', '~> 2.1'
 
 source 'https://gems.contribsys.com/' do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,6 @@ GEM
       faraday (~> 2.0)
     ffi (1.16.3)
     hashdiff (1.1.0)
-    hashie (5.0.0)
     honeybadger (5.8.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
@@ -142,8 +141,6 @@ GEM
     json (2.7.1)
     jsonpath (1.1.5)
       multi_json
-    jwt (2.8.1)
-      base64
     language_server-protocol (3.17.0.3)
     lyber-core (7.4.2)
       activesupport
@@ -167,7 +164,6 @@ GEM
       nokogiri
       nokogiri-happymapper
     multi_json (1.15.0)
-    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
       uri
@@ -183,13 +179,6 @@ GEM
       racc (~> 1.4)
     nokogiri-happymapper (0.10.0)
       nokogiri (~> 1.5)
-    oauth2 (2.0.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
     openapi3_parser (0.9.2)
       commonmarker (~> 0.17)
     openapi_parser (1.0.0)
@@ -273,21 +262,11 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
     sshkit (1.22.0)
       mutex_m
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
-    sul_orcid_client (0.4.1)
-      activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.90)
-      faraday
-      faraday-retry
-      oauth2
-      zeitwerk
     super_diff (0.11.0)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -297,7 +276,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    version_gem (1.1.4)
     webmock (3.23.0)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -338,7 +316,6 @@ DEPENDENCIES
   sidekiq-pro!
   simplecov
   slop
-  sul_orcid_client
   webmock
   zeitwerk (~> 2.1)
 


### PR DESCRIPTION
## Why was this change made? 🤔

I believe we are not using the `sul_orcid_client` gem in this code (we may have before but now it is in DSA).  I don't see it being used anywhere in the code and it doesn't appear to be configured here either.

Here is an example of where it is configured in DSA: https://github.com/sul-dlss/dor-services-app/blob/main/app/jobs/update_orcid_work_job.rb#L39-L47 and no equivalent references in common-accessioning: https://github.com/search?q=repo%3Asul-dlss%2Fcommon-accessioning%20SulOrcidClient&type=code

## How was this change tested? 🤨

CI