### PR TITLE
Bump rexml to address a vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,7 +228,8 @@ GEM
     regexp_parser (2.9.1)
     reline (0.5.7)
       io-console (~> 0.5)
-    rexml (3.2.6)
+    rexml (3.2.8)
+      strscan (>= 3.0.9)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -294,6 +295,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     stringio (3.1.0)
+    strscan (3.1.0)
     super_diff (0.12.1)
       attr_extras (>= 6.2.4)
       diff-lcs


### PR DESCRIPTION
This resolves a security issue that blocks deploys because the
bundle audit check fails.
