### PR TITLE
Switch Cocina::Model::ReleaseTag to Dor::Services::Client::ReleaseTag

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3.3)
+    activesupport (7.1.3.4)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -69,9 +69,9 @@ GEM
       thor
       zeitwerk (~> 2.1)
     coderay (1.1.3)
-    commonmarker (1.1.3)
+    commonmarker (1.1.4)
       rb_sys (~> 0.9)
-    commonmarker (1.1.3-x86_64-linux)
+    commonmarker (1.1.4-x86_64-linux)
     concurrent-ruby (1.3.1)
     config (5.5.1)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -94,7 +94,7 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.0)
-    dor-services-client (14.11.0)
+    dor-services-client (14.12.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.97.0)
       deprecation
@@ -135,7 +135,7 @@ GEM
       activesupport (>= 3.0, < 8.0)
     equivalent-xml (0.6.0)
       nokogiri (>= 1.4.3)
-    faraday (2.9.0)
+    faraday (2.9.1)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
       net-http
@@ -144,7 +144,7 @@ GEM
     ffi (1.17.0)
     ffi (1.17.0-x86_64-linux-gnu)
     hashdiff (1.1.0)
-    honeybadger (5.10.2)
+    honeybadger (5.11.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
@@ -171,7 +171,7 @@ GEM
     method_source (1.1.0)
     mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2024.0507)
+    mime-types-data (3.2024.0604)
     mini_exiftool (2.11.0)
     mini_portile2 (2.8.7)
     minitest (5.23.1)

--- a/spec/robots/dor_repo/release/release_members_spec.rb
+++ b/spec/robots/dor_repo/release/release_members_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
     end
 
     context 'when the collection is released to self only' do
-      let(:release_tag1) { Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') }
+      let(:release_tag1) { Dor::Services::Client::ReleaseTag.new(to: 'Searchworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') }
       let(:release_tags) { [release_tag1] }
 
       let(:members) do
@@ -66,8 +66,8 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
     end
 
     context 'when there are multiple targets but they are all released to self only' do
-      let(:release_tag1) { Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') } # rubocop:disable RSpec/IndexedLet
-      let(:release_tag2) { Cocina::Models::ReleaseTag.new(to: 'Earthworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'petucket') } # rubocop:disable RSpec/IndexedLet
+      let(:release_tag1) { Dor::Services::Client::ReleaseTag.new(to: 'Searchworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') } # rubocop:disable RSpec/IndexedLet
+      let(:release_tag2) { Dor::Services::Client::ReleaseTag.new(to: 'Earthworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'petucket') } # rubocop:disable RSpec/IndexedLet
       let(:release_tags) { [release_tag1, release_tag2] }
       let(:members) do
         [Dor::Services::Client::Members::Member.new(externalIdentifier: 'druid:bb001zc5754', version: 1)]
@@ -80,8 +80,8 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
     end
 
     context 'with multiple tags for a single target' do
-      let(:release_tag1) { Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: true, what: 'self', date: '2019-03-09 19:34:43 UTC', who: 'hfrost ') } # rubocop:disable RSpec/IndexedLet
-      let(:release_tag2) { Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: false, what: 'self', date: '2020-02-07 19:34:43 UTC', who: 'jkalchik') } # rubocop:disable RSpec/IndexedLet
+      let(:release_tag1) { Dor::Services::Client::ReleaseTag.new(to: 'Searchworks', release: true, what: 'self', date: '2019-03-09 19:34:43 UTC', who: 'hfrost ') } # rubocop:disable RSpec/IndexedLet
+      let(:release_tag2) { Dor::Services::Client::ReleaseTag.new(to: 'Searchworks', release: false, what: 'self', date: '2020-02-07 19:34:43 UTC', who: 'jkalchik') } # rubocop:disable RSpec/IndexedLet
       let(:release_tags) { [release_tag1, release_tag2] }
       let(:members) do
         [Dor::Services::Client::Members::Member.new(externalIdentifier: 'druid:bb001zc5754', version: 1)]
@@ -94,7 +94,7 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
     end
 
     context 'when the collection is not released to self' do
-      let(:release_tag1) { Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: true, what: 'collection', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') }
+      let(:release_tag1) { Dor::Services::Client::ReleaseTag.new(to: 'Searchworks', release: true, what: 'collection', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') }
       let(:release_tags) { [release_tag1] }
       let(:members) do
         [
@@ -113,8 +113,8 @@ RSpec.describe Robots::DorRepo::Release::ReleaseMembers do
     end
 
     context 'when there are multiple targets and at least one of the release targets is not released to self' do
-      let(:release_tag1) { Cocina::Models::ReleaseTag.new(to: 'Searchworks', release: true, what: 'collection', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') } # rubocop:disable RSpec/IndexedLet
-      let(:release_tag2) { Cocina::Models::ReleaseTag.new(to: 'Earthworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'petucket') } # rubocop:disable RSpec/IndexedLet
+      let(:release_tag1) { Dor::Services::Client::ReleaseTag.new(to: 'Searchworks', release: true, what: 'collection', date: '2016-10-07 19:34:43 UTC', who: 'lmcrae') } # rubocop:disable RSpec/IndexedLet
+      let(:release_tag2) { Dor::Services::Client::ReleaseTag.new(to: 'Earthworks', release: true, what: 'self', date: '2016-10-07 19:34:43 UTC', who: 'petucket') } # rubocop:disable RSpec/IndexedLet
       let(:release_tags) { [release_tag1, release_tag2] }
       let(:members) do
         [


### PR DESCRIPTION
## Why was this change made? 🤔

Required for removing ReleaseTag from cocina-models


## How was this change tested? 🤨

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


