### PR TITLE
adjust selection criteria for speech to text files

### DIFF
--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -138,7 +138,7 @@ module Dor
         end.compact
       end
 
-      # filter down fileset files to those in preservation and are allowedmimetypes
+      # filter down fileset files to those in preservation and are allowed mimetypes
       # if there are more than one allowed mimetype, grab the preferred type
       def ocr_file(fileset)
         perservedfiles = fileset.structural.contains.select { |file| file.administrative.sdrPreserve && allowed_mimetypes.include?(file.hasMimeType) }


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1346 - adjust logic for which files to select for speech to text.  This sets it so that (1) only files that are both shelved and preserved are selected, (2) only files with mimetype of `audio/mp4` or `video/mp4` are selected, (3) only files in a resource type of `audio` or `video` are selected, (4) only object types of type `media` will be considered.  Any number of files that match in any given resource type will be selected.

## How was this change tested? 🤨

Updated specs