### PR TITLE
skip all steps in the ocrWF if object cannot be OCRed

### DIFF
--- a/lib/robots/dor_repo/ocr/start_ocr.rb
+++ b/lib/robots/dor_repo/ocr/start_ocr.rb
@@ -28,7 +28,8 @@ module Robots
           note = 'No files available or invalid object for OCR'
           workflow = workflow_service.workflow(pid: druid, workflow_name:)
           # get all of the incomplete steps, except for ourself (start-ocr), we will set that with the usual ReturnState
-          incomplete_steps = workflow.incomplete_processes.map(&:name).reject { |step| step == 'start-ocr' }
+          # and set them to skipped in inverse order (last one gets skipped first to avoid any later steps running)
+          incomplete_steps = workflow.incomplete_processes.map(&:name).reject { |step| step == 'start-ocr' }.reverse
           incomplete_steps.each { |process| workflow_service.update_status(druid:, workflow: workflow_name, process:, status:, note:) }
           LyberCore::ReturnState.new(status: status.to_sym, note:)
         end

--- a/lib/robots/dor_repo/ocr/start_ocr.rb
+++ b/lib/robots/dor_repo/ocr/start_ocr.rb
@@ -11,9 +11,26 @@ module Robots
 
         def perform_work
           raise 'Object is already open' if object_client.version.status.open?
-          raise 'No files available or invalid object for OCR' unless Dor::TextExtraction::Ocr.new(cocina_object:).possible?
 
-          object_client.version.open(description: 'Start OCR workflow')
+          if Dor::TextExtraction::Ocr.new(cocina_object:).possible?
+            object_client.version.open(description: 'Start OCR workflow')
+          else
+            skip_workflow
+          end
+        end
+
+        private
+
+        # skip entire ocrWF workflow without opening version if OCR is not possible for this object
+        def skip_workflow
+          workflow_name = 'ocrWF'
+          status = 'skipped'
+          note = 'No files available or invalid object for OCR'
+          workflow = workflow_service.workflow(pid: druid, workflow_name:)
+          # get all of the incomplete steps, except for ourself (start-ocr), we will set that with the usual ReturnState
+          incomplete_steps = workflow.incomplete_processes.map(&:name).reject { |step| step == 'start-ocr' }
+          incomplete_steps.each { |process| workflow_service.update_status(druid:, workflow: workflow_name, process:, status:, note:) }
+          LyberCore::ReturnState.new(status: status.to_sym, note:)
         end
       end
     end

--- a/spec/robots/dor_repo/ocr/start_ocr_spec.rb
+++ b/spec/robots/dor_repo/ocr/start_ocr_spec.rb
@@ -17,9 +17,7 @@ describe Robots::DorRepo::Ocr::StartOcr do
   let(:object_client) do
     instance_double(Dor::Services::Client::Object, version: version_client, workspace: workspace_client, find: object)
   end
-  let(:ocr) do
-    instance_double(Dor::TextExtraction::Ocr, possible?: possible)
-  end
+  let(:ocr) { instance_double(Dor::TextExtraction::Ocr, possible?: possible) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
@@ -39,9 +37,32 @@ describe Robots::DorRepo::Ocr::StartOcr do
   context 'when the object is not opened and is not possible to OCR' do
     let(:version_open) { false }
     let(:possible) { false }
+    let(:note) { 'No files available or invalid object for OCR' }
+    let(:workflow) { 'ocrWF' }
+    let(:status) { 'skipped' }
+    let(:workflow_client) { instance_double(Dor::Workflow::Client, workflow: workflow_response) }
+    let(:workflow_response) { instance_double(Dor::Workflow::Response::Workflow, incomplete_processes: [start_ocr, fetch_files, ocr_create, end_ocr]) }
+    # NOTE: this is just mocking a workflow response, it doesn't actually have to be fully accurate
+    # we just need to expect we will update the status of all steps except start-ocr
+    let(:start_ocr) { instance_double(Dor::Workflow::Response::Process, name: 'start-ocr') }
+    let(:fetch_files) { instance_double(Dor::Workflow::Response::Process, name: 'fetch-files') }
+    let(:ocr_create) { instance_double(Dor::Workflow::Response::Process, name: 'ocr-create') }
+    let(:end_ocr) { instance_double(Dor::Workflow::Response::Process, name: 'end-ocr') }
 
-    it 'raise an error' do
-      expect { perform }.to raise_error('No files available or invalid object for OCR')
+    let(:return_status) { perform.status }
+
+    before do
+      allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+      allow(workflow_client).to receive(:update_status)
+    end
+
+    it 'sets all steps (except self) in the workflow to waiting and returns status of skipped for self' do
+      perform
+      expect(workflow_client).not_to have_received(:update_status).with(druid:, workflow:, process: 'start-ocr', status:, note:)
+      expect(workflow_client).to have_received(:update_status).with(druid:, workflow:, process: 'fetch-files', status:, note:)
+      expect(workflow_client).to have_received(:update_status).with(druid:, workflow:, process: 'ocr-create', status:, note:)
+      expect(workflow_client).to have_received(:update_status).with(druid:, workflow:, process: 'end-ocr', status:, note:)
+      expect(return_status).to eq status
     end
   end
 

--- a/spec/robots/dor_repo/ocr/start_ocr_spec.rb
+++ b/spec/robots/dor_repo/ocr/start_ocr_spec.rb
@@ -56,7 +56,7 @@ describe Robots::DorRepo::Ocr::StartOcr do
       allow(workflow_client).to receive(:update_status)
     end
 
-    it 'sets all steps (except self) in the workflow to waiting and returns status of skipped for self' do
+    it 'sets all steps (except self) in the workflow to skipped and returns status of skipped for self' do
       perform
       expect(workflow_client).not_to have_received(:update_status).with(druid:, workflow:, process: 'start-ocr', status:, note:)
       expect(workflow_client).to have_received(:update_status).with(druid:, workflow:, process: 'fetch-files', status:, note:)


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1259 - mark all ocrWF steps as skipped instead of raising an error if the workflow is started but there is nothing to ocr.  This allows the object to be versioned and fixed if needed instead of putting it in error.

~~HOLD for testing on QA~~

See https://argo-qa.stanford.edu/view/druid:bv915yp9350 for test object on argo-qa that was skipped (google book with no images)

## How was this change tested? 🤨

Updated specs
QA