### PR TITLE
fix split alto

### DIFF
--- a/lib/dor/text_extraction/abbyy/split_alto.rb
+++ b/lib/dor/text_extraction/abbyy/split_alto.rb
@@ -40,10 +40,13 @@ module Dor
             end
           end
         end
+
+        def page_filenames
+          @page_filenames ||= doc.css('//sourceImageInformation').children.select(&:element?).map(&:text)
+        end
         # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
         def split_to_files
-          page_filenames = doc.css('//fileIdentifier').map(&:text)
           pages = doc.css('//Page')
           {}.tap do |file_hash|
             pages.each_with_index do |page, i|

--- a/lib/robots/dor_repo/ocr/split_ocr_xml.rb
+++ b/lib/robots/dor_repo/ocr/split_ocr_xml.rb
@@ -13,6 +13,8 @@ module Robots
         def perform_work
           base_output_path = Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow_service).abbyy_output_path
           alto_path = File.join(base_output_path, "#{bare_druid}.xml")
+          return unless File.exist?(alto_path)
+
           Dor::TextExtraction::Abbyy::SplitAlto.new(alto_path:).write_files
         end
       end

--- a/spec/fixtures/ocr/bb999cc1111_abbyy_alto.xml
+++ b/spec/fixtures/ocr/bb999cc1111_abbyy_alto.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v3#" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.loc.gov/standards/alto/ns-v3# http://www.loc.gov/alto/v3/alto-3-1.xsd">
+<Description>
+<MeasurementUnit>pixel</MeasurementUnit>
+<sourceImageInformation><fileName>example.tiff</fileName></sourceImageInformation>
+<OCRProcessing ID="IdOcr"><ocrProcessingStep><processingDateTime>2024-05-29</processingDateTime><processingSoftware><softwareCreator>ABBYY</softwareCreator><softwareName>ABBYY FineReader Server</softwareName><softwareVersion>14.0</softwareVersion></processingSoftware></ocrProcessingStep></OCRProcessing>
+</Description>
+<Styles>
+<ParagraphStyle ID="StyleId-F145EB33-BA39-4F3E-9C58-AD8181180B9A-" ALIGN="Left" LEFT="-0.5" RIGHT="0." FIRSTLINE="0." LINESPACE="47.700000762939453"/>
+<ParagraphStyle ID="StyleId-FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF-" ALIGN="Left" LEFT="0." RIGHT="0." FIRSTLINE="0."/>
+<ParagraphStyle ID="StyleId-D82FE51F-129D-4839-98A2-68AE0756F9AC-" ALIGN="Left" LEFT="0." RIGHT="0." FIRSTLINE="0."/>
+</Styles>
+<Layout>
+<Page ID="Page1" PHYSICAL_IMG_NR="1" HEIGHT="465" WIDTH="512">
+<TopMargin HEIGHT="25" WIDTH="512" VPOS="0" HPOS="0">
+</TopMargin>
+<LeftMargin HEIGHT="398" WIDTH="76" VPOS="25" HPOS="0">
+</LeftMargin>
+<RightMargin HEIGHT="398" WIDTH="86" VPOS="25" HPOS="426">
+</RightMargin>
+<BottomMargin HEIGHT="42" WIDTH="512" VPOS="423" HPOS="0">
+</BottomMargin>
+<PrintSpace HEIGHT="398" WIDTH="350" VPOS="25" HPOS="76">
+<TextBlock ID="Page1_Block1" HEIGHT="43" WIDTH="162" VPOS="38" HPOS="157" LANG="en-US" STYLEREFS="StyleId-F145EB33-BA39-4F3E-9C58-AD8181180B9A-">
+<TextLine BASELINE="73" HEIGHT="42" WIDTH="161" VPOS="39" HPOS="158"><String WC="0.61500000953674316" CONTENT="o^" HEIGHT="40" WIDTH="71" VPOS="41" HPOS="158"/><SP HEIGHT="42" WIDTH="6" VPOS="39" HPOS="230"/><String WC="0.52999997138977051" CONTENT="J" HEIGHT="34" WIDTH="13" VPOS="39" HPOS="237"/><SP HEIGHT="34" WIDTH="2" VPOS="39" HPOS="251"/><String WC="0.76999998092651367" CONTENT="^N^" HEIGHT="42" WIDTH="65" VPOS="39" HPOS="254"/></TextLine>
+</TextBlock><Illustration ID="Page1_Block2" HEIGHT="379" WIDTH="350" VPOS="38" HPOS="76"/>
+<TextBlock ID="Page1_Block3" HEIGHT="29" WIDTH="68" VPOS="388" HPOS="209" LANG="en-US" STYLEREFS="StyleId-F145EB33-BA39-4F3E-9C58-AD8181180B9A-">
+<TextLine BASELINE="415" HEIGHT="26" WIDTH="66" VPOS="389" HPOS="209"><String WC="0.38249999284744263" CONTENT="1891" HEIGHT="26" WIDTH="66" VPOS="389" HPOS="209"/></TextLine>
+</TextBlock>
+</PrintSpace>
+</Page>
+</Layout>
+</alto>

--- a/spec/lib/dor/text_extraction/abbyy/split_alto_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/split_alto_spec.rb
@@ -15,4 +15,12 @@ describe Dor::TextExtraction::Abbyy::SplitAlto do
   it 'expects output path to be same as alto_path' do
     expect(results.send(:output_path, 'bb222cc3333_00_0001.xml')).to include 'spec/fixtures/ocr/bb222cc3333_00_0001.xml'
   end
+
+  context 'when alto sourceImageInformation is in different format' do
+    let(:druid) { 'bb999cc1111' }
+
+    it 'splits into a single file' do
+      expect(results.send(:split_to_files).keys).to eq ['example.xml']
+    end
+  end
 end

--- a/spec/robots/dor_repo/ocr/split_ocr_xml_spec.rb
+++ b/spec/robots/dor_repo/ocr/split_ocr_xml_spec.rb
@@ -37,4 +37,9 @@ describe Robots::DorRepo::Ocr::SplitOcrXml do
     expect(created_files).to eq ['bb222cc3333_00_0001.xml', 'bb222cc3333_00_0002.xml', 'bb222cc3333_00_0003.xml']
     expect(created_files.all? { |file| File.exist?(File.join(output_path, file)) }).to be true
   end
+
+  it 'there is no file' do
+    created_files = test_perform(robot, druid)
+    expect(created_files).to be_nil
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔
For some reason abbyy alto sometimes have a different value under sourceImageInformation (sometimes fileName, sometimes fileIdentifier). This just looks for nodes underneath sourceImageInformation.

Also if there is a PDF we don't get an alto to split so this makes sure that it doesn't try if the alto file doesn't exist.


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡
Rspec