### PR TITLE
Fix open version code

### DIFF
--- a/lib/robots/dor_repo/caption/caption_create.rb
+++ b/lib/robots/dor_repo/caption/caption_create.rb
@@ -12,7 +12,9 @@ module Robots
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
           # do the caption creation by calling out to Whisper
-          true
+
+          # Leave this step running until the Whisper monitoring job marks it as complete
+          LyberCore::ReturnState.new(status: :noop, note: 'Initiated Whisper captioning.')
         end
       end
     end

--- a/lib/robots/dor_repo/caption/end_caption.rb
+++ b/lib/robots/dor_repo/caption/end_caption.rb
@@ -11,7 +11,6 @@ module Robots
 
         def perform_work
           object_client.version.close
-          true
         end
       end
     end

--- a/lib/robots/dor_repo/caption/start_caption.rb
+++ b/lib/robots/dor_repo/caption/start_caption.rb
@@ -12,7 +12,7 @@ module Robots
         def perform_work
           raise 'Object is already open' if object_client.version.status.open?
 
-          object_client.version.open
+          object_client.version.open(description: 'Start caption workflow')
         end
       end
     end

--- a/lib/robots/dor_repo/ocr/end_ocr.rb
+++ b/lib/robots/dor_repo/ocr/end_ocr.rb
@@ -11,7 +11,6 @@ module Robots
 
         def perform_work
           object_client.version.close
-          true
         end
       end
     end

--- a/lib/robots/dor_repo/ocr/split_ocr_xml.rb
+++ b/lib/robots/dor_repo/ocr/split_ocr_xml.rb
@@ -12,7 +12,6 @@ module Robots
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
           # split single document OCR XML into page level OCR XML
-          true
         end
       end
     end

--- a/lib/robots/dor_repo/ocr/start_ocr.rb
+++ b/lib/robots/dor_repo/ocr/start_ocr.rb
@@ -13,7 +13,6 @@ module Robots
           raise 'Object is already open' if object_client.version.status.open?
 
           object_client.version.open
-          true
         end
       end
     end

--- a/lib/robots/dor_repo/ocr/start_ocr.rb
+++ b/lib/robots/dor_repo/ocr/start_ocr.rb
@@ -12,7 +12,7 @@ module Robots
         def perform_work
           raise 'Object is already open' if object_client.version.status.open?
 
-          object_client.version.open
+          object_client.version.open(description: 'Start OCR workflow')
         end
       end
     end

--- a/spec/robots/dor_repo/caption/caption_create_spec.rb
+++ b/spec/robots/dor_repo/caption/caption_create_spec.rb
@@ -3,10 +3,12 @@
 require 'spec_helper'
 
 describe Robots::DorRepo::Caption::CaptionCreate do
+  subject(:perform) { test_perform(robot, druid) }
+
   let(:druid) { 'druid:bb222cc3333' }
   let(:robot) { described_class.new }
 
   it 'runs the start caption robot' do
-    expect(test_perform(robot, druid)).to be true
+    expect(perform.status).to eq 'noop'
   end
 end

--- a/spec/robots/dor_repo/ocr/end_ocr_spec.rb
+++ b/spec/robots/dor_repo/ocr/end_ocr_spec.rb
@@ -18,7 +18,7 @@ describe Robots::DorRepo::Ocr::EndOcr do
   end
 
   it 'closes the object' do
-    expect(test_perform(robot, druid)).to be true
+    test_perform(robot, druid)
     expect(version_client).to have_received(:close)
   end
 end

--- a/spec/robots/dor_repo/ocr/ocr_create_spec.rb
+++ b/spec/robots/dor_repo/ocr/ocr_create_spec.rb
@@ -3,10 +3,12 @@
 require 'spec_helper'
 
 describe Robots::DorRepo::Ocr::OcrCreate do
+  subject(:perform) { test_perform(robot, druid) }
+
   let(:druid) { 'druid:bb222cc3333' }
   let(:robot) { described_class.new }
 
   it 'runs the OCR create robot' do
-    expect(test_perform(robot, druid)).to be_a(LyberCore::ReturnState)
+    expect(perform.status).to eq 'noop'
   end
 end

--- a/spec/robots/dor_repo/ocr/split_ocr_xml_spec.rb
+++ b/spec/robots/dor_repo/ocr/split_ocr_xml_spec.rb
@@ -7,6 +7,6 @@ describe Robots::DorRepo::Ocr::SplitOcrXml do
   let(:robot) { described_class.new }
 
   it 'runs the split OCR XML robot' do
-    expect(test_perform(robot, druid)).to be true
+    expect(test_perform(robot, druid)).to be_nil
   end
 end

--- a/spec/robots/dor_repo/ocr/start_ocr_spec.rb
+++ b/spec/robots/dor_repo/ocr/start_ocr_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper'
 
 describe Robots::DorRepo::Ocr::StartOcr do
+  subject(:perform) { test_perform(robot, druid) }
+
   let(:druid) { 'druid:bb222cc3333' }
   let(:robot) { described_class.new }
 
@@ -24,7 +26,7 @@ describe Robots::DorRepo::Ocr::StartOcr do
     let(:version_open) { false }
 
     it 'opens the object' do
-      expect(test_perform(robot, druid)).to be true
+      perform
       expect(version_client).to have_received(:open)
     end
   end
@@ -33,7 +35,7 @@ describe Robots::DorRepo::Ocr::StartOcr do
     let(:version_open) { true }
 
     it 'raises an error' do
-      expect { test_perform(robot, druid) }.to raise_error('Object is already open')
+      expect { perform }.to raise_error('Object is already open')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Opening a version requires a description -- this adds it.

It also removes the unnecessary `true` from being returned in places, and adjusts the tests accordingly.

## How was this change tested? 🤨

on qa