### PR TITLE
do not HB alert on each retry; reduce parsing of XML

### DIFF
--- a/lib/dor/text_extraction/abbyy/results.rb
+++ b/lib/dor/text_extraction/abbyy/results.rb
@@ -127,7 +127,7 @@ module Dor
         # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         # Software and version used to do OCR processing, found in ALTO output
         def processing_metadata
-          return {} unless File.exist? alto_doc # PDFs don't have ALTO, so just bail out
+          return {} unless alto_doc && File.exist?(alto_doc) # PDFs don't have ALTO, so just bail out
 
           Nokogiri::XML::Reader(File.read(alto_doc)).each do |node|
             next unless node.name == 'processingSoftware'
@@ -140,7 +140,7 @@ module Dor
             break
           end
         rescue StandardError # If we can't parse the ALTO, log it and move on
-          Honeybadger.notify('Failed to parse processing metadata from ALTO XML', context: { alto_doc: })
+          Honeybadger.notify('Failed to parse processing metadata from ALTO XML', context: { result_path:, alto_doc: })
           {}
         end
         # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/dor/text_extraction/abbyy/results.rb
+++ b/lib/dor/text_extraction/abbyy/results.rb
@@ -14,13 +14,11 @@ module Dor
 
         # Find the latest Abbyy results XML file by druid, since there could be more than one.
         # @param druid [String] The druid to use to look for results
-        # @param logger [Logger] An optional logger to use
-        # @return [Results, nil] The Results object or nil, if one wasn't found.
-        def self.find_latest(druid:, logger: nil)
+        # @return [xml_filepath, nil] The result xml file path or nil, if one wasn't found.
+        def self.find_latest(druid:)
           bare_druid = DruidTools::Druid.new(druid).id
           # NOTE: Dir.glob will sort the filenames in ascending order and we want the last one.
-          result_files = Dir.glob("#{Settings.sdr.abbyy.local_result_path}/#{bare_druid}*.xml")
-          Results.new(result_path: result_files.last, logger:) unless result_files.empty?
+          Dir.glob("#{Settings.sdr.abbyy.local_result_path}/#{bare_druid}*.xml").last
         end
 
         def initialize(result_path:, logger: nil)

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -23,11 +23,12 @@ module Dor
       end
 
       # rubocop:disable Metrics/MethodLength
+      # rubocop:disable Metrics/AbcSize
       def cleanup
         raise "#{abbyy_input_path} is not empty" if Dir.exist?(abbyy_input_path) && !Dir.empty?(abbyy_input_path)
 
         tries = 0
-        max_tries = 4
+        max_tries = 5
         begin
           cleanup_input_folder
           cleanup_output_folder
@@ -38,6 +39,8 @@ module Dor
           tries += 1
           sleep(3**tries)
 
+          logger.info "Retrying cleanup after exception #{e.message}"
+
           retry if tries < max_tries
 
           raise e
@@ -45,6 +48,7 @@ module Dor
         true
       end
       # rubocop:enable Metrics/MethodLength
+      # rubocop:enable Metrics/AbcSize
 
       def possible?
         # only items can be OCR'd
@@ -79,7 +83,8 @@ module Dor
       def cleanup_input_folder
         return unless Dir.exist?(abbyy_input_path)
 
-        logger.info "Removing empty ABBYY input directory: #{abbyy_input_path}"
+        files = Dir.glob("#{abbyy_input_path}/*")
+        logger.info "Removing ABBYY input directory: #{abbyy_input_path}.  Has #{files.count} files/folders: #{files.join(', ')}."
         FileUtils.rm_r(abbyy_input_path)
       end
 
@@ -87,7 +92,8 @@ module Dor
       def cleanup_output_folder
         return unless Dir.exist?(abbyy_output_path)
 
-        logger.info "Removing ABBYY output directory: #{abbyy_output_path}"
+        files = Dir.glob("#{abbyy_output_path}/*")
+        logger.info "Removing ABBYY output directory: #{abbyy_output_path}.  Has #{files.count} files/folders: #{files.join(', ')}."
         FileUtils.rm_r(abbyy_output_path)
       end
 

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -39,7 +39,7 @@ module Dor
           tries += 1
           sleep(3**tries)
 
-          logger.info "Retrying cleanup after exception #{e.message}"
+          logger.info "Retry #{tries} for ocr-workspace-cleanup; after exception #{e.message}"
 
           retry if tries < max_tries
 
@@ -84,7 +84,7 @@ module Dor
         return unless Dir.exist?(abbyy_input_path)
 
         files = Dir.glob("#{abbyy_input_path}/*")
-        logger.info "Removing ABBYY input directory: #{abbyy_input_path}.  Has #{files.count} files/folders: #{files.join(', ')}."
+        logger.info "Removing ABBYY input directory: #{abbyy_input_path}.  Empty: #{Dir.empty?(abbyy_input_path)}. Num files/folders: #{files.count}: #{files.join(', ')}"
         FileUtils.rm_r(abbyy_input_path)
       end
 
@@ -93,7 +93,7 @@ module Dor
         return unless Dir.exist?(abbyy_output_path)
 
         files = Dir.glob("#{abbyy_output_path}/*")
-        logger.info "Removing ABBYY output directory: #{abbyy_output_path}.  Has #{files.count} files/folders: #{files.join(', ')}."
+        logger.info "Removing ABBYY output directory: #{abbyy_output_path}.  Empty: #{Dir.empty?(abbyy_output_path)}. Num files/folders: #{files.count}: #{files.join(', ')}"
         FileUtils.rm_r(abbyy_output_path)
       end
 

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -23,7 +23,6 @@ module Dor
       end
 
       # rubocop:disable Metrics/MethodLength
-      # rubocop:disable Metrics/AbcSize
       def cleanup
         raise "#{abbyy_input_path} is not empty" if Dir.exist?(abbyy_input_path) && !Dir.empty?(abbyy_input_path)
 
@@ -41,13 +40,11 @@ module Dor
 
           retry if tries < max_tries
 
-          Honeybadger.notify('[NOTE] Problem deleting files and folders in ocrWF:ocr-workspace-cleanup', context: { druid: bare_druid, tries:, error: e })
           raise e
         end
         true
       end
       # rubocop:enable Metrics/MethodLength
-      # rubocop:enable Metrics/AbcSize
 
       def possible?
         # only items can be OCR'd

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -27,7 +27,7 @@ module Dor
         raise "#{abbyy_input_path} is not empty" if Dir.exist?(abbyy_input_path) && !Dir.empty?(abbyy_input_path)
 
         tries = 0
-        max_tries = 3
+        max_tries = 4
         begin
           cleanup_input_folder
           cleanup_output_folder

--- a/lib/robots/dor_repo/ocr/stage_files.rb
+++ b/lib/robots/dor_repo/ocr/stage_files.rb
@@ -19,9 +19,10 @@ module Robots
         def move_files(workspace_dir)
           content_dir = File.join(workspace_dir, 'content')
 
-          abbyy_results = Dor::TextExtraction::Abbyy::Results.find_latest(druid:, logger:)
-          raise 'No ABBYY Result XML file found' unless abbyy_results
+          result_path = Dor::TextExtraction::Abbyy::Results.find_latest(druid:)
+          raise 'No ABBYY Result XML file found' unless result_path
 
+          abbyy_results = Dor::TextExtraction::Abbyy::Results.new(result_path:, logger:)
           abbyy_results.move_result_files(content_dir)
         end
       end

--- a/spec/lib/dor/text_extraction/abbyy/results_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/results_spec.rb
@@ -55,9 +55,9 @@ describe Dor::TextExtraction::Abbyy::Results do
       expect(results.alto_doc).to eq "#{abbyy_output_path}/bb222cc3333/bb222cc3333.xml"
     end
 
-    it 'can be found by druid' do
-      found = described_class.find_latest(druid:)
-      expect(found.druid).to eq druid
+    it 'can be found by druid and returns file path' do
+      result_path = described_class.find_latest(druid:)
+      expect(result_path).to eq results_file_path
     end
 
     it 'records the software name and version' do

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -207,10 +207,10 @@ RSpec.describe Dor::TextExtraction::Ocr do
         end
       end
 
-      context 'when the exception occurs four times' do
-        let(:num_errors) { 4 }
+      context 'when the exception occurs five times' do
+        let(:num_errors) { 5 }
 
-        it 'raises the exception after trying three times' do
+        it 'raises the exception after trying four times' do
           expect { ocr.cleanup }.to raise_error(Errno::ENOENT)
           expect(FileUtils).not_to have_received(:rm_r).with(ocr.abbyy_output_path)
         end

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -212,7 +212,6 @@ RSpec.describe Dor::TextExtraction::Ocr do
 
         it 'raises the exception after trying three times' do
           expect { ocr.cleanup }.to raise_error(Errno::ENOENT)
-          expect(Honeybadger).to have_received(:notify).once # one call to HB, exception occurs fourth time
           expect(FileUtils).not_to have_received(:rm_r).with(ocr.abbyy_output_path)
         end
       end

--- a/spec/robots/dor_repo/ocr/stage_files_spec.rb
+++ b/spec/robots/dor_repo/ocr/stage_files_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 describe Robots::DorRepo::Ocr::StageFiles do
   let(:druid) { 'druid:bb222cc3333' }
   let(:robot) { described_class.new }
+  let(:result_path) { '/fake/abbyy/results.xml' }
 
   let(:workspace_client) do
     instance_double(Dor::Services::Client::Workspace, create: '/fake/dor/workspace')
@@ -21,9 +22,10 @@ describe Robots::DorRepo::Ocr::StageFiles do
   context 'when there are files to move' do
     before do
       allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+      allow(Dor::TextExtraction::Abbyy::Results).to receive(:find_latest).with(druid:).and_return(result_path)
       allow(Dor::TextExtraction::Abbyy::Results)
-        .to receive(:find_latest)
-        .with(hash_including(druid:))
+        .to receive(:new)
+        .with(hash_including(result_path:))
         .and_return(results)
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Does five things:

1. Do not send an HB alert each time we attempt to retry deletion of a folder.  This better mimics what is done elsewhere in the code here https://github.com/sul-dlss/common-accessioning/blob/main/lib/robots/dor_repo/ocr/fetch_files.rb#L47-L60 where we only alert if there is an eventual failure.
2. Do not parse the result XML file if we only need to see if a file exists with `find_latest`, otherwise the ocr-workspace-cleanup step is going to have to  unnecessary re-parse that XML file when it all wants to do is delete the file.
3. Stop this HB alert from triggering for PDF docs (which do not have an ALTO file to parse): https://app.honeybadger.io/projects/52894/faults/111166939
4. Adds an extra retry to the cleanup (was still seeing some flakiness even on main)
5. Adds some extra logging to the cleanup to see if we get any more clues as to why it's needed.

## How was this change tested? 🤨

Unit tests and on stage