### PR TITLE
use new public: true tag for releases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'activesupport', '~> 7.0'
 gem 'assembly-image', '~> 2.0' # ruby-vips is used by 2.0.0 for improved image processing
 gem 'assembly-objectfile', '~> 2.1'
 gem 'config'
-gem 'dor-services-client', '~> 14.4'
+gem 'dor-services-client', '~> 14.6'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'dry-struct', '~> 1.0'
 gem 'dry-types', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.0)
-    dor-services-client (14.15.0)
+    dor-services-client (14.16.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.98.0)
       deprecation
@@ -328,7 +328,7 @@ DEPENDENCIES
   config
   debug
   dlss-capistrano
-  dor-services-client (~> 14.4)
+  dor-services-client (~> 14.6)
   dor-workflow-client (~> 7.0)
   druid-tools
   dry-struct (~> 1.0)

--- a/lib/robots/dor_repo/release/release_publish.rb
+++ b/lib/robots/dor_repo/release/release_publish.rb
@@ -25,7 +25,7 @@ module Robots
         end
 
         def release_tags
-          @release_tags ||= object_client.release_tags.list
+          @release_tags ||= object_client.release_tags.list(public: true) # we only want the latest public release tags
         end
 
         def targets_for(release:)

--- a/spec/robots/dor_repo/release/release_publish_spec.rb
+++ b/spec/robots/dor_repo/release/release_publish_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Robots::DorRepo::Release::ReleasePublish do
   let(:druid) { 'bb222cc3333' }
   let(:robot) { described_class.new }
   let(:object_client) { instance_double(Dor::Services::Client::Object, release_tags: release_tags_client) }
-  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags, list: release_tags) }
+  let(:release_tags_client) { instance_double(Dor::Services::Client::ReleaseTags) }
   let(:release_tags) do
     [
       Dor::Services::Client::ReleaseTag.new(
@@ -39,6 +39,7 @@ RSpec.describe Robots::DorRepo::Release::ReleasePublish do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
     allow(PurlFetcher::Client).to receive(:configure)
     allow(PurlFetcher::Client::ReleaseTags).to receive(:release)
+    allow(release_tags_client).to receive(:list).with(public: true).and_return(release_tags)
   end
 
   it 'calls purl fetcher with the release tags' do


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1325 - use only public release tags to ensure we don't incorrectly delete something that should actually be released.

Follow on from https://github.com/sul-dlss/dor-services-client/pull/455 which adds the ability to call this public param in DSA

## How was this change tested? 🤨

New spec