### PR TITLE
shell out to try and delete folders instead of FileUtils

### DIFF
--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -85,7 +85,7 @@ module Dor
 
         files = Dir.glob("#{abbyy_input_path}/*")
         logger.info "Removing ABBYY input directory: #{abbyy_input_path}.  Empty: #{Dir.empty?(abbyy_input_path)}. Num files/folders: #{files.count}: #{files.join(', ')}"
-        FileUtils.rm_r(abbyy_input_path)
+        delete_folder(abbyy_input_path)
       end
 
       # e.g. /abbyy/OUTPUT/ab123cd4567
@@ -94,7 +94,7 @@ module Dor
 
         files = Dir.glob("#{abbyy_output_path}/*")
         logger.info "Removing ABBYY output directory: #{abbyy_output_path}.  Empty: #{Dir.empty?(abbyy_output_path)}. Num files/folders: #{files.count}: #{files.join(', ')}"
-        FileUtils.rm_r(abbyy_output_path)
+        delete_folder(abbyy_output_path)
       end
 
       # e.g. /abbyy/INPUT/ab123cd4567.xml
@@ -175,6 +175,11 @@ module Dor
 
       def allowed_object_types
         resource_type_mapping.keys
+      end
+
+      # shell out to remove a folder and all its contents since FileUtils.rm_r sometimes fails even if the directory is empty
+      def delete_folder(folder)
+        `rm -rf #{folder}`
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -192,7 +192,7 @@ RSpec.describe Dor::TextExtraction::Ocr do
         FileUtils.mkdir_p(ocr.abbyy_output_path)
         allow(Honeybadger).to receive(:notify)
         count = 0
-        allow(FileUtils).to receive(:rm_r) do
+        allow(ocr).to receive(:`) do
           count += 1
           raise Errno::ENOENT if count <= num_errors
         end
@@ -204,8 +204,8 @@ RSpec.describe Dor::TextExtraction::Ocr do
         it 'calls the deletion of the input folder three times and output folder once' do
           ocr.cleanup
           expect(Honeybadger).not_to have_received(:notify) # no calls to HB, success occurs third time
-          expect(FileUtils).to have_received(:rm_r).with(ocr.abbyy_input_path).exactly(3).times
-          expect(FileUtils).to have_received(:rm_r).with(ocr.abbyy_output_path).once
+          expect(ocr).to have_received(:`).with("rm -rf #{ocr.abbyy_input_path}").exactly(3).times
+          expect(ocr).to have_received(:`).with("rm -rf #{ocr.abbyy_output_path}").once
         end
       end
 
@@ -214,7 +214,7 @@ RSpec.describe Dor::TextExtraction::Ocr do
 
         it 'raises the exception after trying four times' do
           expect { ocr.cleanup }.to raise_error(Errno::ENOENT)
-          expect(FileUtils).not_to have_received(:rm_r).with(ocr.abbyy_output_path)
+          expect(ocr).not_to have_received(:`).with("rm -rf #{ocr.abbyy_output_path}")
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔

We get issues sometimes with an empty folder claiming it cannot be deleted with FileUtils even when it is empty.  This seems to work better (delete happened right away with no retries in my integration test run)

## How was this change tested? 🤨

Updated specs.  Deploy to stage and integration tests.