### PR TITLE
Add fetch_files for OCR

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,12 +37,13 @@ end
 group :development do
   gem 'capistrano', '~> 3.0'
   gem 'capistrano-bundler', '~> 1.1'
+  gem 'debug'
   gem 'dlss-capistrano', require: false
+  gem "ruby-debug-completion"
 end
 
 group :development, :test do
-  gem 'byebug'
-  gem 'pry-byebug', platform: %i[ruby_20 ruby_21]
   gem 'rubocop'
   gem 'rubocop-rspec'
 end
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,10 +34,10 @@ GEM
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.0)
     bigdecimal (3.1.8)
+    bond (0.5.1)
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
-    byebug (11.1.3)
     capistrano (3.18.1)
       airbrussh (>= 1.0.0)
       i18n
@@ -77,6 +77,9 @@ GEM
     crack (1.0.0)
       bigdecimal
       rexml
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
     deep_merge (1.2.2)
     deprecation (1.1.0)
       activesupport
@@ -142,6 +145,10 @@ GEM
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    io-console (0.7.2)
+    irb (1.13.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
     json (2.7.2)
     jsonpath (1.1.5)
       multi_json
@@ -201,17 +208,20 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.10.1)
-      byebug (~> 11.0)
-      pry (>= 0.13, < 0.15)
+    psych (5.1.2)
+      stringio
     public_suffix (5.0.5)
     racc (1.7.3)
     rack (3.0.11)
     rainbow (3.1.1)
     rake (13.2.1)
+    rdoc (6.6.3.1)
+      psych (>= 4.0.0)
     redis-client (0.22.1)
       connection_pool
     regexp_parser (2.9.1)
+    reline (0.5.7)
+      io-console (~> 0.5)
     rexml (3.2.6)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -254,6 +264,8 @@ GEM
       rubocop-rspec_rails (~> 2.28)
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
+    ruby-debug-completion (0.2.1)
+      bond (>= 0.3.3)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.1)
       ffi (~> 1.12)
@@ -275,6 +287,7 @@ GEM
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
+    stringio (3.1.0)
     super_diff (0.12.1)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -298,10 +311,10 @@ DEPENDENCIES
   activesupport (~> 7.0)
   assembly-image (~> 2.0)
   assembly-objectfile (~> 2.1)
-  byebug
   capistrano (~> 3.0)
   capistrano-bundler (~> 1.1)
   config
+  debug
   dlss-capistrano
   dor-services-client (~> 14.4)
   dor-workflow-client (~> 7.0)
@@ -314,12 +327,12 @@ DEPENDENCIES
   nokogiri
   preservation-client
   pry
-  pry-byebug
   rake
   rspec (~> 3.0)
   rspec_junit_formatter
   rubocop
   rubocop-rspec
+  ruby-debug-completion
   sidekiq (~> 7.0)
   sidekiq-pro!
   simplecov

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -31,14 +31,14 @@ module Dor
         workflow_context['runOCR'] || false
       end
 
-      private
-
       # return a list of filenames that should be OCR'd
       # iterate over all files in cocina_object.structural.contains, looking at mimetypes
       # return a list of filenames that are correct mimetype
       def filenames_to_ocr
         ocr_files.map(&:filename)
       end
+
+      private
 
       # iterate through cocina strutural contains and return all File objects for files that need to be OCRed
       def ocr_files

--- a/lib/robots/dor_repo/ocr/fetch_files.rb
+++ b/lib/robots/dor_repo/ocr/fetch_files.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module Ocr
+      # Fetch files in need of OCR from Preservation
+      class FetchFiles < LyberCore::Robot
+        def initialize
+          super('ocrWF', 'ocr-fetch-files')
+        end
+
+        def perform_work
+          copy_files
+        end
+
+        private
+
+        def copy_files
+          ocrable_filenames.each do |filename|
+            path = abbyy_path(filename)
+            path.parent.mkpath unless path.parent.directory?
+            path.open('wb') do |file_writer|
+              preservation_client.objects.content(druid:,
+                                                  filepath: filename,
+                                                  on_data: proc { |data, _count| file_writer.write(data) })
+            end
+          end
+        end
+
+        def bare_druid
+          druid.split(':').last
+        end
+
+        def abbyy_path(filename)
+          # NOTE: if files of type "file" were allowed here we would have to
+          # deal with file hierarchy (subdirectories)
+          Pathname.new(File.join(Settings.sdr.abbyy_ticket_path, bare_druid, filename))
+        end
+
+        def ocrable_filenames
+          @ocrable_filenames ||= ocr.required? && ocr.possible? ? ocr.filenames_to_ocr : []
+        end
+
+        def ocr
+          @ocr = Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context)
+        end
+
+        def preservation_client
+          @preservation_client ||= Preservation::Client.configure(url: Settings.preservation_catalog_url, token: Settings.preservation_catalog.token)
+        end
+      end
+    end
+  end
+end

--- a/lib/robots/dor_repo/ocr/ocr_create.rb
+++ b/lib/robots/dor_repo/ocr/ocr_create.rb
@@ -11,7 +11,6 @@ module Robots
 
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
-          # copy files from Preservation to the shared ABBYY mount
           # create XML ticket for ABBYY in shared mount
 
           # Leave this step running until the OCR monitoring job marks it as complete

--- a/spec/robots/dor_repo/ocr/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/ocr/fetch_files_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Robots::DorRepo::Ocr::FetchFiles do
+  let(:robot) { described_class.new }
+  let(:access) { { view: 'world' } }
+  let(:druid) { 'druid:bb222cc3333' }
+  let(:cocina_model) { build(:dro, id: druid).new(structural:, type: object_type, access:) }
+  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+  let(:structural) do
+    {
+      contains: [
+        {
+          type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          externalIdentifier: 'bb111bb2222_1',
+          label: 'Image 1',
+          version: 1,
+          structural: {
+            contains: [
+              {
+                type: 'https://cocina.sul.stanford.edu/models/file',
+                externalIdentifier: 'https://cocina.sul.stanford.edu/file/d30f48f9-1c11-4290-95a4-fea64e346db9',
+                label: 'image111.tif',
+                filename: 'image111.tif',
+                size: 123,
+                version: 1,
+                hasMimeType: 'image/tiff',
+                hasMessageDigests: [
+                  {
+                    type: 'md5',
+                    digest: '42616f9e6c1b7e7b7a71b4fa0c5ef794'
+                  }
+                ],
+                access: {
+                  view: 'dark',
+                  download: 'none',
+                  controlledDigitalLending: false
+                },
+                administrative: {
+                  publish: false,
+                  sdrPreserve: true,
+                  shelve: false
+                }
+              }
+            ]
+          }
+        },
+        {
+          type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          externalIdentifier: 'bb111bb2222_2',
+          label: 'Image 2',
+          version: 1,
+          structural: {
+            contains: [
+              {
+                type: 'https://cocina.sul.stanford.edu/models/file',
+                externalIdentifier: 'https://cocina.sul.stanford.edu/file/39a83c02-5d05-4c3d-bff1-080772cfdd99',
+                label: 'image112.tif',
+                filename: 'image112.tif',
+                size: 123,
+                version: 1,
+                hasMimeType: 'image/tiff',
+                hasMessageDigests: [
+                  {
+                    type: 'sha1',
+                    digest: '5c9f6dc2ca4fd3329619b54a2c6f99a08c088444'
+                  },
+                  {
+                    type: 'md5',
+                    digest: 'ac440802bd590ce0899dafecc5a5ab1b'
+                  }
+                ],
+                access: {
+                  view: 'dark',
+                  download: 'none',
+                  controlledDigitalLending: false
+                },
+                administrative: {
+                  publish: false,
+                  sdrPreserve: true,
+                  shelve: false
+                }
+              }
+            ]
+          }
+        }
+      ],
+      hasMemberOrders: [],
+      isMemberOf: []
+    }
+  end
+
+  let(:dsa_object_client) do
+    instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)
+  end
+
+  let(:pres_client) do
+    instance_double(Preservation::Client, objects: objects_client)
+  end
+
+  let(:objects_client) do
+    instance_double(Preservation::Client::Objects)
+  end
+
+  let(:workflow_client) do
+    instance_double(Dor::Workflow::Client, process: workflow_process, workflow_status: status)
+  end
+
+  let(:workflow_process) do
+    instance_double(Dor::Workflow::Response::Process, lane_id:, context:)
+  end
+
+  let(:lane_id) { 'lane1' }
+  let(:context) { { 'runOCR' => true } }
+  let(:status) { 'waiting' }
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(dsa_object_client)
+    allow(Preservation::Client).to receive(:configure).and_return(pres_client)
+    allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(objects_client).to receive(:content) do |*args|
+      filepath = args.first.fetch(:filepath)
+      args.first.fetch(:on_data).call("Content for: #{filepath}")
+    end
+  end
+
+  describe '#perform' do
+    context 'with two image files' do
+      before do
+        test_perform(robot, druid)
+      end
+
+      it 'calls gets cocina from DSA' do
+        expect(dsa_object_client).to have_received(:find)
+      end
+
+      it 'configures preservation client' do
+        expect(Preservation::Client).to have_received(:configure)
+      end
+
+      it 'calls the workflow service to get the context' do
+        expect(workflow_client).to have_received(:process)
+      end
+
+      it 'writes the two files' do
+        expect(objects_client).to have_received(:content).twice
+
+        file1 = File.join(Settings.sdr.abbyy_ticket_path, 'bb222cc3333', 'image111.tif')
+        expect(File.read(file1)).to eq('Content for: image111.tif')
+
+        file2 = File.join(Settings.sdr.abbyy_ticket_path, 'bb222cc3333', 'image112.tif')
+        expect(File.read(file2)).to eq('Content for: image112.tif')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ end
 ENV['ROBOT_ENVIRONMENT'] = 'test'
 require File.expand_path("#{__dir__}/../config/boot")
 
-require 'byebug'
+require 'debug'
 require 'pry'
 require 'rspec'
 require 'webmock/rspec'


### PR DESCRIPTION
## Why was this change made? 🤔

Add a workflow step for wfOCR to fetch files in need of OCR from preservation using the Preservation::Client.

Closes #1187

## How was this change tested? 🤨

Unit tests. It's not actually part of the workflow yet...

