### PR TITLE
add abbyy workspace cleanup robot

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,9 +21,9 @@ sdr:
     remote_output_path: /tmp
     remote_result_path: /tmp
     # Unix-style paths for the common-accessioning VM, used to manage files
-    local_ticket_path: /tmp
+    local_ticket_path: /tmp/input
     local_result_path: /tmp
-    local_output_path: /tmp
+    local_output_path: /tmp/output
     local_exception_path: /tmp
 
 tech_md_service:

--- a/lib/dor/text_extraction/abbyy/ticket.rb
+++ b/lib/dor/text_extraction/abbyy/ticket.rb
@@ -7,10 +7,10 @@ module Dor
       class Ticket
         attr_reader :filepaths, :ocr_languages, :bare_druid
 
-        def initialize(filepaths:, druid:, ocr_languages:)
+        def initialize(filepaths:, druid:, ocr_languages: [])
           @filepaths = filepaths
           @bare_druid = druid.delete_prefix('druid:')
-          @ocr_languages = ocr_languages || []
+          @ocr_languages = ocr_languages
         end
 
         def write_xml
@@ -36,7 +36,7 @@ module Dor
         end
 
         def language_xml
-          return '' if ocr_languages.empty?
+          return '' if ocr_languages.blank?
 
           language_tags = ocr_languages.map { |lang| "<Language>#{lang}</Language>" }.join("\n")
           "<RecognitionParams RecognitionQuality='Balanced' RecognitionMode='FullPage' UsePullXTextAndRecognizeRest='false' LanguageDetectMode='Always'>

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -30,8 +30,6 @@ module Dor
 
         return true unless Dir.exist?(abbyy_output_path)
 
-        raise "#{abbyy_output_path} is not empty" unless Dir.empty?(abbyy_output_path)
-
         FileUtils.rm_rf(abbyy_output_path)
 
         FileUtils.rm_f(Abbyy::Ticket.new(filepaths: [], druid: cocina_object.externalIdentifier).file_path) # remove XML ticket file

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -8,7 +8,7 @@ module Dor
 
       def initialize(params = {})
         @cocina_object = params[:cocina_object]
-        @workflow_context = params[:workflow_context]
+        @workflow_context = params[:workflow_context] || {}
         @bare_druid = cocina_object.externalIdentifier.delete_prefix('druid:')
       end
 
@@ -18,6 +18,20 @@ module Dor
 
       def abbyy_input_path
         File.join(Settings.sdr.abbyy.local_ticket_path, bare_druid)
+      end
+
+      def cleanup
+        if Dir.exist?(abbyy_input_path)
+          raise "#{abbyy_input_path} is not empty" unless Dir.empty?(abbyy_input_path)
+
+          FileUtils.rm_rf(abbyy_input_path)
+        end
+
+        return true unless Dir.exist?(abbyy_output_path)
+
+        raise "#{abbyy_output_path} is not empty" unless Dir.empty?(abbyy_output_path)
+
+        FileUtils.rm_rf(abbyy_output_path)
       end
 
       def possible?

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -20,6 +20,7 @@ module Dor
         File.join(Settings.sdr.abbyy.local_ticket_path, bare_druid)
       end
 
+      # rubocop:disable Metrics/AbcSize
       def cleanup
         if Dir.exist?(abbyy_input_path)
           raise "#{abbyy_input_path} is not empty" unless Dir.empty?(abbyy_input_path)
@@ -32,7 +33,10 @@ module Dor
         raise "#{abbyy_output_path} is not empty" unless Dir.empty?(abbyy_output_path)
 
         FileUtils.rm_rf(abbyy_output_path)
+
+        FileUtils.rm_f(Abbyy::Ticket.new(filepaths: [], druid: cocina_object.externalIdentifier).file_path) # remove XML ticket file
       end
+      # rubocop:enable Metrics/AbcSize
 
       def possible?
         # only items can be OCR'd

--- a/lib/robots/dor_repo/ocr/fetch_files.rb
+++ b/lib/robots/dor_repo/ocr/fetch_files.rb
@@ -26,11 +26,7 @@ module Robots
         def abbyy_path(filename)
           # NOTE: if files of type "file" were allowed here we would have to
           # deal with file hierarchy (subdirectories)
-          Pathname.new(File.join(abbyy_input_path, filename))
-        end
-
-        def abbyy_input_path
-          @abbyy_input_path ||= Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context).abbyy_input_path
+          Pathname.new(File.join(ocr.abbyy_input_path, filename))
         end
 
         def ocrable_filenames
@@ -38,7 +34,7 @@ module Robots
         end
 
         def ocr
-          @ocr = Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context)
+          @ocr ||= Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context)
         end
 
         # Fetch an item's file from Preservation and write it to disk. Since

--- a/lib/robots/dor_repo/ocr/ocr_create.rb
+++ b/lib/robots/dor_repo/ocr/ocr_create.rb
@@ -11,8 +11,6 @@ module Robots
 
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
-          # create XML ticket for ABBYY in shared mount
-
           # Leave this step running until the OCR monitoring job marks it as complete
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated ABBYY OCRing.')
         end

--- a/lib/robots/dor_repo/ocr/ocr_workspace_cleanup.rb
+++ b/lib/robots/dor_repo/ocr/ocr_workspace_cleanup.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Robots
+  module DorRepo
+    module Ocr
+      # Cleanup empty input and output folders in ABBYY OCR workspace
+      class OcrWorkspaceCleanup < LyberCore::Robot
+        def initialize
+          super('ocrWF', 'ocr-workspace-cleanup')
+        end
+
+        # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
+        def perform_work
+          Dor::TextExtraction::Ocr.new(cocina_object:).cleanup
+        end
+      end
+    end
+  end
+end

--- a/lib/robots/dor_repo/ocr/split_ocr_xml.rb
+++ b/lib/robots/dor_repo/ocr/split_ocr_xml.rb
@@ -11,7 +11,7 @@ module Robots
 
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
-          base_output_path = Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow_service).abbyy_output_path
+          base_output_path = Dor::TextExtraction::Ocr.new(cocina_object:).abbyy_output_path
           alto_path = File.join(base_output_path, "#{bare_druid}.xml")
           return unless File.exist?(alto_path)
 

--- a/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
@@ -18,6 +18,8 @@ describe Dor::TextExtraction::Abbyy::Ticket do
   let(:ticket_xml) { abbyy.send(:xml) }
   let(:fixture_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{bare_druid}_abbyy_ticket.xml") }
 
+  before { FileUtils.mkdir_p(File.dirname(abbyy.file_path)) }
+
   context 'when the files are images' do
     let(:filepaths) { %w[filename1.jp2 filename2.jp2 filename3.jp2] }
 

--- a/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
@@ -9,6 +9,7 @@ describe Dor::TextExtraction::Abbyy::Ticket do
     allow(Settings.sdr.abbyy).to receive_messages(
       local_ticket_path: abbyy_xml_ticket_path
     )
+    FileUtils.mkdir_p(File.dirname(abbyy.file_path))
   end
 
   let(:druid) { 'druid:bb222cc3333' }
@@ -17,8 +18,6 @@ describe Dor::TextExtraction::Abbyy::Ticket do
   let(:ocr_languages) { nil }
   let(:ticket_xml) { abbyy.send(:xml) }
   let(:fixture_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{bare_druid}_abbyy_ticket.xml") }
-
-  before { FileUtils.mkdir_p(File.dirname(abbyy.file_path)) }
 
   context 'when the files are images' do
     let(:filepaths) { %w[filename1.jp2 filename2.jp2 filename3.jp2] }

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Dor::TextExtraction::Ocr do
   let(:ocr) { described_class.new(cocina_object:, workflow_context:) }
+  let(:ticket) { Dor::TextExtraction::Abbyy::Ticket.new(filepaths: [], druid:) }
   let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
   let(:workflow_context) { {} }
   let(:structural) { instance_double(Cocina::Models::DROStructural, contains: [first_fileset, second_fileset]) }
@@ -122,12 +123,12 @@ RSpec.describe Dor::TextExtraction::Ocr do
     before do
       FileUtils.rm_rf(ocr.abbyy_input_path)
       FileUtils.rm_rf(ocr.abbyy_output_path)
+      FileUtils.rm_f(ticket.file_path)
     end
 
-    context 'when no input or output folders' do
+    context 'when no input or output folders or xml file' do
       it 'does nothing' do
-        expect(Dir.exist?(ocr.abbyy_input_path)).to be false
-        expect(Dir.exist?(ocr.abbyy_output_path)).to be false
+        [ocr.abbyy_input_path, ocr.abbyy_output_path, ticket.file_path].each { |path| expect(File.exist?(path)).to be false }
         expect(ocr.cleanup).to be true
       end
     end
@@ -160,18 +161,17 @@ RSpec.describe Dor::TextExtraction::Ocr do
       end
     end
 
-    context 'when input and output folders are empty' do
+    context 'when input and output folders are empty and xml ticket file exists' do
       before do
         FileUtils.mkdir_p(ocr.abbyy_input_path)
         FileUtils.mkdir_p(ocr.abbyy_output_path)
+        FileUtils.touch(ticket.file_path)
       end
 
-      it 'removes both folders' do
-        expect(Dir.exist?(ocr.abbyy_input_path)).to be true
-        expect(Dir.exist?(ocr.abbyy_output_path)).to be true
+      it 'removes both folders and the XML ticket file' do
+        [ocr.abbyy_input_path, ocr.abbyy_output_path, ticket.file_path].each { |path| expect(File.exist?(path)).to be true }
         ocr.cleanup
-        expect(Dir.exist?(ocr.abbyy_input_path)).to be false
-        expect(Dir.exist?(ocr.abbyy_output_path)).to be false
+        [ocr.abbyy_input_path, ocr.abbyy_output_path, ticket.file_path].each { |path| expect(File.exist?(path)).to be false }
       end
     end
   end

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -154,10 +154,10 @@ RSpec.describe Dor::TextExtraction::Ocr do
         FileUtils.touch(File.join(ocr.abbyy_output_path, 'file1.txt'))
       end
 
-      it 'raises an error but still deletes the input path' do
-        expect { ocr.cleanup }.to raise_error("#{ocr.abbyy_output_path} is not empty")
+      it 'removes both folders' do
+        ocr.cleanup
         expect(Dir.exist?(ocr.abbyy_input_path)).to be false
-        expect(Dir.exist?(ocr.abbyy_output_path)).to be true
+        expect(Dir.exist?(ocr.abbyy_output_path)).to be false
       end
     end
 

--- a/spec/robots/dor_repo/ocr/ocr_workspace_cleanup_spec.rb
+++ b/spec/robots/dor_repo/ocr/ocr_workspace_cleanup_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Robots::DorRepo::Ocr::OcrWorkspaceCleanup do
+  let(:druid) { 'druid:bb222cc3333' }
+  let(:robot) { described_class.new }
+
+  let(:object) { build(:dro, id: druid) }
+  let(:ocr) do
+    instance_double(Dor::TextExtraction::Ocr, cleanup: true)
+  end
+  let(:object_client) do
+    instance_double(Dor::Services::Client::Object, find: object)
+  end
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(Dor::TextExtraction::Ocr).to receive(:new).and_return(ocr)
+  end
+
+  it 'calls the cleanup method' do
+    test_perform(robot, druid)
+    expect(ocr).to have_received(:cleanup)
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1212 - clears out empty abbyy input and output folders and XML ticket file

Goes with https://github.com/sul-dlss/workflow-server-rails/pull/771

~~TODO: should we expect the OUTPUT to be empty?  or will have it leftover files that are safe to cleanup?~~ It will clear out non-empty folders

~~NOTE: until we actually complete the implementation of the stage-files robot, this workflow step will just error out each time, as nothing will be emptying the output folder, so we may want to hold off merging it for now.~~

## How was this change tested? 🤨

New specs