### PR TITLE
do not think we need this empty file

### DIFF
--- a/lib/dor/assembly.rb
+++ b/lib/dor/assembly.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module Dor
-  module Assembly
-  end
-end


### PR DESCRIPTION
## Why was this change made? 🤔

I think this file may have been added because we want the "assembly" namespace for classes like `Dor::Assembly::Item`.  It also used to have other config/requires before it was all removed and placed elsewhere. So now I believe declaring an empty module like this is not necessary, as this is inferred from the folder structure of the class definition itself.

## How was this change tested? 🤨

CI

