### PR TITLE
Use sudo to restart ABBYY watcher

### DIFF
--- a/lib/capistrano/tasks/abbyy_watcher_systemd.cap
+++ b/lib/capistrano/tasks/abbyy_watcher_systemd.cap
@@ -5,7 +5,7 @@ namespace :abbyy_watcher_systemd do
   task :restart do
     on fetch(:abbyy_watcher_server) do
       within release_path do
-        execute 'systemctl restart abbyy_watcher'
+        execute 'sudo systemctl restart abbyy_watcher'
       end
     end
   end


### PR DESCRIPTION
You don't need sudo to read the logs/status, but you apparently
do to restart the process!
