### PR TITLE
Speech to text watcher

### DIFF
--- a/bin/speech_to_text_watcher
+++ b/bin/speech_to_text_watcher
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Continually monitor the speech-to-text worker's "done" queue and report job status to SDR
+
+require 'socket'
+
+require_relative '../config/boot'
+
+# Set log level with LOG_LEVEL; share the logger across the stack
+progname = 'speech_to_text_watcher'
+logger = Logger.new(STDOUT, progname:, level: ENV['LOG_LEVEL'] || 'INFO')
+host = Socket.gethostname
+stt_create_done_handler = Dor::TextExtraction::SpeechToTextCreateDoneHandler.new(host:, progname:, logger:)
+
+
+sqs_watcher = Dor::TextExtraction::SqsWatcher.new(role_arn: Settings.aws.speech_to_text.role_arn,
+                                                   queue_url: Settings.aws.speech_to_text.sqs_done_queue_url)
+sqs_watcher.poll do |done_msg|
+  logger.debug("sqs_watcher.poll block received done_msg: #{done_msg}")
+  stt_create_done_handler.process_done_message(done_msg)
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,6 +59,7 @@ aws:
   access_key_id: 'fake-access'
   secret_access_key: 'fake-secret'
   speech_to_text:
+    role_arn: 'arn:aws:iam::1234567890123:role/DevelopersRole'
     base_s3_bucket: 'sul-speech-to-text-dev' # default bucket for storing speech-to-text file
     sqs_todo_queue_url: 'https://sqs.us-west-2.amazonaws.com/queue_url' # queue to send new speech-to-text jobs
     sqs_done_queue_url: 'https://sqs.us-west-2.amazonaws.com/queue_url_done' # queue to receive completed speech-to-text jobs

--- a/lib/dor/text_extraction/abbyy/file_watcher.rb
+++ b/lib/dor/text_extraction/abbyy/file_watcher.rb
@@ -22,7 +22,7 @@ module Dor
         # rubocop:disable Metrics/AbcSize
         def initialize(
           logger: Logger.new($stdout),
-          workflow_updater: Dor::TextExtraction::WorkflowUpdater,
+          workflow_updater_class: Dor::TextExtraction::WorkflowUpdater,
           listener_options: {}
         )
           # Set up the ABBYY directories
@@ -33,7 +33,7 @@ module Dor
 
           # Set up the services and listener
           @logger = logger
-          @workflow_updater = workflow_updater.new(logger:)
+          @workflow_updater = workflow_updater_class.new(logger:)
           @listener_options = default_listener_options.merge(listener_options)
           Dor::Services::Client.configure(logger:, url: Settings.dor_services.url, token: Settings.dor_services.token)
         end

--- a/lib/dor/text_extraction/abbyy/file_watcher.rb
+++ b/lib/dor/text_extraction/abbyy/file_watcher.rb
@@ -62,7 +62,7 @@ module Dor
         # Notify SDR that the OCR workflow step completed successfully
         def process_success(results)
           logger.info "Found successful OCR results for druid:#{results.druid} at #{results.result_path}"
-          workflow_updater.mark_ocr_completed("druid:#{results.druid}")
+          workflow_updater.mark_ocr_create_completed("druid:#{results.druid}")
           create_event(type: 'ocr_success', results:)
         end
 
@@ -71,7 +71,7 @@ module Dor
           logger.info "Found failed OCR results for druid:#{results.druid} at #{results.result_path}: #{results.failure_messages.join('; ')}"
           context = { druid: "druid:#{results.druid}", result_path: results.result_path, failure_messages: results.failure_messages }
           Honeybadger.notify('Found failed OCR results', context:)
-          workflow_updater.mark_ocr_errored("druid:#{results.druid}", error_msg: results.failure_messages.join("\n"))
+          workflow_updater.mark_ocr_create_errored("druid:#{results.druid}", error_msg: results.failure_messages.join("\n"))
           create_event(type: 'ocr_errored', results:)
         end
 

--- a/lib/dor/text_extraction/aws_provider.rb
+++ b/lib/dor/text_extraction/aws_provider.rb
@@ -5,14 +5,12 @@ module Dor
     # The Application's configured interface to AWS.
     class AwsProvider
       delegate :client, to: :resource
-      attr_reader :aws_client_args
 
-      def initialize(region:, access_key_id:, secret_access_key:)
-        @aws_client_args = {
-          region:,
-          access_key_id:,
-          secret_access_key:
-        }
+      def initialize(region:, access_key_id:, secret_access_key:, role_arn: nil)
+        @region = region
+        @access_key_id = access_key_id
+        @secret_access_key = secret_access_key
+        @role_arn = role_arn
       end
 
       # @return [::Aws::S3::Bucket]
@@ -37,12 +35,45 @@ module Dor
 
       # @return [::Aws::SQS::Client]
       def sqs
-        @sqs ||= ::Aws::SQS::Client.new(aws_client_args)
+        ::Aws::SQS::Client.new(aws_client_args)
       end
 
       # @return [::Aws::S3::Resource]
       def resource
         ::Aws::S3::Resource.new(aws_client_args)
+      end
+
+      private
+
+      attr_reader :region, :access_key_id, :secret_access_key, :role_arn
+
+      # @return [Hash<Symbol,Object>] a Hash with connection and credential info, for use instantiating AWS client objects (e.g. SQS, S3)
+      # @note We don't memoize the client args, because if they contain an Aws::AssumeRoleCredentials instance, that instance's initial token
+      #   can go stale. Making a new credentials hash is not resource intensive, so we just make a fresh one each time.
+      def aws_client_args
+        aws_client_args = {
+          region:, access_key_id:, secret_access_key:
+        }
+
+        # role_arn handling deals with e.g.
+        # 'Aws::SQS::Errors::AccessDenied: User: arn:aws:iam::1234567890123:user/uname is not authorized
+        # to perform: sqs:receivemessage on resource: arn:aws:sqs:us-west-2:1234567890123:sul-speech-to-text-done
+        # because no resource-based policy allows the sqs:receivemessage action' when polling for SQS messages
+        return aws_client_args unless role_arn.present?
+
+        # https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/SQS/Client.html
+        aws_client_args[:credentials] = assume_role_credentials(region:, access_key_id:, secret_access_key:, role_arn:)
+
+        aws_client_args
+      end
+
+      def assume_role_credentials(region:, access_key_id:, secret_access_key:, role_arn:)
+        # https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/setup-config.html#aws-ruby-sdk-credentials-access-token
+        Aws::AssumeRoleCredentials.new(
+          client: Aws::STS::Client.new(region:, access_key_id:, secret_access_key:),
+          role_arn:,
+          role_session_name: 'common-accessioning-session'
+        )
       end
     end
   end

--- a/lib/dor/text_extraction/dor_event_logger.rb
+++ b/lib/dor/text_extraction/dor_event_logger.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module Dor
+  module TextExtraction
+    # Send an entry to the dor-services-app event log
+    class DorEventLogger
+      # @param [Logger] an instance of a Ruby Logger (for debug etc logging)
+      def initialize(logger:)
+        Dor::Services::Client.configure(logger:, url: Settings.dor_services.url, token: Settings.dor_services.token)
+      end
+
+      # Publish to the SDR event service with processing information
+      def create_event(druid:, type:, data:)
+        Dor::Services::Client.object(druid).events.create(type:, data:)
+      end
+    end
+  end
+end

--- a/lib/dor/text_extraction/speech_to_text_create_done_handler.rb
+++ b/lib/dor/text_extraction/speech_to_text_create_done_handler.rb
@@ -17,10 +17,11 @@ module Dor
       def process_done_message(done_msg)
         done_msg_hash = JSON.parse(done_msg.body)
         druid, _version = done_msg_hash['id'].split('-') # druid-version, e.g. bc123df4567-v2
+        druid = DruidTools::Druid.new(druid).druid # normalize to namespaced druid, as DSA expects
         event_type = done_msg_hash['error'].blank? ? 'stt-create-success' : 'stt-create-error'
 
-        send_to_dor_event_log(druid:, event_type:, done_msg_hash:)
         update_workflow_step(druid:, create_succeeded: event_type == 'stt-create-success', error_msg: done_msg_hash['error'])
+        send_to_dor_event_log(druid:, event_type:, done_msg_hash:)
       end
 
       private

--- a/lib/dor/text_extraction/speech_to_text_create_done_handler.rb
+++ b/lib/dor/text_extraction/speech_to_text_create_done_handler.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Dor
+  module TextExtraction
+    # Handle an SQS message indicating that a speech-to-text job has completed (handles success or failure)
+    class SpeechToTextCreateDoneHandler
+      attr_reader :dor_event_logger, :host, :logger, :progname, :workflow_updater
+
+      def initialize(host:, progname:, logger:)
+        @host = host
+        @progname = progname
+        @logger = logger
+        @workflow_updater = Dor::TextExtraction::WorkflowUpdater.new(logger:)
+        @dor_event_logger = Dor::TextExtraction::DorEventLogger.new(logger:)
+      end
+
+      def process_done_message(done_msg)
+        done_msg_hash = JSON.parse(done_msg.body)
+        druid, _version = done_msg_hash['id'].split('-') # druid-version, e.g. bc123df4567-v2
+        event_type = done_msg_hash['error'].blank? ? 'stt-create-success' : 'stt-create-error'
+
+        send_to_dor_event_log(druid:, event_type:, done_msg_hash:)
+        update_workflow_step(druid:, create_succeeded: event_type == 'stt-create-success', error_msg: done_msg_hash['error'])
+      end
+
+      private
+
+      def update_workflow_step(druid:, create_succeeded:, error_msg: nil)
+        if create_succeeded
+          workflow_updater.mark_stt_create_completed(druid)
+          logger.debug('process_done_message: stt-create workflow step marked completed')
+        else
+          workflow_updater.mark_stt_create_errored(druid, error_msg:)
+          logger.debug("process_done_message: stt-create workflow step marked errored: #{error_msg}")
+        end
+      end
+
+      def send_to_dor_event_log(druid:, event_type:, done_msg_hash:)
+        data = {
+          host:, invoked_by: progname, done_msg_body: done_msg_hash
+        }
+        dor_event_logger.create_event(druid:, type: event_type, data:)
+        logger.debug("process_done_message: dor-services-app event created: #{{ druid:, event_type:, data: }}")
+      end
+    end
+  end
+end

--- a/lib/dor/text_extraction/sqs_watcher.rb
+++ b/lib/dor/text_extraction/sqs_watcher.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module Dor
+  module TextExtraction
+    # Watch an SQS queue for messages by long polling, allowing the consumer
+    # of this class to specify the queue name and the processing logic.
+    class SqsWatcher
+      attr_reader :logger, :queue_url, :role_arn, :visibility_timeout
+
+      def initialize(queue_url:, role_arn: nil, logger: Logger.new($stdout), visibility_timeout: nil)
+        @queue_url = queue_url
+        @role_arn = role_arn
+        @logger = logger
+        @visibility_timeout = visibility_timeout || default_visibility_timeout
+      end
+
+      def poll
+        logger.info("Starting indefinite long polling of #{queue_url}")
+        poller.poll(visibility_timeout:) do |sqs_msg|
+          yield sqs_msg
+        rescue StandardError => e
+          # unexpected error occurred while processing message.
+          # log it, and skip delete so it can be re-processed later.
+          context = { sqs_msg:, error: e }
+          Honeybadger.notify('Error processing SQS message, skipping deletion to allow requeue', context:)
+          logger.error("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}")
+
+          # without this throw, the message would be deleted upon completion of the block, preventing retry
+          throw :skip_delete # TODO: use msg[:attributes]['ApproximateReceiveCount'] to stop retrying above a certain threshold?
+        end
+      end
+
+      private
+
+      def poller
+        options = { client: aws_provider.sqs }
+        Aws::SQS::QueuePoller.new(queue_url, options).tap do |poller|
+          logger.info("created QueuePoller: #{poller.inspect}")
+        end
+      end
+
+      def default_visibility_timeout
+        120 # pick a reasonable default time by which the job should complete successfully, or allow the message to be requeued for retry
+      end
+
+      def aws_provider
+        @aws_provider ||=
+          Dor::TextExtraction::AwsProvider.new(region: Settings.aws.region,
+                                               access_key_id: Settings.aws.access_key_id,
+                                               secret_access_key: Settings.aws.secret_access_key,
+                                               role_arn:)
+      end
+    end
+  end
+end

--- a/lib/dor/text_extraction/workflow_updater.rb
+++ b/lib/dor/text_extraction/workflow_updater.rb
@@ -13,12 +13,12 @@ module Dor
       end
 
       # Notify SDR that the OCR workflow step completed successfully
-      def mark_ocr_completed(druid)
+      def mark_ocr_create_completed(druid)
         @client.update_status(druid:, workflow: OCR_WF_NAME, process: OCR_WF_CREATE_NAME, status: 'completed')
       end
 
       # Notify SDR that the OCR workflow step failed
-      def mark_ocr_errored(druid, error_msg:)
+      def mark_ocr_create_errored(druid, error_msg:)
         @client.update_error_status(druid:, workflow: OCR_WF_NAME, process: OCR_WF_CREATE_NAME, error_msg:)
       end
     end

--- a/lib/dor/text_extraction/workflow_updater.rb
+++ b/lib/dor/text_extraction/workflow_updater.rb
@@ -4,23 +4,22 @@ module Dor
   module TextExtraction
     # Update the status of workflow steps in SDR based on OCR processing events
     class WorkflowUpdater
-      attr_reader :workflow, :step
+      OCR_WF_NAME = 'ocrWF'
+      OCR_WF_CREATE_NAME = 'ocr-create'
 
       # Default is to update the 'ocr-create' step in the 'ocrWF' workflow
-      def initialize(workflow: 'ocrWF', step: 'ocr-create', client: nil, logger: nil)
-        @workflow = workflow
-        @step = step
+      def initialize(client: nil, logger: nil)
         @client = client || LyberCore::WorkflowClientFactory.build(logger:)
       end
 
       # Notify SDR that the OCR workflow step completed successfully
       def mark_ocr_completed(druid)
-        @client.update_status(druid:, workflow:, process: step, status: 'completed')
+        @client.update_status(druid:, workflow: OCR_WF_NAME, process: OCR_WF_CREATE_NAME, status: 'completed')
       end
 
       # Notify SDR that the OCR workflow step failed
       def mark_ocr_errored(druid, error_msg:)
-        @client.update_error_status(druid:, workflow:, process: step, error_msg:)
+        @client.update_error_status(druid:, workflow: OCR_WF_NAME, process: OCR_WF_CREATE_NAME, error_msg:)
       end
     end
   end

--- a/lib/dor/text_extraction/workflow_updater.rb
+++ b/lib/dor/text_extraction/workflow_updater.rb
@@ -2,10 +2,12 @@
 
 module Dor
   module TextExtraction
-    # Update the status of workflow steps in SDR based on OCR processing events
+    # Update the status of workflow steps in SDR based on text extraction (OCR, speech-to-text) processing events
     class WorkflowUpdater
       OCR_WF_NAME = 'ocrWF'
       OCR_WF_CREATE_NAME = 'ocr-create'
+      STT_WF_NAME = 'speechToTextWF'
+      STT_WF_CREATE_NAME = 'stt-create'
 
       # Default is to update the 'ocr-create' step in the 'ocrWF' workflow
       def initialize(client: nil, logger: nil)
@@ -20,6 +22,16 @@ module Dor
       # Notify SDR that the OCR workflow step failed
       def mark_ocr_create_errored(druid, error_msg:)
         @client.update_error_status(druid:, workflow: OCR_WF_NAME, process: OCR_WF_CREATE_NAME, error_msg:)
+      end
+
+      # Notify SDR that the speech-to-text workflow step completed successfully
+      def mark_stt_create_completed(druid)
+        @client.update_status(druid:, workflow: STT_WF_NAME, process: STT_WF_CREATE_NAME, status: 'completed')
+      end
+
+      # Notify SDR that the speech-to-text workflow step failed
+      def mark_stt_create_errored(druid, error_msg:)
+        @client.update_error_status(druid:, workflow: STT_WF_NAME, process: STT_WF_CREATE_NAME, error_msg:)
       end
     end
   end

--- a/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/file_watcher_spec.rb
@@ -23,8 +23,8 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
     allow(Honeybadger).to receive(:notify)
     allow(Dor::Services::Client).to receive(:configure)
     allow(Dor::Services::Client).to receive(:object).and_return(object_client)
-    allow(workflow_updater).to receive(:mark_ocr_errored)
-    allow(workflow_updater).to receive(:mark_ocr_completed)
+    allow(workflow_updater).to receive(:mark_ocr_create_errored)
+    allow(workflow_updater).to receive(:mark_ocr_create_completed)
     allow(object_client).to receive(:events).and_return(events_client)
     allow(events_client).to receive(:create)
     allow(logger).to receive(:info)
@@ -50,7 +50,7 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
     end
 
     it 'updates the OCR workflow' do
-      expect(workflow_updater).to have_received(:mark_ocr_completed).with(druid)
+      expect(workflow_updater).to have_received(:mark_ocr_create_completed).with(druid)
     end
 
     it 'logs the success' do
@@ -87,7 +87,7 @@ describe Dor::TextExtraction::Abbyy::FileWatcher do
     end
 
     it 'updates the OCR workflow' do
-      expect(workflow_updater).to have_received(:mark_ocr_errored).with(druid, error_msg: "Error one\nError two")
+      expect(workflow_updater).to have_received(:mark_ocr_create_errored).with(druid, error_msg: "Error one\nError two")
     end
 
     it 'publishes an event' do

--- a/spec/lib/dor/text_extraction/aws_provider_spec.rb
+++ b/spec/lib/dor/text_extraction/aws_provider_spec.rb
@@ -38,4 +38,19 @@ describe Dor::TextExtraction::AwsProvider do
       expect(config.credentials.secret_access_key).to eq secret_access_key
     end
   end
+
+  context 'when role_arn is provided' do
+    let(:role_arn) { Settings.aws.speech_to_text.role_arn }
+    let(:provider) { described_class.new(region:, access_key_id:, secret_access_key:, role_arn:) }
+    let(:assume_role_credentials) { instance_double(Aws::AssumeRoleCredentials) }
+
+    before do
+      allow(Aws::AssumeRoleCredentials).to receive(:new).with(client: an_instance_of(Aws::STS::Client), role_arn:, role_session_name: an_instance_of(String)).and_return(assume_role_credentials)
+    end
+
+    it 'configures the credentials with a role_arn value' do
+      expect(provider.sqs.config.credentials).to eq assume_role_credentials
+      expect(Aws::AssumeRoleCredentials).to have_received(:new).once
+    end
+  end
 end

--- a/spec/lib/dor/text_extraction/dor_event_logger_spec.rb
+++ b/spec/lib/dor/text_extraction/dor_event_logger_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+describe Dor::TextExtraction::DorEventLogger do
+  subject(:dor_event_logger) { described_class.new(logger:) }
+
+  let(:logger) { instance_double(Logger) }
+  let(:type) { 'test-event' }
+  let(:data) { { a_result_message: 'for example, or some other helpful context' } }
+  let(:druid) { 'bc123df4567' }
+  let(:events_client) { instance_double(Dor::Services::Client::Events, create: nil) }
+  let(:dor_object) { instance_double(Dor::Services::Client::Object, events: events_client) }
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).with(druid).and_return(dor_object)
+    allow(Dor::Services::Client).to receive(:configure)
+  end
+
+  it 'is configured correctly' do
+    dor_event_logger # just create the instance, don't need to do anything with it
+    expect(Dor::Services::Client).to have_received(:configure).with(logger:, url: Settings.dor_services.url, token: Settings.dor_services.token)
+  end
+
+  it 'creates the event' do
+    dor_event_logger.create_event(druid:, type:, data:)
+    expect(events_client).to have_received(:create).with(type:, data:)
+  end
+end

--- a/spec/lib/dor/text_extraction/speech_to_text_create_done_handler_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_create_done_handler_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe Dor::TextExtraction::SpeechToTextCreateDoneHandler do
+  subject(:handler) { described_class.new(host:, progname:, logger:) }
+
+  let(:host) { 'common-accessioning-test-y.stanford.edu' }
+  let(:progname) { 'stt_create_done_handler_spec' }
+  let(:logger) { instance_double(Logger, debug: nil, info: nil) }
+  let(:druid) { 'bc123df4567' }
+  let(:workflow_updater) { instance_double(Dor::TextExtraction::WorkflowUpdater, mark_stt_create_completed: nil, mark_stt_create_errored: nil) }
+  let(:dor_event_logger) { instance_double(Dor::TextExtraction::DorEventLogger, create_event: nil) }
+  let(:whisper_error_msg) { nil }
+  let(:done_msg_hash) do
+    {
+      'id' => "#{druid}-v2",
+      'media' => ['bear_breaks_into_home_plays_piano_no_speech.mp4'],
+      'finished' => '2024-10-08T16:35:44.959829+00:00',
+      'extraction_technical_metadata' => {
+        'speech_to_text_extraction_program' => { 'name' => 'whisper', 'version' => '20240930' },
+        'effective_options' => { 'fp16' => false },
+        'effective_writer_options' => { 'highlight_words' => nil, 'max_line_count' => nil, 'max_line_width' => nil, 'max_words_per_line' => nil },
+        'effective_model_name' => 'small'
+      }
+    }.tap { |done_msg_hash| done_msg_hash.merge!({ 'error' => whisper_error_msg }) if whisper_error_msg.present? }
+  end
+  let(:done_msg_body) { done_msg_hash.to_json }
+  let(:done_msg) { instance_double(Aws::SQS::Types::Message, body: done_msg_body) }
+  let(:event_data) { { host:, invoked_by: progname, done_msg_body: done_msg_hash } }
+
+  before do
+    allow(Dor::TextExtraction::WorkflowUpdater).to receive(:new).with(logger:).and_return(workflow_updater)
+    allow(Dor::TextExtraction::DorEventLogger).to receive(:new).with(logger:).and_return(dor_event_logger)
+    handler.process_done_message(done_msg)
+  end
+
+  describe '#process_done_message' do
+    context 'when there is no error field' do
+      it 'creates a DOR event log entry for creation success' do
+        expect(dor_event_logger).to have_received(:create_event).with(druid:, type: 'stt-create-success', data: event_data)
+      end
+
+      it 'marks the workflow step as completed' do
+        expect(workflow_updater).to have_received(:mark_stt_create_completed).with(druid)
+      end
+    end
+
+    context 'when there is an error field' do
+      let(:whisper_error_msg) { 'oh no! there was an unexpected error trying to extract text from speech' }
+
+      it 'creates a DOR event log entry for creation failure' do
+        expect(dor_event_logger).to have_received(:create_event).with(druid:, type: 'stt-create-error', data: event_data)
+      end
+
+      it 'marks the workflow step as errored' do
+        expect(workflow_updater).to have_received(:mark_stt_create_errored).with(druid, error_msg: whisper_error_msg)
+      end
+    end
+  end
+end

--- a/spec/lib/dor/text_extraction/speech_to_text_create_done_handler_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_create_done_handler_spec.rb
@@ -6,13 +6,14 @@ describe Dor::TextExtraction::SpeechToTextCreateDoneHandler do
   let(:host) { 'common-accessioning-test-y.stanford.edu' }
   let(:progname) { 'stt_create_done_handler_spec' }
   let(:logger) { instance_double(Logger, debug: nil, info: nil) }
-  let(:druid) { 'bc123df4567' }
+  let(:bare_druid) { 'bc123df4567' }
+  let(:druid) { "druid:#{bare_druid}" }
   let(:workflow_updater) { instance_double(Dor::TextExtraction::WorkflowUpdater, mark_stt_create_completed: nil, mark_stt_create_errored: nil) }
   let(:dor_event_logger) { instance_double(Dor::TextExtraction::DorEventLogger, create_event: nil) }
   let(:whisper_error_msg) { nil }
   let(:done_msg_hash) do
     {
-      'id' => "#{druid}-v2",
+      'id' => "#{bare_druid}-v2",
       'media' => ['bear_breaks_into_home_plays_piano_no_speech.mp4'],
       'finished' => '2024-10-08T16:35:44.959829+00:00',
       'extraction_technical_metadata' => {

--- a/spec/lib/dor/text_extraction/sqs_watcher_spec.rb
+++ b/spec/lib/dor/text_extraction/sqs_watcher_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+describe Dor::TextExtraction::SqsWatcher do
+  subject(:sqs_watcher) { described_class.new(queue_url:, role_arn:, logger:, visibility_timeout:) }
+
+  let(:queue_url) { Settings.aws.speech_to_text.sqs_done_queue_url }
+  let(:region) { Settings.aws.region }
+  let(:access_key_id) { Settings.aws.access_key_id }
+  let(:secret_access_key) { Settings.aws.secret_access_key }
+  let(:role_arn) { Settings.aws.speech_to_text.role_arn }
+  let(:logger) { instance_double(Logger, info: nil, error: nil) }
+  let(:visibility_timeout) { nil }
+  let(:aws_provider) { instance_double(Dor::TextExtraction::AwsProvider, sqs: instance_double(Aws::SQS::Client)) }
+  let(:aws_provider_opts) do
+    { region:, access_key_id:, secret_access_key:, role_arn: }
+  end
+  let(:poller) { instance_double(Aws::SQS::QueuePoller) }
+
+  let(:sqs_msg_hash) do
+    { 'payload_field' => 'payload_value' }
+  end
+  let(:sqs_msg_body) { sqs_msg_hash.to_json }
+  let(:sqs_msg) { instance_double(Aws::SQS::Types::Message, body: sqs_msg_body) }
+
+  let(:message_handler) { instance_double(Dor::TextExtraction::SpeechToTextCreateDoneHandler, process_done_message: nil) }
+
+  before do
+    allow(Honeybadger).to receive(:notify)
+    allow(Dor::TextExtraction::AwsProvider).to receive(:new).with(aws_provider_opts).and_return(aws_provider)
+    allow(Aws::SQS::QueuePoller).to receive(:new).with(queue_url, { client: aws_provider.sqs }).and_return(poller)
+    # NOTE: This is a somewhat unrealistically simplified mocking of QueuePoller#poll,
+    # as the real invocation of that method in this codebase should cause it to run indefinitely,
+    # polling for messages and invoking its block whenever one is received. But this mock instead
+    # executes the block once.
+    # TODO: there is a ticket for investigating localstack for more realistic testing, see
+    # https://github.com/sul-dlss/common-accessioning/issues/1364
+    # Though then it will be necessary to somehow kill the poller thread, or provide the
+    # option to run for only a limited time (via e.g. idle_timeout option to QueuePoller#poll).
+    # Perhaps the infra integration test suite will suffice for realistic regression testing.
+    allow(poller).to receive(:poll).and_yield(sqs_msg)
+  end
+
+  describe '#poll' do
+    let(:sqs_watcher_poll) do
+      sqs_watcher.poll do |sqs_msg|
+        message_handler.process_done_message(sqs_msg)
+      end
+    end
+
+    describe 'no error is raised by the handler' do
+      before { sqs_watcher_poll }
+
+      it 'yields the SQS message received by the poller to the provided block' do
+        expect(message_handler).to have_received(:process_done_message).with(sqs_msg)
+      end
+
+      it 'does not log an error or notify Honeybadger' do
+        expect(Honeybadger).not_to have_received(:notify)
+        expect(logger).not_to have_received(:error)
+      end
+    end
+
+    describe 'an error is raised by the handler' do
+      let(:err_msg) { 'uh-oh' }
+      let(:handler_error) { StandardError.new(err_msg) }
+
+      before do
+        allow(message_handler).to receive(:process_done_message).and_raise(handler_error)
+      end
+
+      it 'throws a :skip_delete so that the message stays on the queue, to be picked up again' do
+        expect { sqs_watcher_poll }.to throw_symbol(:skip_delete)
+      end
+
+      it 'logs an error and notifies Honeybadger' do
+        catch :skip_delete do
+          sqs_watcher_poll
+        end
+        context = { sqs_msg:, error: handler_error }
+        expect(Honeybadger).to have_received(:notify).with('Error processing SQS message, skipping deletion to allow requeue', context:)
+        expect(logger).to have_received(:error).with("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}")
+      end
+    end
+  end
+end

--- a/spec/lib/dor/text_extraction/workflow_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/workflow_updater_spec.rb
@@ -13,16 +13,16 @@ describe Dor::TextExtraction::WorkflowUpdater do
     allow(client).to receive(:update_error_status)
   end
 
-  describe '#mark_ocr_completed' do
+  describe '#mark_ocr_create_completed' do
     it 'calls the workflow client to set completed status' do
-      updater.mark_ocr_completed(druid)
+      updater.mark_ocr_create_completed(druid)
       expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'completed')
     end
   end
 
-  describe '#mark_ocr_errored' do
+  describe '#mark_ocr_create_errored' do
     it 'calls the workflow client to set error status and message' do
-      updater.mark_ocr_errored(druid, error_msg: 'Something went wrong')
+      updater.mark_ocr_create_errored(druid, error_msg: 'Something went wrong')
       expect(client).to have_received(:update_error_status).with(druid:, workflow:, process: step, error_msg: 'Something went wrong')
     end
   end

--- a/spec/lib/dor/text_extraction/workflow_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/workflow_updater_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe Dor::TextExtraction::WorkflowUpdater do
-  subject(:updater) { described_class.new(workflow:, step:, client:) }
+  subject(:updater) { described_class.new(client:) }
 
   let(:workflow) { 'ocrWF' }
   let(:step) { 'ocr-create' }

--- a/spec/lib/dor/text_extraction/workflow_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/workflow_updater_spec.rb
@@ -3,8 +3,6 @@
 describe Dor::TextExtraction::WorkflowUpdater do
   subject(:updater) { described_class.new(client:) }
 
-  let(:workflow) { 'ocrWF' }
-  let(:step) { 'ocr-create' }
   let(:client) { instance_double(Dor::Workflow::Client) }
   let(:druid) { 'bb222cc3333' }
 
@@ -13,17 +11,41 @@ describe Dor::TextExtraction::WorkflowUpdater do
     allow(client).to receive(:update_error_status)
   end
 
-  describe '#mark_ocr_create_completed' do
-    it 'calls the workflow client to set completed status' do
-      updater.mark_ocr_create_completed(druid)
-      expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'completed')
+  describe 'ocrWF' do
+    let(:workflow) { 'ocrWF' }
+    let(:step) { 'ocr-create' }
+
+    describe '#mark_ocr_create_completed' do
+      it 'calls the workflow client to set completed status' do
+        updater.mark_ocr_create_completed(druid)
+        expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'completed')
+      end
+    end
+
+    describe '#mark_ocr_create_errored' do
+      it 'calls the workflow client to set error status and message' do
+        updater.mark_ocr_create_errored(druid, error_msg: 'Something went wrong')
+        expect(client).to have_received(:update_error_status).with(druid:, workflow:, process: step, error_msg: 'Something went wrong')
+      end
     end
   end
 
-  describe '#mark_ocr_create_errored' do
-    it 'calls the workflow client to set error status and message' do
-      updater.mark_ocr_create_errored(druid, error_msg: 'Something went wrong')
-      expect(client).to have_received(:update_error_status).with(druid:, workflow:, process: step, error_msg: 'Something went wrong')
+  describe 'speechToTextWF' do
+    let(:workflow) { 'speechToTextWF' }
+    let(:step) { 'stt-create' }
+
+    describe '#mark_stt_create_completed' do
+      it 'calls the workflow client to set completed status' do
+        updater.mark_stt_create_completed(druid)
+        expect(client).to have_received(:update_status).with(druid:, workflow:, process: step, status: 'completed')
+      end
+    end
+
+    describe '#mark_stt_create_errored' do
+      it 'calls the workflow client to set error status and message' do
+        updater.mark_stt_create_errored(druid, error_msg: 'Something went wrong')
+        expect(client).to have_received(:update_error_status).with(druid:, workflow:, process: step, error_msg: 'Something went wrong')
+      end
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

part of #1358

## How was this change tested? 🤨

- unit tests
- ran the daemon locally at debug log level
  - configured to point to my own test queues
  - commented out the calls to report to DOR event log and workflow service
  - created and worked a test job using [the tools in speech-to-text for creating test jobs](https://github.com/sul-dlss/speech-to-text?tab=readme-ov-file#run)
  - watched the job get picked up by this daemon, saw the message body get parsed properly based on log statements
  - stopped the daemon and uncommented the calls to report to DOR event log and workflow service
  - created another test job
  - watched the daemon log an error because i don't have my local common-accessioning instance configured to talk to a real dor-services-app or workflow-server-rails instance
  - watched the daemon sit there for the default `visibility_timeout` before picking up the same job again, this time with an increased `ApproximateReceiveCount` (will probably do a follow on to limit retries based on that).  job continued to be retried in that manner till i stopped the daemon again.
- ran integration tests against QA (with this branch deployed and running in a `screen` session).
  - i had trouble when specifying a `role_arn` (which i had to do in my laptop env), but was able to attach to the queue when i omitted the `role_arn`.  that turned up another bug with druid format, fixed in the last commit i pushed on.  i then adjusted the queue names a bit, which i think crashed the speech-to-text container in AWS (when terraform tore down the queues for the old names).  after adjusting the queue and bucket names in the `.env` file for the container and restarting it, i was able to successfully run `spec/features/preassembly_speech_to_text_media_spec.rb` from https://github.com/sul-dlss/infrastructure-integration-test/pull/790 without manual intervention (speech-to-text service running as detached docker container in AWS EC2, watcher started manually in `screen` on common-accessioning-qa-a).

examples created by integration tests (notice completed `speechToTextWF`, and `stt-create-success` event):
- https://argo-qa.stanford.edu/view/vz622bs2090
- https://argo-qa.stanford.edu/view/fb528tv2933

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


