### PR TITLE
Revert "remove result.xml files after processing"

### DIFF
--- a/lib/dor/text_extraction/abbyy/file_watcher.rb
+++ b/lib/dor/text_extraction/abbyy/file_watcher.rb
@@ -64,7 +64,6 @@ module Dor
           @logger.info "Found successful OCR results for druid:#{results.druid} at #{results.result_path}"
           @workflow_updater.mark_ocr_completed("druid:#{results.druid}")
           create_event(type: 'ocr_success', results:)
-          FileUtils.rm_f(results.result_path)
         end
 
         # Notify SDR that the OCR workflow step failed
@@ -74,7 +73,6 @@ module Dor
           Honeybadger.notify('Found failed OCR results', context:)
           @workflow_updater.mark_ocr_errored("druid:#{results.druid}", error_msg: results.failure_messages.join("\n"))
           create_event(type: 'ocr_errored', results:)
-          FileUtils.rm_f(results.result_path)
         end
 
         # Publish to the SDR event service with processing information

--- a/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
@@ -13,7 +13,6 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
   let(:events_client) { instance_double(Dor::Services::Client::Events) }
   let(:listener_options) { { force_polling: true } }
   let(:file_watcher) { described_class.new(logger:, listener_options:) }
-  let(:xml_data) { Hash.new(path: '') }
 
   before do
     allow(Settings.sdr.abbyy).to receive_messages(
@@ -45,17 +44,13 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
     before do
       file_watcher.start
       copy_abbyy_alto(output_path:, druid: bare_druid, contents: alto_contents)
-      xml_data[:path] = create_abbyy_result(abbyy_result_xml_path, druid: bare_druid, contents: result_contents)
+      create_abbyy_result(abbyy_result_xml_path, druid: bare_druid, contents: result_contents)
       sleep(1) # Allow enough time to poll the filesystem
       file_watcher.stop
     end
 
     it 'updates the OCR workflow' do
       expect(workflow_updater).to have_received(:mark_ocr_completed).with(druid)
-    end
-
-    it 'removes the xml file' do
-      expect(File.exist?(xml_data[:path])).to be false
     end
 
     it 'logs the success' do
@@ -86,17 +81,13 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
 
     before do
       file_watcher.start
-      xml_data[:path] = create_abbyy_result(abbyy_exceptions_path, druid: bare_druid, success: false, contents: errors_xml)
+      create_abbyy_result(abbyy_exceptions_path, druid: bare_druid, success: false, contents: errors_xml)
       sleep(1) # Allow enough time to poll the filesystem
       file_watcher.stop
     end
 
     it 'updates the OCR workflow' do
       expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid, error_msg: "Error one\nError two")
-    end
-
-    it 'removes the xml file' do
-      expect(File.exist?(xml_data[:path])).to be false
     end
 
     it 'publishes an event' do

--- a/spec/support/abbyy_helper.rb
+++ b/spec/support/abbyy_helper.rb
@@ -32,7 +32,6 @@ def create_abbyy_result(base_path, druid:, run_index: 0, success: true, contents
   index_tag = run_index.positive? ? '.%04d'.format(run_index) : ''
   filename = File.join(base_path, "#{druid}#{index_tag}.xml.result.xml")
   change_fs(:added, filename, "<XmlResult IsFailed=\"#{!success}\">#{contents}</XmlResult>")
-  filename
 end
 
 def copy_abbyy_alto(output_path:, contents:, druid:)


### PR DESCRIPTION
Reverts sul-dlss/common-accessioning#1307

Turns out stage-files depends on the XML ticket file being there.  We should clean it up later (in the cleanup step)