### PR TITLE
Handle referencing files in druid subdirectory

### DIFF
--- a/lib/dor/text_extraction/abbyy/ticket.rb
+++ b/lib/dor/text_extraction/abbyy/ticket.rb
@@ -16,10 +16,14 @@ module Dor
           File.write(file_path, xml)
         end
 
+        def file_path
+          File.join(Settings.sdr.abbyy_ticket_path, "#{bare_druid}.xml")
+        end
+
         private
 
-        def file_path
-          File.join(Settings.sdr.abbyy_ticket_path, "#{druid}.xml")
+        def bare_druid
+          @bare_druid ||= druid.split(':').last
         end
 
         def image_output
@@ -31,14 +35,14 @@ module Dor
         end
 
         def output_file_path
-          File.join(Settings.sdr.abbyy_output_path, druid).encode(xml: :text)
+          File.join(Settings.sdr.abbyy_output_path, bare_druid).encode(xml: :text)
         end
 
         def alto_output
           "<ExportFormat OutputFileFormat='ALTO' OutputFlowType='SharedFolder' FormatVersion='3_1' CoordinatesParticularity='Words' WriteWordConfidence='true'>
             <OutputLocation>#{output_file_path}</OutputLocation>
             <FileExistsAction>Overwrite</FileExistsAction>
-            <NamingRule>#{druid}.&lt;Ext&gt;</NamingRule>
+            <NamingRule>#{bare_druid}.&lt;Ext&gt;</NamingRule>
           </ExportFormat>"
         end
 
@@ -46,7 +50,7 @@ module Dor
           "<ExportFormat OutputFileFormat='Text' OutputFlowType='SharedFolder' EncodingType='UTF8'>
             <OutputLocation>#{output_file_path}</OutputLocation>
             <FileExistsAction>Overwrite</FileExistsAction>
-            <NamingRule>#{druid}.&lt;Ext&gt;</NamingRule>
+            <NamingRule>#{bare_druid}.&lt;Ext&gt;</NamingRule>
           </ExportFormat>"
         end
 
@@ -57,12 +61,17 @@ module Dor
                         PdfUACompatible='true'>
             <OutputLocation>#{output_file_path}</OutputLocation>
             <FileExistsAction>Overwrite</FileExistsAction>
-            <NamingRule>#{druid}.&lt;Ext&gt;</NamingRule>
+            <NamingRule>#{bare_druid}.&lt;Ext&gt;</NamingRule>
           </ExportFormat>"
         end
 
         def input_filepaths_field
-          filepaths.map { |filename| "<InputFile Name=#{filename.encode(xml: :attr)}/>" }.join("\n")
+          # windows filepath since Abbyy service runs on a Windows machine
+          filepaths.map do |filename|
+            filename = filename.gsub('/', '\\')
+            path = "#{bare_druid}\\#{filename}"
+            "<InputFile Name=#{path.encode(xml: :attr)}/>"
+          end.join("\n")
         end
 
         def xml

--- a/spec/fixtures/ocr/cc333dd4444_abbyy_ticket.xml
+++ b/spec/fixtures/ocr/cc333dd4444_abbyy_ticket.xml
@@ -5,23 +5,23 @@
                 PdfAComplianceMode='PDFAM_PdfA_2u' PdfVersion='Version17'
                 Scenario='MaxQuality' UseImprovedCompression='true' MRCMode='Normal'
                 PdfUACompatible='true'>
-      <OutputLocation>/tmp/bb222cc3333</OutputLocation>
+      <OutputLocation>/tmp/cc333dd4444</OutputLocation>
       <FileExistsAction>Overwrite</FileExistsAction>
-      <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+      <NamingRule>cc333dd4444.&lt;Ext&gt;</NamingRule>
     </ExportFormat>
     <ExportFormat OutputFileFormat='ALTO' OutputFlowType='SharedFolder' FormatVersion='3_1' CoordinatesParticularity='Words' WriteWordConfidence='true'>
-      <OutputLocation>/tmp/bb222cc3333</OutputLocation>
+      <OutputLocation>/tmp/cc333dd4444</OutputLocation>
       <FileExistsAction>Overwrite</FileExistsAction>
-      <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+      <NamingRule>cc333dd4444.&lt;Ext&gt;</NamingRule>
     </ExportFormat>
     <ExportFormat OutputFileFormat='Text' OutputFlowType='SharedFolder' EncodingType='UTF8'>
-      <OutputLocation>/tmp/bb222cc3333</OutputLocation>
+      <OutputLocation>/tmp/cc333dd4444</OutputLocation>
       <FileExistsAction>Overwrite</FileExistsAction>
-      <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+      <NamingRule>cc333dd4444.&lt;Ext&gt;</NamingRule>
     </ExportFormat>
     <XMLResultLocation>/tmp</XMLResultLocation>
   </ExportParams>
-  <InputFile Name='bb222cc3333\filename1.jp2'/>
-  <InputFile Name='bb222cc3333\filename2.jp2'/>
-  <InputFile Name='bb222cc3333\filename3.jp2'/>
+  <InputFile Name='cc333dd4444\subdir\filename1.jp2'/>
+  <InputFile Name='cc333dd4444\filename2.jp2'/>
+  <InputFile Name='cc333dd4444\filename3.jp2'/>
 </XmlTicket>

--- a/spec/fixtures/ocr/new_druid_abbyy_ticket.xml
+++ b/spec/fixtures/ocr/new_druid_abbyy_ticket.xml
@@ -8,6 +8,6 @@
     </ExportFormat>
     <XMLResultLocation>/tmp</XMLResultLocation>
   </ExportParams>
-  <InputFile Name="filename3.PDF"/>
-  <InputFile Name="filename4.pdf"/>
+  <InputFile Name="new_druid\filename3.PDF"/>
+  <InputFile Name="new_druid\filename4.pdf"/>
 </XmlTicket>

--- a/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
@@ -3,31 +3,42 @@
 require 'spec_helper'
 
 describe Dor::TextExtraction::Abbyy::Ticket do
-  let(:druid) { 'bb222cc3333' }
+  let(:druid) { 'druid:bb222cc3333' }
+  let(:bare_druid) { druid.split(':').last }
   let(:abbyy) { described_class.new(filepaths:, druid:) }
   let(:ticket_xml) { abbyy.send(:xml) }
-  let(:fixture_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{druid}_abbyy_ticket.xml") }
+  let(:fixture_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{bare_druid}_abbyy_ticket.xml") }
 
   context 'when the files are images' do
-    let(:file_path) { abbyy.send(:file_path) }
-    let(:filepaths) { %w[/with/path/filename1.jp2 filename2.jp2 filename3.jp2] }
+    let(:filepaths) { %w[filename1.jp2 filename2.jp2 filename3.jp2] }
 
-    before { FileUtils.rm_f(file_path) }
+    before { FileUtils.rm_f(abbyy.file_path) }
 
     it 'creates xml for files for images' do
       expect(ticket_xml).to be_equivalent_to File.read(fixture_path)
     end
 
     it 'writes the file to disk' do
-      expect(File.exist?(file_path)).to be false
+      expect(File.exist?(abbyy.file_path)).to be false
       abbyy.write_xml
-      expect(File.exist?(file_path)).to be true
+      expect(File.exist?(abbyy.file_path)).to be true
+    end
+  end
+
+  context 'when the files have hierarchy' do
+    let(:druid) { 'druid:cc333dd4444' }
+    let(:filepaths) { %w[subdir/filename1.jp2 filename2.jp2 filename3.jp2] }
+
+    before { FileUtils.rm_f(abbyy.file_path) }
+
+    it 'creates xml for files for images' do
+      expect(ticket_xml).to be_equivalent_to File.read(fixture_path)
     end
   end
 
   context 'when the files are not images' do
     let(:filepaths) { %w[filename3.PDF filename4.pdf] }
-    let(:druid) { 'new_druid' }
+    let(:druid) { 'druid:new_druid' }
 
     it 'creates xml for files for pdfs' do
       expect(ticket_xml).to be_equivalent_to File.read(fixture_path)


### PR DESCRIPTION
## Why was this change made? 🤔

Rather than requiring the user of the Abbyy class to know that file
paths should be in a druid subdirectory using Windows file separator the
caller can just pass in the filenames and the Abbyy class will handle
making sure they are referenced in the XML using the druid subdirectory.

Also update the paths used so that they include the "bare" druid,
or only the identifier only includes the identifier portion, so
instead of '/tmp/druid:bb22ccc3333' it will be '/tmp/bb22ccc3333'.

Even though they are currently out of scope the ticket writing will also
handle when there is file hierarchy in the path: 'x/y.png' instead of
'y.png'.

## How was this change tested? 🤨

Unit tests.

