### PR TITLE
remove workflow param from cleanup

### DIFF
--- a/lib/robots/dor_repo/accession/reset_workspace.rb
+++ b/lib/robots/dor_repo/accession/reset_workspace.rb
@@ -13,7 +13,7 @@ module Robots
 
         def perform_work
           # Cleanup is performed async by dor-services-app.
-          object_client.workspace.cleanup(workflow: 'accessionWF', lane_id:)
+          object_client.workspace.cleanup(lane_id:)
 
           # dor-services-app will update the workflow step, do don't do it here.
           LyberCore::ReturnState.new(status: :noop, note: 'Initiated reset API call.')

--- a/spec/robots/dor_repo/accession/reset_workspace_spec.rb
+++ b/spec/robots/dor_repo/accession/reset_workspace_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Robots::DorRepo::Accession::ResetWorkspace do
 
     it 'resets the workspace' do
       expect(return_status).to eq 'noop'
-      expect(workspace_client).to have_received(:cleanup).with(workflow: 'accessionWF', lane_id: 'default')
+      expect(workspace_client).to have_received(:cleanup).with(lane_id: 'default')
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

The reset-workspace step is calling an endpoint that will mark it as complete. There is no other workflow step that will ever call this job, so there is no need to pass in a workflow param anymore (it used to also be triggered by disseminationWF:cleanup, but that is gone, see #1385).

see https://github.com/search?q=org%3Asul-dlss+workspace.cleanup&type=code

This changes needs to be coordinated with https://github.com/sul-dlss/dor-services-app/pull/5186 and https://github.com/sul-dlss/dor-services-client/pull/475 which remove the param from the call.

HOLD for #1385

Process:
1. Merge https://github.com/sul-dlss/dor-services-client/pull/475 and then cut a new release
2. Update https://github.com/sul-dlss/common-accessioning/pull/1386 to use new dor-services-client release, merge it
3. Merge https://github.com/sul-dlss/dor-services-app/pull/5186
4. Deploy all

## How was this change tested? 🤨

Spec