### PR TITLE
rescue for the correct exception for a retry

### DIFF
--- a/lib/robots/dor_repo/ocr/start_ocr.rb
+++ b/lib/robots/dor_repo/ocr/start_ocr.rb
@@ -26,7 +26,7 @@ module Robots
           tries = 0
           begin
             object_client.version.open(description: 'Start OCR workflow')
-          rescue Dor::Services::Client::Error => e
+          rescue Dor::Services::Client::UnexpectedResponse => e
             tries += 1
             sleep(2**tries)
 

--- a/spec/robots/dor_repo/ocr/start_ocr_spec.rb
+++ b/spec/robots/dor_repo/ocr/start_ocr_spec.rb
@@ -47,7 +47,7 @@ describe Robots::DorRepo::Ocr::StartOcr do
         count = 0
         allow(version_client).to receive(:open) do |*_args|
           count += 1
-          raise Dor::Services::Client::Error unless count > 2
+          raise Dor::Services::Client::UnexpectedResponse.new(response: 'nope') unless count > 2
 
           true
         end
@@ -61,10 +61,10 @@ describe Robots::DorRepo::Ocr::StartOcr do
     end
 
     context 'when open version fails and exceeds maximum tries' do
-      before { allow(version_client).to receive(:open).and_raise(Dor::Services::Client::Error) }
+      before { allow(version_client).to receive(:open).and_raise(Dor::Services::Client::UnexpectedResponse.new(response: 'nope')) }
 
       it 'logs to honeybadger and then raises the error' do
-        expect { perform }.to raise_error(Dor::Services::Client::Error)
+        expect { perform }.to raise_error(Dor::Services::Client::UnexpectedResponse)
         expect(version_client).to have_received(:open).thrice # shakespeare coding (all three times fail)
         expect(Honeybadger).to have_received(:notify).twice # two calls to HB for the first two failures
       end


### PR DESCRIPTION
## Why was this change made? 🤔

In order to correctly retry a situation where the object cannot be opened in start-ocr because it thinks it is still being accessioned, we need to rescue the correct exception.  

Here is an example showing what is raised when this happens: https://app.honeybadger.io/projects/52894/faults/108881704

```
Dor::Services::Client::UnexpectedResponse: Unable to open version (Object net yet accessioned)
                 
          exception_class = EXCEPTION_CLASS.fetch(response.status, UnexpectedResponse)
          raise exception_class.new(response: response,
                                    object_identifier: object_identifier,
                                    errors: data.fetch('errors', []))
```

This changes the rescue clause to catch the correct error: https://github.com/sul-dlss/dor-services-client/blob/main/lib/dor/services/client.rb#L43-L55

coming from https://github.com/sul-dlss/dor-services-client/blob/main/lib/dor/services/client.rb#L43-L55

Still no explanation for why this happens sometimes.  This happened for a very large object for which a number of steps ran slowly, but that shouldn't matter I don't think: https://argo-qa.stanford.edu/view/druid:xh838rk3862

This is where the source exception is coming from i believe, basically dor-services-client calls DSA and asks it to open, and then `.open` calls `ensure_openable!` first, which throws the exception.

https://github.com/sul-dlss/dor-services-app/blob/main/app/services/version_service.rb#L157-L158

This calls https://github.com/sul-dlss/dor-services-app/blob/main/app/services/workflow_state_service.rb#L55-L59 which looks for the lifecycle of `accessioned` via the workflow service, which I guess is coming back as missing at first.  Since all of the calls are to workflow-server-rails, once a completed step of end-accession is there, it should come back.  

This looks potentially suspicious, but has to do with solr which I don't think should matter in our case: https://github.com/sul-dlss/workflow-server-rails/blob/main/app/controllers/steps_controller.rb#L57-L61  