### PR TITLE
ALTO XML split robot: ensure all expected nodes are in each split file

### DIFF
--- a/lib/dor/text_extraction/abbyy/split_alto.rb
+++ b/lib/dor/text_extraction/abbyy/split_alto.rb
@@ -30,10 +30,10 @@ module Dor
           Nokogiri::XML::Builder.new do |xml|
             xml.alto(namespaces) do
               xml.Description do
-                doc.css('//MeasurementUnit').each { |node| xml.parent << node }
-                doc.css('//OCRProcessing').each { |node| xml.parent << node }
+                doc.css('//MeasurementUnit').each { |node| xml.parent << node.dup }
+                doc.css('//OCRProcessing').each { |node| xml.parent << node.dup }
               end
-              doc.css('//Styles').each { |node| xml.parent << node }
+              doc.css('//Styles').each { |node| xml.parent << node.dup }
               xml.Layout do
                 xml.parent << page
               end


### PR DESCRIPTION
## Why was this change made? 🤔

~~To address #1278 (hopefully) and maybe #1279~~

Does not seem to address #1278 or #1279 but I think we still want it.

The `<Description>` nodes are currently only added to the first page level XML document.  This ensures they get added to all.  Compare the working and non-working objects in the original ticket to see this.

~~HOLD for testing on QA~~

## How was this change tested? 🤨

Localhost and QA