### PR TITLE
Miscellaneous touchups (mostly to OCR cleanup)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -353,3 +353,8 @@ RSpec/RepeatedSubjectCall: # new in 2.27
   Enabled: true
 RSpec/UndescriptiveLiteralsDescription: # new in 2.29
   Enabled: true
+
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -43,13 +43,13 @@ module Dor
 
         # e.g. /abbyy/RESULTXML/ab123cd4567.xml.result.xml
         abbyy_results = Dor::TextExtraction::Abbyy::Results.find_latest(druid: bare_druid, logger:)
-        if abbyy_results # this could be nil if there is no latest result XML file located
+        if abbyy_results # this could be nil if there is no latest result XML file for this druid
           logger.info "Removing XML Result File: #{abbyy_results.result_path}"
           FileUtils.rm_f(abbyy_results.result_path)
         end
 
         # e.g. /abbyy/EXCEPTIONS/druid:ab123cd4567.xml.result.xml
-        abbyy_exceptions = Dir.glob("#{Settings.sdr.abbyy.local_exception_path}/*#{bare_druid}*")
+        abbyy_exceptions = Dir.glob("#{Settings.sdr.abbyy.local_exception_path}/*#{bare_druid}*.xml")
         abbyy_exceptions.each do |abbyy_exception_file|
           logger.info "Removing XML Exception File: #{abbyy_exception_file}"
           FileUtils.rm_f(abbyy_exception_file)

--- a/lib/tasks/cleanup.rake
+++ b/lib/tasks/cleanup.rake
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 namespace :abbyy do
   # ROBOT_ENVIRONMENT=production bundle exec rake abbyy:cleanup
-  desc 'Cleanup empty ABBYY input and output directories and older ABBYY tickets'
+  desc 'Cleanup empty ABBYY input and output directories and older ABBYY tickets (for clearing detritus from e.g. ABBYY runs that errored)'
   task cleanup: :environment do |_task, _args|
     # Delete XML Result files older than 1 week
     result_files = Dir.glob("#{Settings.sdr.abbyy.local_result_path}/*.xml")
@@ -21,7 +21,7 @@ namespace :abbyy do
 
     # Delete ABBYY input directories that are empty and ticket files older than 1 week
     input_entries = Dir.glob("#{Settings.sdr.abbyy.local_ticket_path}/*")
-    puts "Checking ABBYY input folders/files #{Settings.sdr.abbyy.local_ticket_path} for deletion: #{input_entries.size} folders found."
+    puts "Checking ABBYY input folders/files #{Settings.sdr.abbyy.local_ticket_path} for deletion: #{input_entries.size} folders/files found."
     num_deleted = 0
     input_entries.each do |entry|
       if File.directory?(entry) && Dir.empty?(entry)
@@ -32,6 +32,8 @@ namespace :abbyy do
         num_deleted += 1
         puts "Deleting ABBYY ticket file #{entry}"
         FileUtils.rm_f(entry)
+      else
+        puts "skipping #{entry} (if it's a directory, it wasn't empty; if it's a file, it was less than 1 week old)"
       end
     end
     puts "Deleted #{num_deleted} empty input folders or XML files older than 1 week."


### PR DESCRIPTION
## Why was this change made? 🤔

* slight clarity improvements (to a comment, a rake task description, and some terminal output)
* slightly safer ABBYY OCR cleanup code
* keep up with rubocop rules

## How was this change tested? 🤨

* ran unit tests locally
* ran modified rake task locally in both modes, after running unit tests, so that there'd be test data to clean up

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


