### PR TITLE
allow more time for cleanup retries

### DIFF
--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -36,9 +36,9 @@ module Dor
           cleanup_abbyy_exceptions
         rescue SystemCallError => e # SystemCallError is the superclass of all errors raised by system calls, such as Errno::ENOENT from FileUtils.rm_r
           tries += 1
-          sleep(2**tries)
+          sleep(3**tries)
 
-          raise e unless tries < 3
+          raise e unless tries < 4
 
           Honeybadger.notify('[NOTE] Problem deleting files and folders in ocrWF:ocr-workspace-cleanup', context: { druid: bare_druid, tries:, error: e })
           retry

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -208,12 +208,12 @@ RSpec.describe Dor::TextExtraction::Ocr do
         end
       end
 
-      context 'when the exception occurs three times' do
-        let(:num_errors) { 3 }
+      context 'when the exception occurs four times' do
+        let(:num_errors) { 4 }
 
         it 'raises the exception after trying three times' do
           expect { ocr.cleanup }.to raise_error(Errno::ENOENT)
-          expect(Honeybadger).to have_received(:notify).twice # two calls to HB, exception occurs third time
+          expect(Honeybadger).to have_received(:notify).thrice # three calls to HB, exception occurs fourth time
           expect(FileUtils).not_to have_received(:rm_r).with(ocr.abbyy_output_path)
         end
       end


### PR DESCRIPTION
## Why was this change made? 🤔

Allow for more time to retry the ocr cleanup step, since we are seeing some file latency issues in stage.  See https://app.honeybadger.io/projects/52894/faults/109731242/01J3G1TY9JXXT59N9QJPETQF0N

This issue was sporadic while running integration tests.  Will also follow up with OPs

## How was this change tested? 🤨

Localhost with updated CI

