### PR TITLE
Remove cleanup from end accession

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,13 +9,13 @@ gem 'assembly-objectfile', '~> 2.1'
 gem 'aws-sdk-s3' # used for sending files to S3 for the speech-to-text workflow
 gem 'aws-sdk-sqs' # used for sending sqs mssages for the speech-to-text workflow
 gem 'config'
-gem 'dor-services-client', '~> 14.6', github: 'sul-dlss/dor-services-client', branch: 'combine-reset-and-cleanup'
+gem 'dor-services-client', '~> 15.0'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'dry-struct', '~> 1.0'
 gem 'dry-types', '~> 1.1'
 gem 'druid-tools'
 gem 'honeybadger'
-gem 'lyber-core', '~> 7.5' # 7.5.0 has the ability to set and return workflow context
+gem 'lyber-core', '~> 7.6' # 7.6 uses the correct dor-services-client version (> 15.0)
 gem 'nokogiri'
 gem 'purl_fetcher-client'
 gem 'preservation-client'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'assembly-objectfile', '~> 2.1'
 gem 'aws-sdk-s3' # used for sending files to S3 for the speech-to-text workflow
 gem 'aws-sdk-sqs' # used for sending sqs mssages for the speech-to-text workflow
 gem 'config'
-gem 'dor-services-client', '~> 14.6'
+gem 'dor-services-client', '~> 14.6', github: 'sul-dlss/dor-services-client', branch: 'combine-reset-and-cleanup'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'dry-struct', '~> 1.0'
 gem 'dry-types', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,16 @@
+GIT
+  remote: https://github.com/sul-dlss/dor-services-client.git
+  revision: b4a49aa1a2835b4641268e62c8133baa1218577c
+  branch: combine-reset-and-cleanup
+  specs:
+    dor-services-client (14.21.0)
+      activesupport (>= 4.2, < 8)
+      cocina-models (~> 0.99.0)
+      deprecation
+      faraday (~> 2.0)
+      faraday-retry
+      zeitwerk (~> 2.1)
+
 GEM
   remote: https://gems.contribsys.com/
   specs:
@@ -114,13 +127,6 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
-    dor-services-client (14.21.0)
-      activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.99.0)
-      deprecation
-      faraday (~> 2.0)
-      faraday-retry
-      zeitwerk (~> 2.1)
     dor-workflow-client (7.5.0)
       activesupport (>= 3.2.1, < 8)
       deprecation (>= 0.99.0)
@@ -355,7 +361,7 @@ DEPENDENCIES
   config
   debug
   dlss-capistrano
-  dor-services-client (~> 14.6)
+  dor-services-client (~> 14.6)!
   dor-workflow-client (~> 7.0)
   druid-tools
   dry-struct (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,3 @@
-GIT
-  remote: https://github.com/sul-dlss/dor-services-client.git
-  revision: b4a49aa1a2835b4641268e62c8133baa1218577c
-  branch: combine-reset-and-cleanup
-  specs:
-    dor-services-client (14.21.0)
-      activesupport (>= 4.2, < 8)
-      cocina-models (~> 0.99.0)
-      deprecation
-      faraday (~> 2.0)
-      faraday-retry
-      zeitwerk (~> 2.1)
-
 GEM
   remote: https://gems.contribsys.com/
   specs:
@@ -127,6 +114,13 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
+    dor-services-client (15.0.0)
+      activesupport (>= 4.2, < 8)
+      cocina-models (~> 0.99.0)
+      deprecation
+      faraday (~> 2.0)
+      faraday-retry
+      zeitwerk (~> 2.1)
     dor-workflow-client (7.5.0)
       activesupport (>= 3.2.1, < 8)
       deprecation (>= 0.99.0)
@@ -190,10 +184,10 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.6.1)
-    lyber-core (7.5.0)
+    lyber-core (7.6.0)
       activesupport
       config
-      dor-services-client (~> 14.0)
+      dor-services-client (~> 15.0)
       dor-workflow-client (>= 7.4)
       druid-tools
       honeybadger
@@ -361,7 +355,7 @@ DEPENDENCIES
   config
   debug
   dlss-capistrano
-  dor-services-client (~> 14.6)!
+  dor-services-client (~> 15.0)
   dor-workflow-client (~> 7.0)
   druid-tools
   dry-struct (~> 1.0)
@@ -369,7 +363,7 @@ DEPENDENCIES
   equivalent-xml
   honeybadger
   listen (~> 3.9)
-  lyber-core (~> 7.5)
+  lyber-core (~> 7.6)
   nokogiri
   preservation-client
   pry

--- a/lib/robots/dor_repo/accession/end_accession.rb
+++ b/lib/robots/dor_repo/accession/end_accession.rb
@@ -13,12 +13,7 @@ module Robots
           next_dissemination_wf = special_dissemination_wf
           workflow_service.create_workflow_by_name(druid, next_dissemination_wf, version: current_version, lane_id:) if next_dissemination_wf.present?
 
-          # Note that this used to be handled by the disseminationWF, which is no longer used.
-          object_client.workspace.cleanup(workflow: 'accessionWF', lane_id:)
-
           start_captioning
-
-          LyberCore::ReturnState.new(status: :noop, note: 'Initiated cleanup API call.')
         end
 
         private

--- a/lib/robots/dor_repo/accession/reset_workspace.rb
+++ b/lib/robots/dor_repo/accession/reset_workspace.rb
@@ -12,8 +12,8 @@ module Robots
         end
 
         def perform_work
-          # Reset workspace is performed async by dor-services-app.
-          object_client.workspace.reset(workflow: 'accessionWF', lane_id:)
+          # Cleanup is performed async by dor-services-app.
+          object_client.workspace.cleanup(workflow: 'accessionWF', lane_id:)
 
           # dor-services-app will update the workflow step, do don't do it here.
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated reset API call.')

--- a/lib/robots/dor_repo/accession/reset_workspace.rb
+++ b/lib/robots/dor_repo/accession/reset_workspace.rb
@@ -4,6 +4,7 @@ module Robots
   module DorRepo
     module Accession
       # This takes link for the object in the /dor/workspace directory and renames it so it has a version number.
+      # It also cleans up the workspace directory.
       # (i.e. /dor/assembly/xw/754/sd/7436/xw754sd7436/ -> /dor/assembly/xw/754/sd/7436/xw754sd7436_v2/)
       class ResetWorkspace < LyberCore::Robot
         def initialize

--- a/lib/robots/dor_repo/dissemination/cleanup.rb
+++ b/lib/robots/dor_repo/dissemination/cleanup.rb
@@ -10,9 +10,9 @@ module Robots
         end
 
         def perform_work
+          object_client.workspace.cleanup(workflow: 'disseminationWF', lane_id:)
+          # Oct 3 2024:  Warn. If we never see these warnings, we can get rid of this robot completely.
           Honeybadger.notify('[WARNING] DisseminationWF:cleanup robot is deprecated and should not be used.', context: { druid: })
-          # Oct 3 2024: just warn, do not actually do the work.  If we never see these warnings, we can get rid of this robot.
-          # object_client.workspace.cleanup(workflow: 'disseminationWF', lane_id:)
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated cleanup API call.')
         end
       end

--- a/lib/robots/dor_repo/dissemination/cleanup.rb
+++ b/lib/robots/dor_repo/dissemination/cleanup.rb
@@ -3,15 +3,16 @@
 module Robots
   module DorRepo
     module Dissemination
-      # NOTE: This step has been merged into the end accession robot. It should no longer be used, but is left in case
-      # there are existing workflow steps that require it.
+      # This step has been merged into the end accession robot. It should no longer be used.
       class Cleanup < LyberCore::Robot
         def initialize
           super('disseminationWF', 'cleanup')
         end
 
         def perform_work
-          object_client.workspace.cleanup(workflow: 'disseminationWF', lane_id:)
+          Honeybadger.notify('[WARNING] DisseminationWF:cleanup robot is deprecated and should not be used.', context: { druid: })
+          # Oct 3 2024: just warn, do not actually do the work.  If we never see these warnings, we can get rid of this robot.
+          # object_client.workspace.cleanup(workflow: 'disseminationWF', lane_id:)
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated cleanup API call.')
         end
       end

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -12,10 +12,9 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
   let(:context) { {} }
   let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'default', context:) }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, create_workflow_by_name: nil, process:) }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, find: object, workspace: workspace_client) }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, find: object) }
   let(:apo_object_client) { instance_double(Dor::Services::Client::Object, find: apo) }
   let(:version_client) { instance_double(Dor::Services::Client::ObjectVersion, current: '1') }
-  let(:workspace_client) { instance_double(Dor::Services::Client::Workspace, cleanup: true) }
   let(:ocr) { instance_double(Dor::TextExtraction::Ocr, possible?: true, required?: false) }
   let(:stt) { instance_double(Dor::TextExtraction::SpeechToText, possible?: true, required?: false) }
 

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -30,12 +30,10 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
   describe '#perform' do
     subject(:perform) { test_perform(robot, druid) }
 
-    let(:return_status) { perform.status }
-
     context 'when there is no special dissemniation workflow' do
-      it 'cleans up' do
-        expect(return_status).to eq 'noop'
-        expect(workspace_client).to have_received(:cleanup).with(workflow: 'accessionWF', lane_id: 'default')
+      it 'completes without creating any new workflows' do
+        perform
+        expect(workflow_client).not_to have_received(:create_workflow_by_name)
       end
 
       context 'when OCR' do
@@ -121,7 +119,6 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
         perform
         expect(workflow_client).to have_received(:create_workflow_by_name)
           .with(druid, 'wasDisseminationWF', version: '1', lane_id: 'default')
-        expect(workspace_client).to have_received(:cleanup).with(workflow: 'accessionWF', lane_id: 'default')
       end
     end
   end

--- a/spec/robots/dor_repo/accession/reset_workspace_spec.rb
+++ b/spec/robots/dor_repo/accession/reset_workspace_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Robots::DorRepo::Accession::ResetWorkspace do
   let(:druid) { 'druid:oo000oo0001' }
   let(:robot) { described_class.new }
   let(:object_client) { instance_double(Dor::Services::Client::Object, workspace: workspace_client) }
-  let(:workspace_client) { instance_double(Dor::Services::Client::Workspace, reset: nil) }
+  let(:workspace_client) { instance_double(Dor::Services::Client::Workspace, cleanup: nil) }
   let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'default') }
   let(:workflow_client) { instance_double(Dor::Workflow::Client, process:) }
 
@@ -22,7 +22,7 @@ RSpec.describe Robots::DorRepo::Accession::ResetWorkspace do
 
     it 'resets the workspace' do
       expect(return_status).to eq 'noop'
-      expect(workspace_client).to have_received(:reset).with(workflow: 'accessionWF', lane_id: 'default')
+      expect(workspace_client).to have_received(:cleanup).with(workflow: 'accessionWF', lane_id: 'default')
     end
   end
 end

--- a/spec/robots/dor_repo/dissemination/cleanup_spec.rb
+++ b/spec/robots/dor_repo/dissemination/cleanup_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Robots::DorRepo::Dissemination::Cleanup do
       allow(Honeybadger).to receive(:notify)
     end
 
-    it 'is does nothing except notify HB' do
+    it 'is successful and notifies HB' do
       test_perform(robot, druid)
-      expect(workspace_client).not_to have_received(:cleanup).with(workflow: 'disseminationWF', lane_id: 'default')
+      expect(workspace_client).to have_received(:cleanup).with(workflow: 'disseminationWF', lane_id: 'default')
       expect(Honeybadger).to have_received(:notify)
     end
   end

--- a/spec/robots/dor_repo/dissemination/cleanup_spec.rb
+++ b/spec/robots/dor_repo/dissemination/cleanup_spec.rb
@@ -16,11 +16,13 @@ RSpec.describe Robots::DorRepo::Dissemination::Cleanup do
     before do
       allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
       allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
+      allow(Honeybadger).to receive(:notify)
     end
 
-    it 'is successful' do
+    it 'is does nothing except notify HB' do
       test_perform(robot, druid)
-      expect(workspace_client).to have_received(:cleanup).with(workflow: 'disseminationWF', lane_id: 'default')
+      expect(workspace_client).not_to have_received(:cleanup).with(workflow: 'disseminationWF', lane_id: 'default')
+      expect(Honeybadger).to have_received(:notify)
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Part of https://github.com/sul-dlss/dor-services-app/issues/5110

Fixes #1322

Remove the call to `cleanup` from end-accession robot.  We will instead do this from the existing reset-workspace robot.  Note that we don't need the call to the `reset` endpoint because all of it's work is already done by cleanup.  The `reset` endpoint is going away in the related DSA and dsa-client PRs.  

We need to coordinate changes in [DSA](https://github.com/sul-dlss/dor-services-app/pull/5183)

Deploy this first before DSA.

## How was this change tested? 🤨

Specs
Integration tests

