### PR TITLE
refactor fetch-files robot into own class

### DIFF
--- a/lib/dor/text_extraction/file_fetcher.rb
+++ b/lib/dor/text_extraction/file_fetcher.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+module Dor
+  module TextExtraction
+    # Fetch files from preservation to make them available for text extraction (ocr or speech-to-text)
+    class FileFetcher
+      attr_reader :druid, :logger
+
+      def initialize(druid:, logger:)
+        @druid = druid
+        @logger = logger
+      end
+
+      # Fetch an item's file from Preservation and write it to disk. Since
+      # we've observed inconsistency in QA and Stage with the NFS volumes
+      # where files are written, we need to recheck.
+      # @param [String] filename the filename to fetch
+      # @param [Pathname] path the path to write the file to (leave off if you don't want to write to disk)
+      # @param [String] cloud_endpoint the cloud endpoint to send the file to (leave off if you don't want to send to cloud)
+      # @param [Integer] max_tries the number of times to retry fetching the file
+      # rubocop:disable Metrics/MethodLength
+      def write_file_with_retries(filename:, max_tries: 3, path: nil, cloud_endpoint: nil)
+        tries = 0
+        written = false
+        begin
+          if path
+            written = fetch_and_write_file_to_disk(filename:, path:)
+          elsif cloud_endpoint
+            written = fetch_and_send_file_to_s3(filename:, cloud_endpoint:)
+          end
+        rescue Faraday::ResourceNotFound
+          tries += 1
+          logger.warn("received NotFoundError from Preservation try ##{tries}")
+
+          sleep(2**tries)
+
+          retry unless tries > max_tries
+
+          context = { druid:, filename:, path: path.to_s, cloud_endpoint:, max_tries: }
+          logger.error("Exceeded max_tries attempting to fetch file: #{context}")
+          Honeybadger.notify('Exceeded max_tries attempting to fetch file', context:)
+        end
+
+        written
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      # fetch a file from preservation and send to cloud endpoint
+      # TODO: implement this method for AWS S3, it will be used for the speech-to-text workflow
+      def fetch_and_send_file_to_s3(filename:, cloud_endpoint:)
+        logger.info("fetching #{filename} for #{druid} and sending to #{cloud_endpoint}")
+        preservation_client.objects.content(
+          druid:,
+          filepath: filename,
+          on_data: proc { |_data, _count| } # actually send the file to the cloud endpoint
+        )
+
+        true # NOTE: return false on failure
+      end
+
+      # fetch a file from perservation and write to disk
+      def fetch_and_write_file_to_disk(filename:, path:)
+        path.open('wb') do |file_writer|
+          logger.info("fetching #{filename} for #{druid} and saving to #{path}")
+          preservation_client.objects.content(
+            druid:,
+            filepath: filename,
+            on_data: proc { |data, _count| file_writer.write(data) }
+          )
+        end
+
+        true
+      end
+
+      private
+
+      def preservation_client
+        @preservation_client ||= Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)
+      end
+    end
+  end
+end

--- a/lib/dor/text_extraction/file_fetcher.rb
+++ b/lib/dor/text_extraction/file_fetcher.rb
@@ -14,20 +14,23 @@ module Dor
       # Fetch an item's file from Preservation and write it to disk. Since
       # we've observed inconsistency in QA and Stage with the NFS volumes
       # where files are written, we need to recheck.
+      # This method will retry fetching the file up to `max_tries` times.
       # @param [String] filename the filename to fetch
-      # @param [Pathname] path the path to write the file to (leave off if you don't want to write to disk)
-      # @param [String] cloud_endpoint the cloud endpoint to send the file to (leave off if you don't want to send to cloud)
+      # @param [Pathname] path the path to write the file to (leave off if sending to cloud)
+      # @param [String] bucket the S3 bucket to write the file to (leave off if sending to disk)
+      # @param [Symbol] method (could be :file or :cloud), default to :file
       # @param [Integer] max_tries the number of times to retry fetching the file
+      # @return [Boolean] true if the file was fetched and written, false otherwise
       # rubocop:disable Metrics/MethodLength
-      def write_file_with_retries(filename:, max_tries: 3, path: nil, cloud_endpoint: nil)
+      def write_file_with_retries(filename:, max_tries: 3, path: nil, bucket: nil, method: :file)
         tries = 0
         written = false
         begin
-          if path
-            written = fetch_and_write_file_to_disk(filename:, path:)
-          elsif cloud_endpoint
-            written = fetch_and_send_file_to_s3(filename:, cloud_endpoint:)
-          end
+          written = if method == :file
+                      fetch_and_write_file_to_disk(filename:, path:)
+                    else
+                      fetch_and_send_file_to_s3(filename:, bucket:)
+                    end
         rescue Faraday::ResourceNotFound
           tries += 1
           logger.warn("received NotFoundError from Preservation try ##{tries}")
@@ -36,7 +39,7 @@ module Dor
 
           retry unless tries > max_tries
 
-          context = { druid:, filename:, path: path.to_s, cloud_endpoint:, max_tries: }
+          context = { druid:, filename:, path: path.to_s, bucket:, max_tries: }
           logger.error("Exceeded max_tries attempting to fetch file: #{context}")
           Honeybadger.notify('Exceeded max_tries attempting to fetch file', context:)
         end
@@ -47,8 +50,8 @@ module Dor
 
       # fetch a file from preservation and send to cloud endpoint
       # TODO: implement this method for AWS S3, it will be used for the speech-to-text workflow
-      def fetch_and_send_file_to_s3(filename:, cloud_endpoint:)
-        logger.info("fetching #{filename} for #{druid} and sending to #{cloud_endpoint}")
+      def fetch_and_send_file_to_s3(filename:, bucket:)
+        logger.info("fetching #{filename} for #{druid} and sending to #{bucket}")
         preservation_client.objects.content(
           druid:,
           filepath: filename,

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -5,14 +5,13 @@ module Dor
     # Determine if OCR is required and possible for a given object
     # rubocop:disable Metrics/ClassLength
     class Ocr
-      attr_reader :cocina_object, :workflow_context, :bare_druid, :logger, :backoff
+      attr_reader :cocina_object, :workflow_context, :bare_druid, :logger
 
-      def initialize(cocina_object:, workflow_context: {}, backoff: 3, logger: nil)
+      def initialize(cocina_object:, workflow_context: {}, logger: nil)
         @cocina_object = cocina_object
         @workflow_context = workflow_context
         @bare_druid = cocina_object.externalIdentifier.delete_prefix('druid:')
         @logger = logger || Logger.new($stdout)
-        @backoff = backoff
       end
 
       def abbyy_output_path
@@ -38,7 +37,7 @@ module Dor
           cleanup_abbyy_exceptions
         rescue SystemCallError => e # SystemCallError is the superclass of all errors raised by system calls, such as Errno::ENOENT from FileUtils.rm_r
           tries += 1
-          sleep(backoff**tries)
+          sleep(3**tries)
 
           logger.info "Retry #{tries} for ocr-workspace-cleanup; after exception #{e.message}"
 

--- a/lib/dor/text_extraction/version_updater.rb
+++ b/lib/dor/text_extraction/version_updater.rb
@@ -13,7 +13,7 @@ module Dor
         @max_tries = max_tries
       end
 
-      def self.open(druid:, object_client:, description: '', max_tries: 3)
+      def self.open(druid:, object_client:, description:, max_tries: 3)
         new(druid:, object_client:, description:, max_tries:).open_object
       end
 

--- a/lib/robots/dor_repo/ocr/fetch_files.rb
+++ b/lib/robots/dor_repo/ocr/fetch_files.rb
@@ -9,19 +9,16 @@ module Robots
           super('ocrWF', 'fetch-files')
         end
 
+        # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
-          copy_files
-        end
-
-        private
-
-        def copy_files
           ocrable_filenames.each do |filename|
             path = abbyy_path(filename)
             path.parent.mkpath unless path.parent.directory?
-            raise "Unable to fetch #{filename} for #{druid}" unless write_file_with_retries(druid:, filename:, path:, max_tries: 3)
+            raise "Unable to fetch #{filename} for #{druid}" unless file_fetcher.write_file_with_retries(filename:, path:, max_tries: 3)
           end
         end
+
+        private
 
         def abbyy_path(filename)
           # NOTE: if files of type "file" were allowed here we would have to
@@ -37,47 +34,8 @@ module Robots
           @ocr ||= Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context)
         end
 
-        # Fetch an item's file from Preservation and write it to disk. Since
-        # we've observed inconsistency in QA and Stage with the NFS volumes
-        # where files are written we recheck.
-        # rubocop:disable Metrics/MethodLength
-        def write_file_with_retries(druid:, filename:, path:, max_tries:)
-          tries = 0
-          written = false
-          begin
-            written = fetch_file(druid:, filename:, path:)
-          rescue Faraday::ResourceNotFound
-            tries += 1
-            logger.warn("received NotFoundError from Preservation try ##{tries}")
-
-            sleep(2**tries)
-
-            retry unless tries > max_tries
-
-            context = { druid:, filename:, path: path.to_s, max_tries: }
-            logger.error("Exceeded max_tries attempting to fetch file for OCR: #{context}")
-            Honeybadger.notify('Exceeded max_tries attempting to fetch file for OCR', context:)
-          end
-
-          written
-        end
-        # rubocop:enable Metrics/MethodLength
-
-        def fetch_file(druid:, filename:, path:)
-          path.open('wb') do |file_writer|
-            logger.info("fetching #{filename} for #{druid} and saving to #{path}")
-            preservation_client.objects.content(
-              druid:,
-              filepath: filename,
-              on_data: proc { |data, _count| file_writer.write(data) }
-            )
-          end
-
-          true
-        end
-
-        def preservation_client
-          @preservation_client ||= Preservation::Client.configure(url: Settings.preservation_catalog.url, token: Settings.preservation_catalog.token)
+        def file_fetcher
+          @file_fetcher ||= Dor::TextExtraction::FileFetcher.new(druid:, logger:)
         end
       end
     end

--- a/lib/robots/dor_repo/speech_to_text/fetch_files.rb
+++ b/lib/robots/dor_repo/speech_to_text/fetch_files.rb
@@ -11,9 +11,29 @@ module Robots
 
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
-          # TODO: copy files from preservation to STT workspace here
-          # see similiar code in lib/robots/dor_repo/ocr/fetch_files.rb and refactor as needed to avoid duplication
-          true
+          sttable_filenames.each do |filename|
+            raise "Unable to fetch #{filename} for #{druid}" unless file_fetcher.write_file_with_retries(filename:, cloud_endpoint: cloud_endpoint(filename), max_tries: 3)
+          end
+        end
+
+        private
+
+        # TODO: implement this method for AWS S3, it will be used by the FileFetcher class
+        # it indicates the cloud endpoint to send the file to
+        def cloud_endpoint(filename)
+          "s3://some-bucket/#{filename}"
+        end
+
+        def sttable_filenames
+          @sttable_filenames ||= speech_to_text.filenames_to_stt
+        end
+
+        def speech_to_text
+          @speech_to_text ||= Dor::TextExtraction::SpeechToText.new(cocina_object:, workflow_context: workflow.context)
+        end
+
+        def file_fetcher
+          @file_fetcher ||= Dor::TextExtraction::FileFetcher.new(druid:, logger:)
         end
       end
     end

--- a/lib/robots/dor_repo/speech_to_text/fetch_files.rb
+++ b/lib/robots/dor_repo/speech_to_text/fetch_files.rb
@@ -12,7 +12,7 @@ module Robots
         # available from LyberCore::Robot: druid, bare_druid, workflow_service, object_client, cocina_object, logger
         def perform_work
           sttable_filenames.each do |filename|
-            raise "Unable to fetch #{filename} for #{druid}" unless file_fetcher.write_file_with_retries(filename:, cloud_endpoint: cloud_endpoint(filename), max_tries: 3)
+            raise "Unable to fetch #{filename} for #{druid}" unless file_fetcher.write_file_with_retries(filename:, bucket: bucket_path(filename), max_tries: 3)
           end
         end
 
@@ -20,7 +20,7 @@ module Robots
 
         # TODO: implement this method for AWS S3, it will be used by the FileFetcher class
         # it indicates the cloud endpoint to send the file to
-        def cloud_endpoint(filename)
+        def bucket_path(filename)
           "s3://some-bucket/#{filename}"
         end
 

--- a/spec/lib/dor/text_extraction/file_fetcher_spec.rb
+++ b/spec/lib/dor/text_extraction/file_fetcher_spec.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Dor::TextExtraction::FileFetcher do
+  let(:file_fetcher) { described_class.new(druid:, logger:) }
+
+  let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil) }
+  let(:druid) { 'druid:bb222cc3333' }
+  let(:objects_client) { instance_double(Preservation::Client::Objects) }
+
+  let(:pres_client) do
+    instance_double(Preservation::Client, objects: objects_client)
+  end
+
+  before do
+    allow(Preservation::Client).to receive(:configure).and_return(pres_client)
+    allow(file_fetcher).to receive(:sleep) # effectively make the sleep a no-op so that the test doesn't take so long due to retries and backoff
+  end
+
+  describe '#write_file_with_retries' do
+    context 'when writing to disk' do
+      context 'when preservation is done' do
+        before do
+          allow(objects_client).to receive(:content) do |*args|
+            filepath = args.first.fetch(:filepath)
+            args.first.fetch(:on_data).call("Content for: #{filepath}")
+          end
+        end
+
+        it 'writes the file' do
+          file_fetcher.write_file_with_retries(filename: 'image111.tif', path: Pathname.new('/tmp/image111.tif'))
+          expect(Preservation::Client).to have_received(:configure)
+          expect(logger).to have_received(:info).once
+          expect(objects_client).to have_received(:content).once # success first time!
+
+          file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
+          expect(File.read(file1)).to eq('Content for: image111.tif')
+        end
+      end
+
+      context 'when preservation is still processing' do
+        before do
+          count = 0
+          allow(objects_client).to receive(:content) do |*args|
+            count += 1
+            raise Faraday::ResourceNotFound, 'druid not available yet' unless count > 2
+
+            filepath = args.first.fetch(:filepath)
+            args.first.fetch(:on_data).call("Content for: #{filepath}")
+          end
+        end
+
+        it 'writes the file and warns' do
+          file_fetcher.write_file_with_retries(filename: 'image111.tif', path: Pathname.new('/tmp/image111.tif'))
+          expect(Preservation::Client).to have_received(:configure)
+          expect(logger).to have_received(:warn).twice
+
+          expect(objects_client).to have_received(:content).exactly(3).times # 2 failures, 3rd time is the charm
+
+          file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
+          expect(File.read(file1)).to eq('Content for: image111.tif')
+        end
+
+        context 'when retries are exhausted before the files show up on the preservation NFS mount' do
+          before do
+            allow(Honeybadger).to receive(:notify)
+
+            allow(objects_client).to receive(:content) do
+              raise Faraday::ResourceNotFound, 'druid not available yet'
+            end
+          end
+
+          it 'returns false, sends to HB, and logs an error' do
+            written = file_fetcher.write_file_with_retries(filename: 'image111.tif', path: Pathname.new('/tmp/image111.tif'))
+            expect(written).to be(false)
+
+            context = { druid:, filename: 'image111.tif', path: '/tmp/image111.tif', cloud_endpoint: nil, max_tries: 3 }
+            expect(logger).to have_received(:error).with("Exceeded max_tries attempting to fetch file: #{context}")
+            expect(Honeybadger).to have_received(:notify).with('Exceeded max_tries attempting to fetch file', context:)
+            expect(file_fetcher).to have_received(:sleep).with(8) # should have hit max backoff time of 2^3 seconds
+          end
+        end
+      end
+    end
+
+    context 'when sending to cloud endpoint' do
+      before do
+        allow(objects_client).to receive(:content) do |*args|
+          filepath = args.first.fetch(:filepath)
+          args.first.fetch(:on_data).call("Content for: #{filepath}")
+        end
+      end
+
+      it 'fetches files from perservation and sends to cloud' do
+        # TODO: add in actual expectations here when the method is implemented
+        file_fetcher.write_file_with_retries(filename: 'file1.mov', cloud_endpoint: 's3://some-bucket/file1.mov')
+        expect(logger).to have_received(:info).once
+        expect(objects_client).to have_received(:content).once
+        expect(Preservation::Client).to have_received(:configure)
+      end
+    end
+  end
+end

--- a/spec/lib/dor/text_extraction/file_fetcher_spec.rb
+++ b/spec/lib/dor/text_extraction/file_fetcher_spec.rb
@@ -8,12 +8,18 @@ describe Dor::TextExtraction::FileFetcher do
   let(:logger) { instance_double(Logger, warn: nil, info: nil, error: nil) }
   let(:druid) { 'druid:bb222cc3333' }
   let(:objects_client) { instance_double(Preservation::Client::Objects) }
+  let(:filename) { 'image111.tif' }
+  let(:base_dir) { 'tmp/b22cc3333' }
+  let(:file_path) { File.join(base_dir, filename) }
+  let(:path) { Pathname.new(file_path) }
+  let(:cloud_endpoint) { 's3://some-bucket/file1.mov' }
 
   let(:pres_client) do
     instance_double(Preservation::Client, objects: objects_client)
   end
 
   before do
+    FileUtils.mkdir_p(base_dir) unless File.directory?(base_dir)
     allow(Preservation::Client).to receive(:configure).and_return(pres_client)
     allow(file_fetcher).to receive(:sleep) # effectively make the sleep a no-op so that the test doesn't take so long due to retries and backoff
   end
@@ -29,13 +35,12 @@ describe Dor::TextExtraction::FileFetcher do
         end
 
         it 'writes the file' do
-          file_fetcher.write_file_with_retries(filename: 'image111.tif', path: Pathname.new('/tmp/image111.tif'))
+          file_fetcher.write_file_with_retries(filename:, path:)
           expect(Preservation::Client).to have_received(:configure)
           expect(logger).to have_received(:info).once
           expect(objects_client).to have_received(:content).once # success first time!
 
-          file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
-          expect(File.read(file1)).to eq('Content for: image111.tif')
+          expect(File.read(file_path)).to eq("Content for: #{filename}")
         end
       end
 
@@ -52,14 +57,13 @@ describe Dor::TextExtraction::FileFetcher do
         end
 
         it 'writes the file and warns' do
-          file_fetcher.write_file_with_retries(filename: 'image111.tif', path: Pathname.new('/tmp/image111.tif'))
+          file_fetcher.write_file_with_retries(filename:, path:)
           expect(Preservation::Client).to have_received(:configure)
           expect(logger).to have_received(:warn).twice
 
           expect(objects_client).to have_received(:content).exactly(3).times # 2 failures, 3rd time is the charm
 
-          file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
-          expect(File.read(file1)).to eq('Content for: image111.tif')
+          expect(File.read(file_path)).to eq("Content for: #{filename}")
         end
 
         context 'when retries are exhausted before the files show up on the preservation NFS mount' do
@@ -72,10 +76,10 @@ describe Dor::TextExtraction::FileFetcher do
           end
 
           it 'returns false, sends to HB, and logs an error' do
-            written = file_fetcher.write_file_with_retries(filename: 'image111.tif', path: Pathname.new('/tmp/image111.tif'))
+            written = file_fetcher.write_file_with_retries(filename:, path:)
             expect(written).to be(false)
 
-            context = { druid:, filename: 'image111.tif', path: '/tmp/image111.tif', cloud_endpoint: nil, max_tries: 3 }
+            context = { druid:, filename:, path: file_path, cloud_endpoint: nil, max_tries: 3 }
             expect(logger).to have_received(:error).with("Exceeded max_tries attempting to fetch file: #{context}")
             expect(Honeybadger).to have_received(:notify).with('Exceeded max_tries attempting to fetch file', context:)
             expect(file_fetcher).to have_received(:sleep).with(8) # should have hit max backoff time of 2^3 seconds
@@ -94,7 +98,7 @@ describe Dor::TextExtraction::FileFetcher do
 
       it 'fetches files from perservation and sends to cloud' do
         # TODO: add in actual expectations here when the method is implemented
-        file_fetcher.write_file_with_retries(filename: 'file1.mov', cloud_endpoint: 's3://some-bucket/file1.mov')
+        file_fetcher.write_file_with_retries(filename: 'file1.mov', cloud_endpoint:)
         expect(logger).to have_received(:info).once
         expect(objects_client).to have_received(:content).once
         expect(Preservation::Client).to have_received(:configure)

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Dor::TextExtraction::Ocr do
-  let(:ocr) { described_class.new(cocina_object:, workflow_context:, backoff: 1) } # setting a backoff of 1 to make testing much faster
+  let(:ocr) { described_class.new(cocina_object:, workflow_context:) }
   let(:ticket) { Dor::TextExtraction::Abbyy::Ticket.new(filepaths: [], druid:) }
   let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
   let(:workflow_context) { {} }
@@ -24,6 +24,8 @@ RSpec.describe Dor::TextExtraction::Ocr do
     sdr_value = instance_double(Cocina::Models::FileAdministrative, sdrPreserve: sdr_peserve)
     instance_double(Cocina::Models::File, administrative: sdr_value, hasMimeType: mimetype[extension], filename:)
   end
+
+  before { allow(ocr).to receive(:sleep) } # effectively make the sleep a no-op so that the test doesn't take so long due to retries and backoff
 
   describe '#possible?' do
     context 'when the object is not a DRO' do

--- a/spec/lib/dor/text_extraction/version_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/version_updater_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Dor::TextExtraction::VersionUpdater do
-  subject(:updater) { described_class.new(druid:, object_client:, description:, max_tries: 3) }
+  let(:updater) { described_class.new(druid:, object_client:, description:, max_tries: 3) }
 
   let(:druid) { 'druid:bb222cc3333' }
   let(:description) { 'Starting OCR' }
@@ -19,6 +19,7 @@ describe Dor::TextExtraction::VersionUpdater do
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
     allow(version_client).to receive(:open)
+    allow(updater).to receive(:sleep) # effectively make the sleep a no-op so that the test doesn't take so long due to retries and backoff
   end
 
   describe '.open' do

--- a/spec/robots/dor_repo/ocr/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/ocr/fetch_files_spec.rb
@@ -3,209 +3,48 @@
 require 'spec_helper'
 
 describe Robots::DorRepo::Ocr::FetchFiles do
-  let(:robot) { described_class.new }
-  let(:access) { { view: 'world' } }
-  let(:druid) { 'druid:bb222cc3333' }
-  let(:cocina_model) { build(:dro, id: druid).new(structural:, type: object_type, access:) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
-  let(:structural) do
-    {
-      contains: [
-        {
-          type: 'https://cocina.sul.stanford.edu/models/resources/image',
-          externalIdentifier: 'bb111bb2222_1',
-          label: 'Image 1',
-          version: 1,
-          structural: {
-            contains: [
-              {
-                type: 'https://cocina.sul.stanford.edu/models/file',
-                externalIdentifier: 'https://cocina.sul.stanford.edu/file/d30f48f9-1c11-4290-95a4-fea64e346db9',
-                label: 'image111.tif',
-                filename: 'image111.tif',
-                size: 123,
-                version: 1,
-                hasMimeType: 'image/tiff',
-                hasMessageDigests: [
-                  {
-                    type: 'md5',
-                    digest: '42616f9e6c1b7e7b7a71b4fa0c5ef794'
-                  }
-                ],
-                access: {
-                  view: 'dark',
-                  download: 'none',
-                  controlledDigitalLending: false
-                },
-                administrative: {
-                  publish: false,
-                  sdrPreserve: true,
-                  shelve: false
-                }
-              }
-            ]
-          }
-        },
-        {
-          type: 'https://cocina.sul.stanford.edu/models/resources/image',
-          externalIdentifier: 'bb111bb2222_2',
-          label: 'Image 2',
-          version: 1,
-          structural: {
-            contains: [
-              {
-                type: 'https://cocina.sul.stanford.edu/models/file',
-                externalIdentifier: 'https://cocina.sul.stanford.edu/file/39a83c02-5d05-4c3d-bff1-080772cfdd99',
-                label: 'image112.tif',
-                filename: 'image112.tif',
-                size: 123,
-                version: 1,
-                hasMimeType: 'image/tiff',
-                hasMessageDigests: [
-                  {
-                    type: 'sha1',
-                    digest: '5c9f6dc2ca4fd3329619b54a2c6f99a08c088444'
-                  },
-                  {
-                    type: 'md5',
-                    digest: 'ac440802bd590ce0899dafecc5a5ab1b'
-                  }
-                ],
-                access: {
-                  view: 'dark',
-                  download: 'none',
-                  controlledDigitalLending: false
-                },
-                administrative: {
-                  publish: false,
-                  sdrPreserve: true,
-                  shelve: false
-                }
-              }
-            ]
-          }
-        }
-      ],
-      hasMemberOrders: [],
-      isMemberOf: []
-    }
-  end
+  subject(:perform) { test_perform(robot, druid) }
 
+  let(:druid) { 'druid:bb222cc3333' }
+  let(:robot) { described_class.new }
+  let(:ocr) { instance_double(Dor::TextExtraction::Ocr, abbyy_input_path:, filenames_to_ocr: ['file1.txt', 'file2.pdf']) }
+  let(:cocina_model) { build(:dro, id: druid).new(structural: {}, type: object_type, access: { view: 'world' }) }
+  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+  let(:file_fetcher) { instance_double(Dor::TextExtraction::FileFetcher, write_file_with_retries: written) }
   let(:dsa_object_client) do
     instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)
   end
-
-  let(:pres_client) do
-    instance_double(Preservation::Client, objects: objects_client)
-  end
-
-  let(:objects_client) do
-    instance_double(Preservation::Client::Objects)
-  end
-
   let(:workflow_client) do
-    instance_double(Dor::Workflow::Client, process: workflow_process, workflow_status: status)
+    instance_double(Dor::Workflow::Client, process: workflow_process, workflow_status: 'waiting')
   end
-
   let(:workflow_process) do
-    instance_double(Dor::Workflow::Response::Process, lane_id:, context:)
+    instance_double(Dor::Workflow::Response::Process, lane_id: 'lane1', context: { 'runOCR' => true })
   end
-
-  let(:lane_id) { 'lane1' }
-  let(:context) { { 'runOCR' => true } }
-  let(:status) { 'waiting' }
+  let(:abbyy_input_path) { File.join(Settings.sdr.abbyy.local_ticket_path, druid) }
 
   before do
     allow(Dor::Services::Client).to receive(:object).and_return(dsa_object_client)
-    allow(Preservation::Client).to receive(:configure).and_return(pres_client)
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(Dor::TextExtraction::FileFetcher).to receive(:new).and_return(file_fetcher)
+    allow(Dor::TextExtraction::Ocr).to receive(:new).and_return(ocr)
   end
 
-  describe '#perform' do
-    context 'with two image files' do
-      before do
-        allow(objects_client).to receive(:content) do |*args|
-          filepath = args.first.fetch(:filepath)
-          args.first.fetch(:on_data).call("Content for: #{filepath}")
-        end
+  context 'when fetching files is successful' do
+    let(:written) { true }
 
-        test_perform(robot, druid)
-      end
-
-      it 'calls gets cocina from DSA' do
-        expect(dsa_object_client).to have_received(:find)
-      end
-
-      it 'configures preservation client' do
-        expect(Preservation::Client).to have_received(:configure)
-      end
-
-      it 'calls the workflow service to get the context' do
-        expect(workflow_client).to have_received(:process)
-      end
-
-      it 'writes the two files' do
-        expect(objects_client).to have_received(:content).twice
-
-        file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
-        expect(File.read(file1)).to eq('Content for: image111.tif')
-
-        file2 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image112.tif')
-        expect(File.read(file2)).to eq('Content for: image112.tif')
-      end
+    it 'calls the write_file_with_retries method with correct files' do
+      expect(perform).to eq ['file1.txt', 'file2.pdf']
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.txt', path: Pathname.new("#{abbyy_input_path}/file1.txt"), max_tries: 3).once
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file2.pdf', path: Pathname.new("#{abbyy_input_path}/file2.pdf"), max_tries: 3).once
     end
+  end
 
-    context 'when preservation is still processing' do
-      before do
-        allow(robot).to receive(:sleep) # effectively make the sleep a no-op so that the test doesn't take so long due to retries and backoff
+  context 'when fetching files fails' do
+    let(:written) { false }
 
-        count = 0
-        allow(objects_client).to receive(:content) do |*args|
-          count += 1
-          raise Faraday::ResourceNotFound, 'druid not available yet' unless count > 2
-
-          filepath = args.first.fetch(:filepath)
-          args.first.fetch(:on_data).call("Content for: #{filepath}")
-        end
-
-        test_perform(robot, druid)
-      end
-
-      it 'writes the two files' do
-        expect(objects_client).to have_received(:content).exactly(4).times
-
-        file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
-        expect(File.read(file1)).to eq('Content for: image111.tif')
-
-        file2 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image112.tif')
-        expect(File.read(file2)).to eq('Content for: image112.tif')
-      end
-
-      context 'when retries are exhausted before the files show up on the preservation NFS mount' do
-        before do
-          allow(Honeybadger).to receive(:notify)
-          allow(robot.logger).to receive(:error)
-          allow(robot).to receive(:sleep) # effectively make the sleep a no-op so that the test doesn't take so long due to retries and backoff
-
-          allow(objects_client).to receive(:content) do |*args|
-            raise Faraday::ResourceNotFound, 'druid not available yet' if args.first.fetch(:filepath) == 'image112.tif'
-
-            filepath = args.first.fetch(:filepath)
-            args.first.fetch(:on_data).call("Content for: #{filepath}")
-          end
-        end
-
-        it 'writes the first file but raises when it is unable to fetch the second' do
-          expect { test_perform(robot, druid) }.to raise_error('Unable to fetch image112.tif for druid:bb222cc3333')
-
-          file1 = File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image111.tif')
-          expect(File.read(file1)).to eq('Content for: image111.tif')
-          context = { druid:, filename: 'image112.tif', path: File.join(Settings.sdr.abbyy.local_ticket_path, 'bb222cc3333', 'image112.tif'), max_tries: 3 }
-          expect(robot.logger).to have_received(:error).with("Exceeded max_tries attempting to fetch file for OCR: #{context}")
-          expect(Honeybadger).to have_received(:notify).with('Exceeded max_tries attempting to fetch file for OCR', context:)
-          expect(robot).to have_received(:sleep).with(8) # should have hit max backoff time of 2^3 seconds
-        end
-      end
+    it 'raises an exception' do
+      expect { perform }.to raise_error(RuntimeError, 'Unable to fetch file1.txt for druid:bb222cc3333')
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.txt', path: Pathname.new("#{abbyy_input_path}/file1.txt"), max_tries: 3).once
     end
   end
 end

--- a/spec/robots/dor_repo/speech_to_text/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/fetch_files_spec.rb
@@ -7,8 +7,43 @@ describe Robots::DorRepo::SpeechToText::FetchFiles do
 
   let(:druid) { 'druid:bb222cc3333' }
   let(:robot) { described_class.new }
+  let(:file_fetcher) { instance_double(Dor::TextExtraction::FileFetcher, write_file_with_retries: written) }
+  let(:stt) { instance_double(Dor::TextExtraction::SpeechToText, filenames_to_stt: ['file1.mov', 'file2.mp3']) }
+  let(:cocina_model) { build(:dro, id: druid).new(structural: {}, type: object_type, access: { view: 'world' }) }
+  let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+  let(:dsa_object_client) do
+    instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)
+  end
+  let(:workflow_client) do
+    instance_double(Dor::Workflow::Client, process: workflow_process, workflow_status: 'waiting')
+  end
+  let(:workflow_process) do
+    instance_double(Dor::Workflow::Response::Process, lane_id: 'lane1', context: { 'runSpeechToText' => true })
+  end
 
-  it 'runs the fetch-files robot' do
-    expect(perform).to be true
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(dsa_object_client)
+    allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+    allow(Dor::TextExtraction::FileFetcher).to receive(:new).and_return(file_fetcher)
+    allow(Dor::TextExtraction::SpeechToText).to receive(:new).and_return(stt)
+  end
+
+  context 'when fetching files is successful' do
+    let(:written) { true }
+
+    it 'calls the write_file_with_retries method with correct files' do
+      expect(perform).to eq ['file1.mov', 'file2.mp3']
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.mov', cloud_endpoint: 's3://some-bucket/file1.mov', max_tries: 3).once
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file2.mp3', cloud_endpoint: 's3://some-bucket/file2.mp3', max_tries: 3).once
+    end
+  end
+
+  context 'when fetching files fails' do
+    let(:written) { false }
+
+    it 'raises an exception' do
+      expect { perform }.to raise_error(RuntimeError, 'Unable to fetch file1.mov for druid:bb222cc3333')
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.mov', cloud_endpoint: 's3://some-bucket/file1.mov', max_tries: 3).once
+    end
   end
 end

--- a/spec/robots/dor_repo/speech_to_text/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/fetch_files_spec.rb
@@ -33,8 +33,8 @@ describe Robots::DorRepo::SpeechToText::FetchFiles do
 
     it 'calls the write_file_with_retries method with correct files' do
       expect(perform).to eq ['file1.mov', 'file2.mp3']
-      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.mov', cloud_endpoint: 's3://some-bucket/file1.mov', max_tries: 3).once
-      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file2.mp3', cloud_endpoint: 's3://some-bucket/file2.mp3', max_tries: 3).once
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.mov', bucket: 's3://some-bucket/file1.mov', max_tries: 3).once
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file2.mp3', bucket: 's3://some-bucket/file2.mp3', max_tries: 3).once
     end
   end
 
@@ -43,7 +43,7 @@ describe Robots::DorRepo::SpeechToText::FetchFiles do
 
     it 'raises an exception' do
       expect { perform }.to raise_error(RuntimeError, 'Unable to fetch file1.mov for druid:bb222cc3333')
-      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.mov', cloud_endpoint: 's3://some-bucket/file1.mov', max_tries: 3).once
+      expect(file_fetcher).to have_received(:write_file_with_retries).with(filename: 'file1.mov', bucket: 's3://some-bucket/file1.mov', max_tries: 3).once
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1345 

The ocr `fetch-files` robot contains functionality that we will need for the new speech-to-text `fetch-files` robot -- namely pulling content down from preservation and writing to disk (or sending to the cloud).

This PR:

1. Creates a new class do to this and moves the part of the code related to fetching files from preservation and writing them to disk over to the new class.
2. Adds stub methods in this new class that can be implemented later to send content to the cloud.
3. Updates the existing ocr `fetch-files` robot to use the new class.
4. Stubs out the new speech-to-text `fetch-files` robot to use the new class.
5. Move and update the tests from the robot to the new class, and simplify them a bit so it doesn't mock out all of the cocina and DSA stuff for getting filenames (not really needed, since that is all tested in a different `OCR` class that actually has the responsibility to to that)
6. Update the specs for the robots (a lot simpler, just prove we are calling out to our new class).
7. Remove some `backoff` stuff I added earlier to make the specs faster, since I noticed Ed had a much better way of doing this in the specs (which is just to mock the call to `sleep` itself).

## How was this change tested? 🤨

Specs
Deploy branch to stage and run OCR integration tests
