### PR TITLE
Add StartAccession robot whose job is to alert if object is open

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (14.5.0)
+    dor-services-client (14.6.1)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.96.0)
       deprecation

--- a/lib/robots/dor_repo/accession/start_accession.rb
+++ b/lib/robots/dor_repo/accession/start_accession.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module Accession
+      # Kicks off accessioning by making sure the item is not open
+      class StartAccession < LyberCore::Robot
+        def initialize
+          super('accessionWF', 'start-accession')
+        end
+
+        def perform_work
+          Honeybadger.notify('[WARNING] Accessioning has been started with an object that is still open') if object_client.version.status.open?
+        end
+      end
+    end
+  end
+end

--- a/spec/robots/dor_repo/accession/start_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/start_accession_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Robots::DorRepo::Accession::StartAccession do
+  subject(:robot) { described_class.new }
+
+  let(:druid) { 'druid:zz000zz0001' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+  let(:version_client) do
+    instance_double(Dor::Services::Client::ObjectVersion,
+                    status: instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: version_open))
+  end
+  let(:version_open) { false }
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+  end
+
+  describe '#perform' do
+    subject(:perform) { test_perform(robot, druid) }
+
+    before { allow(Honeybadger).to receive(:notify) }
+
+    it 'does not notify Honeybadger' do
+      perform
+      expect(Honeybadger).not_to have_received(:notify)
+    end
+
+    context 'when object is still open' do
+      let(:version_open) { true }
+
+      it 'notifies Honeybadger' do
+        perform
+        expect(Honeybadger).to have_received(:notify).once.with('[WARNING] Accessioning has been started with an object that is still open')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Partnered with https://github.com/sul-dlss/workflow-server-rails/pull/748

# Why was this change made?

Connects to sul-dlss/workflow-server-rails#738

# How was this change tested?

CI
