### PR TITLE
do not set role=transcription for txt ocr files

### DIFF
--- a/lib/dor/text_extraction/cocina_updater.rb
+++ b/lib/dor/text_extraction/cocina_updater.rb
@@ -169,7 +169,7 @@ module Dor
         Cocina::Models::File.new(
           externalIdentifier: file_identifier,
           label: object_file.filename,
-          use: 'transcription',
+          use: use(object_file),
           sdrGeneratedText: true,
           correctedForAccessibility: false,
           type: Cocina::Models::ObjectType.file,
@@ -189,6 +189,11 @@ module Dor
           view: 'world',
           download: 'world'
         }
+      end
+
+      # set the use attribute based on the mimetype (only XML and PDF OCR files will have a use attribute set to 'transcription')
+      def use(object_file)
+        %w[application/pdf application/xml].include?(object_file.mimetype) ? 'transcription' : nil
       end
 
       def administrative

--- a/spec/lib/dor/text_extraction/cocina_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/cocina_updater_spec.rb
@@ -78,7 +78,7 @@ describe Dor::TextExtraction::CocinaUpdater do
       file = resource1_files[1]
       expect(file.label).to eq 'image1.txt'
       expect(file.filename).to eq 'image1.txt'
-      expect(file.use).to eq 'transcription'
+      expect(file.use).to be_nil
       expect(file.sdrGeneratedText).to be true
       expect(file.correctedForAccessibility).to be false
       expect(file.access.view).to be 'world'

--- a/spec/robots/dor_repo/ocr/update_cocina_spec.rb
+++ b/spec/robots/dor_repo/ocr/update_cocina_spec.rb
@@ -55,10 +55,8 @@ describe Robots::DorRepo::Ocr::UpdateCocina do
   end
 
   context 'with an xml file' do
-    before do
-      # setup a fake OCR file in the workspace directory which matches the name of the image file in the Cocina
-      FileUtils.cp('spec/fixtures/ocr/001.xml', File.join(workspace_content_dir, 'image1.xml'))
-    end
+    # setup a fake OCR XML file in the workspace directory which matches the name of the image file in the Cocina
+    before { create_xml_file('image1.xml') }
 
     it 'runs the update cocina robot and sets the transcription role' do
       new_cocina = test_perform(robot, druid)
@@ -69,10 +67,8 @@ describe Robots::DorRepo::Ocr::UpdateCocina do
   end
 
   context 'with a txt file' do
-    before do
-      # setup a fake OCR file in the workspace directory which matches the name of the image file in the Cocina
-      FileUtils.cp('spec/fixtures/ocr/001.txt', File.join(workspace_content_dir, 'image1.txt'))
-    end
+    # setup a fake OCR txt file in the workspace directory which matches the name of the image file in the Cocina
+    before { create_txt_file('image1.txt') }
 
     it 'runs the update cocina robot and does not set the transcription role' do
       new_cocina = test_perform(robot, druid)

--- a/spec/robots/dor_repo/ocr/update_cocina_spec.rb
+++ b/spec/robots/dor_repo/ocr/update_cocina_spec.rb
@@ -52,16 +52,33 @@ describe Robots::DorRepo::Ocr::UpdateCocina do
     allow(Dor::Services::Client).to receive(:object).and_return(dsa_object_client)
 
     allow(DruidTools::Druid).to receive(:new).and_return(druid_tools)
-
-    # setup a fake OCR file in the workspace directory which matches the name of
-    # the image file in the Cocina
-    FileUtils.touch(File.join(workspace_content_dir, 'image1.xml'))
   end
 
-  it 'runs the update cocina robot' do
-    new_cocina = test_perform(robot, druid)
-    new_file = new_cocina.structural.contains[0].structural.contains[1]
-    expect(new_file.filename).to eq 'image1.xml'
-    expect(new_file.use).to eq 'transcription'
+  context 'with an xml file' do
+    before do
+      # setup a fake OCR file in the workspace directory which matches the name of the image file in the Cocina
+      FileUtils.cp('spec/fixtures/ocr/001.xml', File.join(workspace_content_dir, 'image1.xml'))
+    end
+
+    it 'runs the update cocina robot and sets the transcription role' do
+      new_cocina = test_perform(robot, druid)
+      new_file = new_cocina.structural.contains[0].structural.contains[1]
+      expect(new_file.filename).to eq 'image1.xml'
+      expect(new_file.use).to eq 'transcription'
+    end
+  end
+
+  context 'with a txt file' do
+    before do
+      # setup a fake OCR file in the workspace directory which matches the name of the image file in the Cocina
+      FileUtils.cp('spec/fixtures/ocr/001.txt', File.join(workspace_content_dir, 'image1.txt'))
+    end
+
+    it 'runs the update cocina robot and does not set the transcription role' do
+      new_cocina = test_perform(robot, druid)
+      new_file = new_cocina.structural.contains[0].structural.contains[1]
+      expect(new_file.filename).to eq 'image1.txt'
+      expect(new_file.use).to be_nil
+    end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1285 - presuming we want to be consistent with our current approach the way pre-assembly does it, we would not set role=transcription for txt OCR files

see https://github.com/sul-dlss/pre-assembly/blob/main/app/lib/pre_assembly/from_staging_location/file.rb#L28-L38 for how pre-assembly is set up

Discussion: https://stanfordlib.slack.com/archives/C06EVDJV45N/p1718220321336929

## How was this change tested? 🤨

Localhost