### PR TITLE
speed up testing by allowing backoff to be set for open version retries

### DIFF
--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -5,13 +5,14 @@ module Dor
     # Determine if OCR is required and possible for a given object
     # rubocop:disable Metrics/ClassLength
     class Ocr
-      attr_reader :cocina_object, :workflow_context, :bare_druid, :logger
+      attr_reader :cocina_object, :workflow_context, :bare_druid, :logger, :backoff
 
-      def initialize(cocina_object:, workflow_context: {}, logger: nil)
+      def initialize(cocina_object:, workflow_context: {}, backoff: 3, logger: nil)
         @cocina_object = cocina_object
         @workflow_context = workflow_context
         @bare_druid = cocina_object.externalIdentifier.delete_prefix('druid:')
         @logger = logger || Logger.new($stdout)
+        @backoff = backoff
       end
 
       def abbyy_output_path
@@ -37,7 +38,7 @@ module Dor
           cleanup_abbyy_exceptions
         rescue SystemCallError => e # SystemCallError is the superclass of all errors raised by system calls, such as Errno::ENOENT from FileUtils.rm_r
           tries += 1
-          sleep(3**tries)
+          sleep(backoff**tries)
 
           logger.info "Retry #{tries} for ocr-workspace-cleanup; after exception #{e.message}"
 

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Dor::TextExtraction::Ocr do
-  let(:ocr) { described_class.new(cocina_object:, workflow_context:) }
+  let(:ocr) { described_class.new(cocina_object:, workflow_context:, backoff: 1) } # setting a backoff of 1 to make testing much faster
   let(:ticket) { Dor::TextExtraction::Abbyy::Ticket.new(filepaths: [], druid:) }
   let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
   let(:workflow_context) { {} }


### PR DESCRIPTION
## Why was this change made? 🤔

Running test suite is slow locally when you have to wait for a lot of retries with a long wait time between each.  This lets us set it so we can wait less if needed (e.g. for testing).

## How was this change tested? 🤨

Unit tests