### PR TITLE
ensure workflow versions match object versions

### DIFF
--- a/lib/robots/dor_repo/accession/end_accession.rb
+++ b/lib/robots/dor_repo/accession/end_accession.rb
@@ -31,7 +31,7 @@ module Robots
             # start OCR workflow
             # Note: since the first step of ocrWF opens the version, we want the new ocrWF to be associated
             #       with the next object version
-            workflow_service.create_workflow_by_name(druid, 'ocrWF', version: (current_version.to_i + 1).to_s, lane_id:)
+            workflow_service.create_workflow_by_name(druid, 'ocrWF', version: (current_version.to_i + 1), lane_id:)
           end
 
           # TODO: Start captionioning text extraction workflow if needed

--- a/lib/robots/dor_repo/accession/end_accession.rb
+++ b/lib/robots/dor_repo/accession/end_accession.rb
@@ -29,7 +29,9 @@ module Robots
             raise 'Object cannot be OCRd' unless ocr.possible?
 
             # start OCR workflow
-            workflow_service.create_workflow_by_name(druid, 'ocrWF', version: current_version, lane_id:)
+            # Note: since the first step of ocrWF opens the version, we want the new ocrWF to be associated
+            #       with the next object version
+            workflow_service.create_workflow_by_name(druid, 'ocrWF', version: (current_version.to_i + 1).to_s, lane_id:)
           end
 
           # TODO: Start captionioning text extraction workflow if needed

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
         it 'does not start ocrWF' do
           perform
-          expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '2', lane_id: 'default')
+          expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default')
         end
       end
 
@@ -50,7 +50,7 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
         it 'starts ocrWF' do
           perform
-          expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '2', lane_id: 'default')
+          expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default')
         end
       end
 

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
         it 'does not start ocrWF' do
           perform
-          expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '1', lane_id: 'default')
+          expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '2', lane_id: 'default')
         end
       end
 
@@ -50,7 +50,7 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
         it 'starts ocrWF' do
           perform
-          expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '1', lane_id: 'default')
+          expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: '2', lane_id: 'default')
         end
       end
 


### PR DESCRIPTION
## Why was this change made? 🤔

When we create ocrWF, it will be in the next object version (since the first step of ocrWF is open the object version).  So start ocrWF with the next version up.  This ensures workflow service and SDR remain in sync. 

## How was this change tested? 🤨

QA