### PR TITLE
start ocr logic for end-accession

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'dry-struct', '~> 1.0'
 gem 'dry-types', '~> 1.1'
 gem 'druid-tools'
 gem 'honeybadger'
-gem 'lyber-core', '~> 7.3'
+gem 'lyber-core', '~> 7.5' # 7.5.0 has the ability to set and return workflow context
 gem 'nokogiri'
 gem 'preservation-client'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,11 +146,11 @@ GEM
     jsonpath (1.1.5)
       multi_json
     language_server-protocol (3.17.0.3)
-    lyber-core (7.4.2)
+    lyber-core (7.5.0)
       activesupport
       config
       dor-services-client (~> 14.0)
-      dor-workflow-client
+      dor-workflow-client (>= 7.4)
       druid-tools
       honeybadger
       sidekiq (~> 7.0)
@@ -310,7 +310,7 @@ DEPENDENCIES
   dry-types (~> 1.1)
   equivalent-xml
   honeybadger
-  lyber-core (~> 7.3)
+  lyber-core (~> 7.5)
   nokogiri
   preservation-client
   pry

--- a/config/settings.local.yml
+++ b/config/settings.local.yml
@@ -1,0 +1,3 @@
+# can be useful if you want to point to a localhost workserver-server-rails
+workflow:
+  url: http://localhost:3000

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -12,11 +12,13 @@ module Dor
       end
 
       def required?
-        return false unless cocina_object.dro? # only items can be OCR'd
+        # only items can be OCR'd
+        return false unless cocina_object.dro?
 
+        # only specific content types can be OCR'd
         return false unless allowed_object_types.include? cocina_object.type
 
-        # user has indicated that OCR should be run (set as workflow_context)
+        # checks if user has indicated that OCR should be run (set as workflow_context)
         return false unless workflow_context['runOCR']
 
         # TODO: check for required input files for OCR? (skip if none found) e.g. by mimetype

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -14,14 +14,29 @@ module Dor
       def required?
         return false unless cocina_object.dro? # only items can be OCR'd
 
-        # TODO: check for specific content types that should be OCR'd? (skip if invalid object content type)
-        # TODO: check for required input files for OCR? (skip if none found)
-        # TODO: check for any files that have "manuallyCorrected" in cocina structural (then skip)
+        return false unless allowed_object_types.include? cocina_object.type
 
         # user has indicated that OCR should be run (set as workflow_context)
         return false unless workflow_context['runOCR']
 
+        # TODO: check for required input files for OCR? (skip if none found) e.g. by mimetype
+        # Tterate over all files in cocina_object.structural.contains, looking at mimetypes
+        # if there are no files that are correct mimetype
+
+        # TODO: check for any files that have "manuallyCorrected" in cocina structural (then skip)
+
         true
+      end
+
+      private
+
+      # defines the object types for which OCR can possibly be run
+      def allowed_object_types
+        %w[
+          https://cocina.sul.stanford.edu/models/book
+          https://cocina.sul.stanford.edu/models/document
+          https://cocina.sul.stanford.edu/models/image
+        ]
       end
     end
   end

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -2,7 +2,7 @@
 
 module Dor
   module TextExtraction
-    # Determine if OCR is required for a given object
+    # Determine if OCR is required and possible for a given object
     class Ocr
       attr_reader :cocina_object, :workflow_context
 
@@ -11,15 +11,12 @@ module Dor
         @workflow_context = params[:workflow_context]
       end
 
-      def required?
+      def possible?
         # only items can be OCR'd
         return false unless cocina_object.dro?
 
         # only specific content types can be OCR'd
         return false unless allowed_object_types.include? cocina_object.type
-
-        # checks if user has indicated that OCR should be run (set as workflow_context)
-        return false unless workflow_context['runOCR']
 
         # check to be sure there are actually files to be OCRed
         return false unless filenames_to_ocr.any?
@@ -28,6 +25,13 @@ module Dor
 
         true
       end
+
+      def required?
+        # checks if user has indicated that OCR should be run (set as workflow_context)
+        workflow_context['runOCR'] || false
+      end
+
+      private
 
       # return a list of filenames that should be OCR'd
       # iterate over all files in cocina_object.structural.contains, looking at mimetypes
@@ -47,8 +51,8 @@ module Dor
         end
       end
 
-      private
-
+      # TODO: refine list of allowed mimetypes for OCR
+      # TODO: may use ordering of mimetypes to preferentially select files for OCR
       # defines the mimetypes types for which files for which OCR can possibly be run
       def allowed_mimetypes
         %w[
@@ -59,6 +63,7 @@ module Dor
         ]
       end
 
+      # TODO: refine list of allowed object types for OCR
       # defines the object types for which OCR can possibly be run
       def allowed_object_types
         %w[

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Dor
+  module TextExtraction
+    # Determine if OCR is required for a given object
+    class Ocr
+      attr_reader :cocina_object, :workflow_context
+
+      def initialize(params = {})
+        @cocina_object = params[:cocina_object]
+        @workflow_context = params[:workflow_context]
+      end
+
+      def required?
+        return false unless cocina_object.dro? # only items can be OCR'd
+
+        # TODO: check for specific content types that should be OCR'd? (skip if invalid object content type)
+        # TODO: check for required input files for OCR? (skip if none found)
+        # TODO: check for any files that have "manuallyCorrected" in cocina structural (then skip)
+
+        # user has indicated that OCR should be run (set as workflow_context)
+        return false unless workflow_context['runOCR']
+
+        true
+      end
+    end
+  end
+end

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -21,16 +21,43 @@ module Dor
         # checks if user has indicated that OCR should be run (set as workflow_context)
         return false unless workflow_context['runOCR']
 
-        # TODO: check for required input files for OCR? (skip if none found) e.g. by mimetype
-        # Tterate over all files in cocina_object.structural.contains, looking at mimetypes
-        # if there are no files that are correct mimetype
+        # check to be sure there are actually files to be OCRed
+        return false unless filenames_to_ocr.any?
 
         # TODO: check for any files that have "manuallyCorrected" in cocina structural (then skip)
 
         true
       end
 
+      # return a list of filenames that should be OCR'd
+      # iterate over all files in cocina_object.structural.contains, looking at mimetypes
+      # return a list of filenames that are correct mimetype
+      def filenames_to_ocr
+        cocina_files.select { |file| allowed_mimetypes.include? file.hasMimeType }.map(&:filename)
+      end
+
+      # iterate through cocina strutural contains and return all File objects
+      def cocina_files
+        [].tap do |files|
+          cocina_object.structural.contains.each do |fileset|
+            fileset.structural.contains.each do |file|
+              files << file
+            end
+          end
+        end
+      end
+
       private
+
+      # defines the mimetypes types for which files for which OCR can possibly be run
+      def allowed_mimetypes
+        %w[
+          application/pdf
+          image/tiff
+          image/jp2
+          image/jpeg
+        ]
+      end
 
       # defines the object types for which OCR can possibly be run
       def allowed_object_types

--- a/lib/robots/dor_repo/accession/end_accession.rb
+++ b/lib/robots/dor_repo/accession/end_accession.rb
@@ -25,6 +25,9 @@ module Robots
           # see https://github.com/sul-dlss/lyber-core/blob/main/lib/lyber_core/robot.rb and https://github.com/sul-dlss/lyber-core/blob/main/lib/lyber_core/workflow.rb
           workflow_service.create_workflow_by_name(druid, 'ocrWF', version: current_version, lane_id:) if Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context).required?
 
+          # Todo: Start captionioning text extraction workflow if needed
+          # workflow_service.create_workflow_by_name(druid, 'captioningWF', version: current_version, lane_id:) if Dor::TextExtraction::Captioning.new(cocina_object:, workflow_context: workflow.context).required?
+
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated cleanup API call.')
         end
         # rubocop:enable Metrics/AbcSize

--- a/lib/robots/dor_repo/accession/end_accession.rb
+++ b/lib/robots/dor_repo/accession/end_accession.rb
@@ -25,7 +25,7 @@ module Robots
           # see https://github.com/sul-dlss/lyber-core/blob/main/lib/lyber_core/robot.rb and https://github.com/sul-dlss/lyber-core/blob/main/lib/lyber_core/workflow.rb
           workflow_service.create_workflow_by_name(druid, 'ocrWF', version: current_version, lane_id:) if Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context).required?
 
-          # Todo: Start captionioning text extraction workflow if needed
+          # TODO: Start captionioning text extraction workflow if needed
           # workflow_service.create_workflow_by_name(druid, 'captioningWF', version: current_version, lane_id:) if Dor::TextExtraction::Captioning.new(cocina_object:, workflow_context: workflow.context).required?
 
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated cleanup API call.')

--- a/lib/robots/dor_repo/ocr/ocr_create.rb
+++ b/lib/robots/dor_repo/ocr/ocr_create.rb
@@ -11,8 +11,11 @@ module Robots
 
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
-          # do the ocr creation by calling out to ABBYY
-          true
+          # copy files from Preservation to the shared ABBYY mount
+          # create XML ticket for ABBYY in shared mount
+
+          # Leave this step running until the OCR monitoring job marks it as complete
+          LyberCore::ReturnState.new(status: :noop, note: 'Initiated ABBYY OCRing.')
         end
       end
     end

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dor::TextExtraction::Ocr do
+  let(:ocr) { described_class.new(cocina_object:, workflow_context:) }
+
+  describe '#required?' do
+    context 'when the object is not a DRO' do
+      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: false) }
+      let(:workflow_context) { { 'runOCR' => true } }
+
+      it 'returns false even if context includes runOCR' do
+        expect(ocr.required?).to be false
+      end
+    end
+
+    context 'when the object is a DRO' do
+      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true) }
+
+      context 'when workflow context does not include runOCR' do
+        let(:workflow_context) { {} }
+
+        it 'returns false' do
+          expect(ocr.required?).to be false
+        end
+      end
+
+      context 'when workflow context includes runOCR' do
+        let(:workflow_context) { { 'runOCR' => true } }
+
+        it 'returns false' do
+          expect(ocr.required?).to be true
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -4,10 +4,12 @@ require 'spec_helper'
 
 RSpec.describe Dor::TextExtraction::Ocr do
   let(:ocr) { described_class.new(cocina_object:, workflow_context:) }
+  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+  let(:workflow_context) { {} }
 
   describe '#required?' do
     context 'when the object is not a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: false) }
+      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: false, type: object_type) }
       let(:workflow_context) { { 'runOCR' => true } }
 
       it 'returns false even if context includes runOCR' do
@@ -16,10 +18,16 @@ RSpec.describe Dor::TextExtraction::Ocr do
     end
 
     context 'when the object is a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true) }
+      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, type: object_type) }
 
       context 'when workflow context does not include runOCR' do
-        let(:workflow_context) { {} }
+        it 'returns false' do
+          expect(ocr.required?).to be false
+        end
+      end
+
+      context 'when the object type is one that does not require OCR' do
+        let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
 
         it 'returns false' do
           expect(ocr.required?).to be false
@@ -29,8 +37,16 @@ RSpec.describe Dor::TextExtraction::Ocr do
       context 'when workflow context includes runOCR' do
         let(:workflow_context) { { 'runOCR' => true } }
 
-        it 'returns false' do
+        it 'returns true' do
           expect(ocr.required?).to be true
+        end
+
+        context 'when the object type is one that does not require OCR' do
+          let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+
+          it 'returns false' do
+            expect(ocr.required?).to be false
+          end
         end
       end
     end

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -40,7 +40,15 @@ RSpec.describe Dor::TextExtraction::Ocr do
         let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [text_file, text_file]) }
 
         it 'returns false' do
-          expect(ocr.required?).to be false
+          expect(ocr.possible?).to be false
+        end
+      end
+
+      context 'when the object has files that can be OCRed' do
+        let(:first_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [jpg_file]) }
+
+        it 'returns true' do
+          expect(ocr.possible?).to be true
         end
       end
     end
@@ -65,7 +73,7 @@ RSpec.describe Dor::TextExtraction::Ocr do
       end
     end
 
-    context 'when workflow context is emptye' do
+    context 'when workflow context is empty' do
       let(:workflow_context) { {} }
 
       it 'returns false' do

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe Dor::TextExtraction::Ocr do
   let(:ocr) { described_class.new(cocina_object:, workflow_context:) }
   let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
   let(:workflow_context) { {} }
+  let(:structural) { instance_double(Cocina::Models::DROStructural, contains: [first_fileset, second_fileset]) }
+  let(:first_fileset) { instance_double(Cocina::Models::FileSet, structural: first_fileset_structural) }
+  let(:second_fileset) { instance_double(Cocina::Models::FileSet, structural: second_fileset_structural) }
+  let(:first_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [pdf_file]) }
+  let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [jpg_file, text_file]) }
+  let(:pdf_file) { instance_double(Cocina::Models::File, hasMimeType: 'application/pdf', filename: 'file1.pdf') }
+  let(:jpg_file) { instance_double(Cocina::Models::File, hasMimeType: 'image/jpeg', filename: 'file2.jpg') }
+  let(:text_file) { instance_double(Cocina::Models::File, hasMimeType: 'text/plain', filename: 'file3.txt') }
 
   describe '#required?' do
     context 'when the object is not a DRO' do
@@ -18,7 +26,7 @@ RSpec.describe Dor::TextExtraction::Ocr do
     end
 
     context 'when the object is a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, type: object_type) }
+      let(:cocina_object) { instance_double(Cocina::Models::DRO, dro?: true, type: object_type, structural:) }
 
       context 'when workflow context does not include runOCR' do
         it 'returns false' do
@@ -48,7 +56,32 @@ RSpec.describe Dor::TextExtraction::Ocr do
             expect(ocr.required?).to be false
           end
         end
+
+        context 'when the object has no files that can be OCRed' do
+          let(:first_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [text_file]) }
+          let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [text_file, text_file]) }
+
+          it 'returns false' do
+            expect(ocr.required?).to be false
+          end
+        end
       end
+    end
+  end
+
+  describe '#filenames_to_ocr' do
+    let(:cocina_object) { instance_double(Cocina::Models::DRO, structural:) }
+
+    it 'returns a list of filenames that should be OCRed' do
+      expect(ocr.filenames_to_ocr).to eq(['file1.pdf', 'file2.jpg'])
+    end
+  end
+
+  describe '#cocina_files' do
+    let(:cocina_object) { instance_double(Cocina::Models::DRO, structural:) }
+
+    it 'returns a list of all filenames' do
+      expect(ocr.cocina_files).to eq([pdf_file, jpg_file, text_file])
     end
   end
 end

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -9,14 +9,17 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
   let(:apo) { build(:admin_policy, id: apo_druid) }
   let(:druid) { 'druid:zz000zz0001' }
   let(:apo_druid) { 'druid:mx121xx1234' }
-  let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'default') }
+  let(:context) { {} }
+  let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'default', context:) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil, process:) }
   let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, find: object, workspace: workspace_client) }
   let(:apo_object_client) { instance_double(Dor::Services::Client::Object, find: apo) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
   let(:workspace_client) { instance_double(Dor::Services::Client::Workspace, cleanup: true) }
+  let(:ocr) { instance_double(Dor::TextExtraction::Ocr, required?: false) }
 
   before do
+    allow(Dor::TextExtraction::Ocr).to receive(:new).and_return(ocr)
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     allow(Dor::Services::Client).to receive(:object).with(apo_druid).and_return(apo_object_client)
@@ -31,6 +34,22 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
       it 'cleans up' do
         expect(return_status).to eq 'noop'
         expect(workspace_client).to have_received(:cleanup).with(workflow: 'accessionWF', lane_id: 'default')
+      end
+
+      context 'when OCR is not required' do
+        it 'does not start ocrWF' do
+          perform
+          expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '1', lane_id: 'default')
+        end
+      end
+
+      context 'when OCR is required' do
+        let(:ocr) { instance_double(Dor::TextExtraction::Ocr, required?: true) }
+
+        it 'starts ocrWF' do
+          perform
+          expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '1', lane_id: 'default')
+        end
       end
     end
 

--- a/spec/robots/dor_repo/ocr/ocr_create_spec.rb
+++ b/spec/robots/dor_repo/ocr/ocr_create_spec.rb
@@ -7,6 +7,6 @@ describe Robots::DorRepo::Ocr::OcrCreate do
   let(:robot) { described_class.new }
 
   it 'runs the OCR create robot' do
-    expect(test_perform(robot, druid)).to be true
+    expect(test_perform(robot, druid)).to be_a(LyberCore::ReturnState)
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1163 and fixes #1164

The end-accession robot will start the ocrWF as needed.

~~- check for metadata in cocina to determine if we need to start the ocrWF~~ deferred to later ticket #1203

~~Currently blocked by sul-dlss/cocina-models#705 until will resolve the cocina models decisions~~

Notes: 

- the logic for starting OCR workflow is not yet complete, we need to deal with the checks for cocina metadata still.
- captionWF is ignored for now, will add later when we actually work on it

## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


