### PR TITLE
stop ocrWF from starting if there are no OCRable files

### DIFF
--- a/lib/robots/dor_repo/ocr/fetch_files.rb
+++ b/lib/robots/dor_repo/ocr/fetch_files.rb
@@ -34,7 +34,7 @@ module Robots
         end
 
         def ocrable_filenames
-          @ocrable_filenames ||= ocr.required? && ocr.possible? ? ocr.filenames_to_ocr : []
+          @ocrable_filenames ||= ocr.filenames_to_ocr
         end
 
         def ocr

--- a/lib/robots/dor_repo/ocr/start_ocr.rb
+++ b/lib/robots/dor_repo/ocr/start_ocr.rb
@@ -11,6 +11,7 @@ module Robots
 
         def perform_work
           raise 'Object is already open' if object_client.version.status.open?
+          raise 'No files available or invalid object for OCR' unless Dor::TextExtraction::Ocr.new(cocina_object:).possible?
 
           object_client.version.open(description: 'Start OCR workflow')
         end

--- a/spec/robots/dor_repo/ocr/start_ocr_spec.rb
+++ b/spec/robots/dor_repo/ocr/start_ocr_spec.rb
@@ -17,13 +17,18 @@ describe Robots::DorRepo::Ocr::StartOcr do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, version: version_client, workspace: workspace_client, find: object)
   end
+  let(:ocr) do
+    instance_double(Dor::TextExtraction::Ocr, possible?: possible)
+  end
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    allow(Dor::TextExtraction::Ocr).to receive(:new).and_return(ocr)
   end
 
-  context 'when the object is not opened' do
+  context 'when the object is not opened and is possible to OCR' do
     let(:version_open) { false }
+    let(:possible) { true }
 
     it 'opens the object' do
       perform
@@ -31,8 +36,18 @@ describe Robots::DorRepo::Ocr::StartOcr do
     end
   end
 
+  context 'when the object is not opened and is not possible to OCR' do
+    let(:version_open) { false }
+    let(:possible) { false }
+
+    it 'raise an error' do
+      expect { perform }.to raise_error('No files available or invalid object for OCR')
+    end
+  end
+
   context 'when the object is already opened' do
     let(:version_open) { true }
+    let(:possible) { true }
 
     it 'raises an error' do
       expect { perform }.to raise_error('Object is already open')


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1255 - prevent ocrWF from starting if OCR is not possible to run

## How was this change tested? 🤨

New specs