### PR TITLE
Create ABBYY file watcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem 'rake'
 gem 'sidekiq', '~> 7.0'
 gem 'slop'
 gem 'zeitwerk', '~> 2.1'
+gem "listen", "~> 3.9" # used for watching ABBYY OCR output directories
 
 source 'https://gems.contribsys.com/' do
   gem 'sidekiq-pro'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,9 @@ GEM
     jsonpath (1.1.5)
       multi_json
     language_server-protocol (3.17.0.3)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
     lyber-core (7.5.0)
       activesupport
       config
@@ -215,6 +218,9 @@ GEM
     rack (3.0.11)
     rainbow (3.1.1)
     rake (13.2.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.10.1)
+      ffi (~> 1.0)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     redis-client (0.22.1)
@@ -323,6 +329,7 @@ DEPENDENCIES
   dry-types (~> 1.1)
   equivalent-xml
   honeybadger
+  listen (~> 3.9)
   lyber-core (~> 7.5)
   nokogiri
   preservation-client

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,6 +19,7 @@ sdr:
   abbyy_ticket_path: /tmp
   abbyy_output_path: /tmp
   abbyy_result_path: /tmp
+  abbyy_exception_path: /tmp
 
 tech_md_service:
   url: 'https://dor-techmd-test.stanford.test'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -16,10 +16,14 @@ assembly:
 
 sdr:
   local_workspace_root: /dor/workspace
-  abbyy_ticket_path: /tmp
-  abbyy_output_path: /tmp
-  abbyy_result_path: /tmp
-  abbyy_exception_path: /tmp
+  abbyy:
+    # Windows-style paths for the ABBYY machine, referenced in XML tickets
+    remote_output_path: /tmp
+    remote_result_path: /tmp
+    # Unix-style paths for the common-accessioning VM, used to manage files
+    local_ticket_path: /tmp
+    local_result_path: /tmp
+    local_exception_path: /tmp
 
 tech_md_service:
   url: 'https://dor-techmd-test.stanford.test'

--- a/lib/dor/text_extraction/abbyy/file_watcher.rb
+++ b/lib/dor/text_extraction/abbyy/file_watcher.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Dor
+  module TextExtraction
+    module Abbyy
+      # Watch jobs ABBYY is processing via the filesystem and report back to SDR
+      class FileWatcher
+        attr_reader :result_xml_path, :exceptions_path
+
+        # These methods control the underlying listener; see:
+        # https://github.com/guard/listen?tab=readme-ov-file#pause--start--stop
+        # NOTE: You need to `sleep` or otherwise avoid letting the process
+        # exit after starting in order for the listener's thread to keep running
+        delegate :start, :pause, :stop, to: :listener
+
+        def initialize(workflow_updater: nil, listener_options: {})
+          @result_xml_path = Settings.sdr.abbyy_result_path
+          @exceptions_path = Settings.sdr.abbyy_exception_path
+
+          # Ensure the ABBYY directories exist
+          raise ArgumentError, "ABBYY result XML path '#{result_xml_path}' is not a directory" unless File.directory?(result_xml_path)
+          raise ArgumentError, "ABBYY exceptions path '#{exceptions_path}' is not a directory" unless File.directory?(exceptions_path)
+
+          # Set up the workflow updater and listener
+          @workflow_updater = workflow_updater || Dor::TextExtraction::WorkflowUpdater.new
+          @listener_options = default_listener_options.merge(listener_options)
+        end
+
+        private
+
+        # See: https://github.com/guard/listen?tab=readme-ov-file#options
+        def default_listener_options
+          {
+            only: /\.result\.xml$/,
+            force_polling: false # Polling is required to access the Samba share
+          }
+        end
+
+        # Controlled by the `start`, `pause`, and `stop` methods
+        def listener
+          @listener ||= Listen.to(result_xml_path, exceptions_path, **@listener_options) do |_modified, added, _removed|
+            results = added.map { |path| Dor::TextExtraction::Abbyy::Results.new(result_path: path) }
+            successes, failures = results.partition(&:success?)
+            successes.each(&method(:process_success))
+            failures.each(&method(:process_failure))
+          end
+        end
+
+        # Notify SDR that the OCR workflow step completed successfully
+        def process_success(results)
+          @workflow_updater.mark_ocr_completed(results.druid)
+        end
+
+        # Notify SDR that the OCR workflow step failed
+        def process_failure(results)
+          @workflow_updater.mark_ocr_errored(results.druid)
+        end
+      end
+    end
+  end
+end

--- a/lib/dor/text_extraction/abbyy/file_watcher.rb
+++ b/lib/dor/text_extraction/abbyy/file_watcher.rb
@@ -13,9 +13,10 @@ module Dor
         # exit after starting in order for the listener's thread to keep running
         delegate :start, :pause, :stop, to: :listener
 
+        # rubocop:disable Metrics/AbcSize
         def initialize(workflow_updater: nil, listener_options: {})
-          @result_xml_path = Settings.sdr.abbyy_result_path
-          @exceptions_path = Settings.sdr.abbyy_exception_path
+          @result_xml_path = Settings.sdr.abbyy.local_result_path
+          @exceptions_path = Settings.sdr.abbyy.local_exception_path
 
           # Ensure the ABBYY directories exist
           raise ArgumentError, "ABBYY result XML path '#{result_xml_path}' is not a directory" unless File.directory?(result_xml_path)
@@ -25,6 +26,7 @@ module Dor
           @workflow_updater = workflow_updater || Dor::TextExtraction::WorkflowUpdater.new
           @listener_options = default_listener_options.merge(listener_options)
         end
+        # rubocop:enable Metrics/AbcSize
 
         private
 

--- a/lib/dor/text_extraction/abbyy/file_watcher.rb
+++ b/lib/dor/text_extraction/abbyy/file_watcher.rb
@@ -53,7 +53,7 @@ module Dor
 
         # Notify SDR that the OCR workflow step failed
         def process_failure(results)
-          @workflow_updater.mark_ocr_errored(results.druid)
+          @workflow_updater.mark_ocr_errored(results.druid, error_message: results.failure_messages.join("\n"))
         end
       end
     end

--- a/lib/dor/text_extraction/abbyy/ticket.rb
+++ b/lib/dor/text_extraction/abbyy/ticket.rb
@@ -17,7 +17,7 @@ module Dor
         end
 
         def file_path
-          File.join(Settings.sdr.abbyy_ticket_path, "#{bare_druid}.xml")
+          File.join(Settings.sdr.abbyy.local_ticket_path, "#{bare_druid}.xml")
         end
 
         private
@@ -35,7 +35,7 @@ module Dor
         end
 
         def output_file_path
-          File.join(Settings.sdr.abbyy_output_path, bare_druid).encode(xml: :text)
+          File.join(Settings.sdr.abbyy.remote_output_path, bare_druid).encode(xml: :text)
         end
 
         def alto_output
@@ -79,7 +79,7 @@ module Dor
           <XmlTicket>
             <ExportParams XMLResultPublishingMethod='XMLResultToFolder'>
               #{pdf_files? ? pdfa_output : image_output}
-              <XMLResultLocation>#{Settings.sdr.abbyy_result_path.encode(xml: :text)}</XMLResultLocation>
+              <XMLResultLocation>#{Settings.sdr.abbyy.remote_result_path.encode(xml: :text)}</XMLResultLocation>
             </ExportParams>
             #{input_filepaths_field}
           </XmlTicket>"

--- a/lib/dor/text_extraction/workflow_updater.rb
+++ b/lib/dor/text_extraction/workflow_updater.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Dor
+  module TextExtraction
+    # Update the status of workflow steps in SDR based on OCR processing events
+    class WorkflowUpdater
+      attr_reader :workflow, :step
+
+      # Default is to update the 'ocr-create' step in the 'ocrWF' workflow
+      def initialize(workflow: 'ocrWF', step: 'ocr-create', client: nil, logger: nil)
+        @workflow = workflow
+        @step = step
+        @client = client || LyberCore::WorkflowClientFactory.build(logger:)
+      end
+
+      # Notify SDR that the OCR workflow step completed successfully
+      def mark_ocr_completed(druid)
+        @client.update_status(druid:, workflow:, process: step, status: 'completed')
+      end
+
+      # Notify SDR that the OCR workflow step failed
+      def mark_ocr_errored(druid)
+        @client.update_status(druid:, workflow:, process: step, status: 'error')
+      end
+    end
+  end
+end

--- a/lib/dor/text_extraction/workflow_updater.rb
+++ b/lib/dor/text_extraction/workflow_updater.rb
@@ -19,8 +19,8 @@ module Dor
       end
 
       # Notify SDR that the OCR workflow step failed
-      def mark_ocr_errored(druid)
-        @client.update_status(druid:, workflow:, process: step, status: 'error')
+      def mark_ocr_errored(druid, error_message:)
+        @client.update_status(druid:, workflow:, process: step, status: 'error', note: error_message)
       end
     end
   end

--- a/lib/robots/dor_repo/ocr/fetch_files.rb
+++ b/lib/robots/dor_repo/ocr/fetch_files.rb
@@ -34,7 +34,7 @@ module Robots
         def abbyy_path(filename)
           # NOTE: if files of type "file" were allowed here we would have to
           # deal with file hierarchy (subdirectories)
-          Pathname.new(File.join(Settings.sdr.abbyy_ticket_path, bare_druid, filename))
+          Pathname.new(File.join(Settings.sdr.abbyy.local_ticket_path, bare_druid, filename))
         end
 
         def ocrable_filenames

--- a/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Dor::TextExtraction::Abbyy::FileWatcher do
+  include_context 'with abbyy dir'
+
+  let(:druid) { 'ab123cd4567' }
+  let(:workflow_updater) { instance_double(Dor::TextExtraction::WorkflowUpdater) }
+  let(:listener_options) { {} }
+  let(:file_watcher) { described_class.new(workflow_updater:, listener_options:) }
+
+  before do
+    allow(Settings.sdr).to receive_messages(
+      abbyy_result_path: abbyy_result_xml_path,
+      abbyy_exception_path: abbyy_exceptions_path
+    )
+    allow(workflow_updater).to receive(:mark_ocr_completed)
+    allow(workflow_updater).to receive(:mark_ocr_errored)
+  end
+
+  context 'with polling disabled' do
+    it 'notifies SDR when a successful result is created' do
+      file_watcher.start
+      create_abbyy_result(abbyy_result_xml_path, druid:)
+      file_watcher.stop
+      expect(workflow_updater).to have_received(:mark_ocr_completed).with(druid)
+    end
+
+    it 'notifies SDR when an exception result is created' do
+      file_watcher.start
+      create_abbyy_result(abbyy_exceptions_path, druid:, success: false)
+      file_watcher.stop
+      expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid)
+    end
+  end
+
+  context 'with polling enabled' do
+    let(:listener_options) { { force_polling: true } }
+
+    it 'notifies SDR when a successful result is created' do
+      file_watcher.start
+      create_abbyy_result(abbyy_result_xml_path, druid:)
+      sleep(1) # Allow enough time to poll the filesystem
+      file_watcher.stop
+      expect(workflow_updater).to have_received(:mark_ocr_completed).with(druid)
+    end
+
+    it 'notifies SDR when an exception result is created' do
+      file_watcher.start
+      create_abbyy_result(abbyy_exceptions_path, druid:, success: false)
+      sleep(1) # Allow enough time to poll the filesystem
+      file_watcher.stop
+      expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid)
+    end
+  end
+end

--- a/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
@@ -17,9 +17,9 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
   end
 
   before do
-    allow(Settings.sdr).to receive_messages(
-      abbyy_result_path: abbyy_result_xml_path,
-      abbyy_exception_path: abbyy_exceptions_path
+    allow(Settings.sdr.abbyy).to receive_messages(
+      local_result_path: abbyy_result_xml_path,
+      local_exception_path: abbyy_exceptions_path
     )
     allow(workflow_updater).to receive(:mark_ocr_completed)
     allow(workflow_updater).to receive(:mark_ocr_errored)

--- a/spec/lib/dor/text_extraction/workflow_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/workflow_updater_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe Dor::TextExtraction::WorkflowUpdater do
+  subject(:updater) { described_class.new(workflow:, step:, client:) }
+
+  let(:workflow) { 'myOcrWF' }
+  let(:step) { 'creation-step' }
+  let(:client) { instance_double(Dor::Workflow::Client) }
+  let(:druid) { 'bb222cc3333' }
+
+  before do
+    allow(client).to receive(:update_status)
+  end
+
+  describe '#mark_ocr_completed' do
+    it 'calls the workflow client to set completed status' do
+      updater.mark_ocr_completed(druid)
+      expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'completed')
+    end
+  end
+
+  describe '#mark_ocr_errored' do
+    it 'calls the workflow client to set error status' do
+      updater.mark_ocr_errored(druid)
+      expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'error')
+    end
+  end
+end

--- a/spec/lib/dor/text_extraction/workflow_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/workflow_updater_spec.rb
@@ -20,9 +20,9 @@ describe Dor::TextExtraction::WorkflowUpdater do
   end
 
   describe '#mark_ocr_errored' do
-    it 'calls the workflow client to set error status' do
-      updater.mark_ocr_errored(druid)
-      expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'error')
+    it 'calls the workflow client to set error status and message' do
+      updater.mark_ocr_errored(druid, error_message: 'Something went wrong')
+      expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'error', note: 'Something went wrong')
     end
   end
 end

--- a/spec/robots/dor_repo/ocr/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/ocr/fetch_files_spec.rb
@@ -146,10 +146,10 @@ describe Robots::DorRepo::Ocr::FetchFiles do
       it 'writes the two files' do
         expect(objects_client).to have_received(:content).twice
 
-        file1 = File.join(Settings.sdr.abbyy_ticket_path, 'bb222cc3333', 'image111.tif')
+        file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
         expect(File.read(file1)).to eq('Content for: image111.tif')
 
-        file2 = File.join(Settings.sdr.abbyy_ticket_path, 'bb222cc3333', 'image112.tif')
+        file2 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image112.tif')
         expect(File.read(file2)).to eq('Content for: image112.tif')
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,9 @@ RSpec.configure do |config|
   config.example_status_persistence_file_path = '.rspec_status'
 end
 
+# Require all support files
+Dir["#{__dir__}/support/**/*.rb"].each { |f| require f }
+
 # Use rsync to create a copy of the test_input directory that we can modify.
 def clone_test_input(destination)
   source = 'spec/test_input'

--- a/spec/support/abbyy_helper.rb
+++ b/spec/support/abbyy_helper.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+# Shared context for setting up and tearing down ABBYY directory
+shared_context 'with abbyy dir' do
+  around do |example|
+    Dir.mktmpdir('abbyy-') do |dir|
+      # Set up ABBYY directories for results and exceptions
+      result_xml_path = File.join(dir, 'RESULTXML')
+      exceptions_path = File.join(dir, 'EXCEPTIONS')
+      Dir.mkdir(result_xml_path)
+      Dir.mkdir(exceptions_path)
+
+      # Make the directories available to the test
+      @abbyy_root_path = dir
+      @abbyy_result_xml_path = result_xml_path
+      @abbyy_exceptions_path = exceptions_path
+      example.run
+    end
+  end
+
+  attr_reader :abbyy_root_path, :abbyy_result_xml_path, :abbyy_exceptions_path
+end
+
+# Create a stub ABBYY result file
+def create_abbyy_result(base_path, druid:, run_index: 0, success: true)
+  index_tag = run_index.positive? ? '.%04d'.format(run_index) : ''
+  filename = File.join(base_path, "#{druid}#{index_tag}.xml.result.xml")
+  change_fs(:added, filename, "<XmlResult IsFailed=\"#{!success}\"></XmlResult>")
+end
+
+### Below are adapted from Listen's spec/support/acceptance_helpers.rb ###
+
+# rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+def change_fs(type, path, contents)
+  case type
+  when :modified
+    File.exist?(path) or raise "Bad test: cannot modify #{path.inspect} (it doesn't exist)"
+
+    # wait until full second, because this might be followed by a modification
+    # event (which otherwise may not be detected every time)
+    _sleep_until_next_second(Pathname.pwd)
+
+    File.open(path, 'a') { |f| f.write(contents) }
+
+    # separate it from upcoming modifications"
+    _sleep_to_separate_events
+  when :added
+    File.exist?(path) and raise "Bad test: cannot add #{path.inspect} (it already exists)"
+
+    # wait until full second, because this might be followed by a modification
+    # event (which otherwise may not be detected every time)
+    _sleep_until_next_second(Pathname.pwd)
+
+    File.write(path, contents)
+
+    # separate it from upcoming modifications"
+    _sleep_to_separate_events
+  when :removed
+    File.exist?(path) or raise "Bad test: cannot remove #{path.inspect} (it doesn't exist)"
+    File.unlink(path)
+  else
+    raise "bad test: unknown type: #{type.inspect}"
+  end
+end
+# rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+# Used by change_fs() above so that the FS change (e.g. file created) happens
+# as close to the start of a new second (time) as possible.
+#
+# E.g. if file is created at 1234567.999 (unix time), it's mtime on some
+# filesystems is rounded, so it becomes 1234567.0, but if the change
+# notification happens a little while later, e.g. at 1234568.111, now the file
+# mtime and the current time in seconds are different (1234567 vs 1234568), and
+# so the MD5 test won't kick in (see file.rb) - the file will not be considered
+# for content checking (sha), so File.change will consider the file unmodified.
+#
+# This means, that if a file is added at 1234567.888 (and updated in Record),
+# and then its content is modified at 1234567.999, and checking for changes
+# happens at 1234568.111, the modification won't be detected.
+# (because Record mtime is 1234567.0, current FS mtime from stat() is the
+# same, and the checking happens in another second - 1234568).
+#
+# So basically, adding a file and detecting its later modification should all
+# happen within 1 second (which makes testing and debugging difficult).
+#
+def _sleep_until_next_second(path)
+  Listen::File.inaccurate_mac_time?(path)
+
+  t = Time.now.utc
+  diff = t.to_f - t.to_i
+
+  sleep(1.05 - diff)
+end
+
+def _sleep_to_separate_events
+  # separate the events or Darwin and Polling
+  # will detect only the :added event
+  #
+  # (This is because both use directory scanning which may not kick in time
+  # before the next filesystem change)
+  #
+  # The minimum for this is the time it takes between a syscall
+  # changing the filesystem ... and ... an async
+  # Listen::File.scan to finish comparing the file with the
+  # Record
+  #
+  # This necessary for:
+  # - Darwin Adapter
+  # - Polling Adapter
+  # - Linux Adapter in FSEvent emulation mode
+  # - maybe Windows adapter (probably not)
+  sleep(0.4)
+end

--- a/spec/support/abbyy_helper.rb
+++ b/spec/support/abbyy_helper.rb
@@ -21,11 +21,11 @@ shared_context 'with abbyy dir' do
   attr_reader :abbyy_root_path, :abbyy_result_xml_path, :abbyy_exceptions_path
 end
 
-# Create a stub ABBYY result file
-def create_abbyy_result(base_path, druid:, run_index: 0, success: true)
+# Create a stub ABBYY result file with optional error status, contents, etc.
+def create_abbyy_result(base_path, druid:, run_index: 0, success: true, contents: '')
   index_tag = run_index.positive? ? '.%04d'.format(run_index) : ''
   filename = File.join(base_path, "#{druid}#{index_tag}.xml.result.xml")
-  change_fs(:added, filename, "<XmlResult IsFailed=\"#{!success}\"></XmlResult>")
+  change_fs(:added, filename, "<XmlResult IsFailed=\"#{!success}\">#{contents}</XmlResult>")
 end
 
 ### Below are adapted from Listen's spec/support/acceptance_helpers.rb ###


### PR DESCRIPTION
- Create a workflow updater service for text extraction
- Create a FileWatcher that emits events based on ABBYY jobs

#1231 will create a background service to run the `FileWatcher` using systemd.
