### PR TITLE
use dor-workflow-client method to set step to error

### DIFF
--- a/lib/dor/text_extraction/abbyy/file_watcher.rb
+++ b/lib/dor/text_extraction/abbyy/file_watcher.rb
@@ -61,7 +61,7 @@ module Dor
         # Notify SDR that the OCR workflow step failed
         def process_failure(results)
           @logger.info "Found failed OCR results for druid:#{results.druid} at #{results.result_path}"
-          @workflow_updater.mark_ocr_errored("druid:#{results.druid}", error_message: results.failure_messages.join("\n"))
+          @workflow_updater.mark_ocr_errored("druid:#{results.druid}", error_msg: results.failure_messages.join("\n"))
         end
       end
     end

--- a/lib/dor/text_extraction/workflow_updater.rb
+++ b/lib/dor/text_extraction/workflow_updater.rb
@@ -19,8 +19,8 @@ module Dor
       end
 
       # Notify SDR that the OCR workflow step failed
-      def mark_ocr_errored(druid, error_message:)
-        @client.update_status(druid:, workflow:, process: step, status: 'error', note: error_message)
+      def mark_ocr_errored(druid, error_msg:)
+        @client.update_error_status(druid:, workflow:, process: step, error_msg:)
       end
     end
   end

--- a/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
@@ -40,7 +40,7 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
       file_watcher.start
       create_abbyy_result(abbyy_exceptions_path, druid: bare_druid, success: false, contents: errors_xml)
       file_watcher.stop
-      expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid, error_message: "Error one\nError two")
+      expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid, error_msg: "Error one\nError two")
     end
   end
 
@@ -60,7 +60,7 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
       create_abbyy_result(abbyy_exceptions_path, druid: bare_druid, success: false, contents: errors_xml)
       sleep(1) # Allow enough time to poll the filesystem
       file_watcher.stop
-      expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid, error_message: "Error one\nError two")
+      expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid, error_msg: "Error one\nError two")
     end
   end
 end

--- a/spec/lib/dor/text_extraction/workflow_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/workflow_updater_spec.rb
@@ -3,13 +3,14 @@
 describe Dor::TextExtraction::WorkflowUpdater do
   subject(:updater) { described_class.new(workflow:, step:, client:) }
 
-  let(:workflow) { 'myOcrWF' }
-  let(:step) { 'creation-step' }
+  let(:workflow) { 'ocrWF' }
+  let(:step) { 'ocr-create' }
   let(:client) { instance_double(Dor::Workflow::Client) }
   let(:druid) { 'bb222cc3333' }
 
   before do
     allow(client).to receive(:update_status)
+    allow(client).to receive(:update_error_status)
   end
 
   describe '#mark_ocr_completed' do
@@ -21,8 +22,8 @@ describe Dor::TextExtraction::WorkflowUpdater do
 
   describe '#mark_ocr_errored' do
     it 'calls the workflow client to set error status and message' do
-      updater.mark_ocr_errored(druid, error_message: 'Something went wrong')
-      expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'error', note: 'Something went wrong')
+      updater.mark_ocr_errored(druid, error_msg: 'Something went wrong')
+      expect(client).to have_received(:update_error_status).with(druid:, workflow:, process: step, error_msg: 'Something went wrong')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

We have a specific way to put a step in error via the dor-workflow-client and this sets the error message correctly.

## How was this change tested? 🤨

Updated specs