### PR TITLE
update dsa client

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'assembly-objectfile', '~> 2.1'
 gem 'aws-sdk-s3' # used for sending files to S3 for the speech-to-text workflow
 gem 'aws-sdk-sqs' # used for sending sqs mssages for the speech-to-text workflow
 gem 'config'
-gem 'dor-services-client', '~> 15.0'
+gem 'dor-services-client', '~> 15.1'
 gem 'dor-workflow-client', '~> 7.0'
 gem 'dry-struct', '~> 1.0'
 gem 'dry-types', '~> 1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
       capistrano-shared_configs
       ed25519
     docile (1.4.1)
-    dor-services-client (15.0.0)
+    dor-services-client (15.1.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.99.0)
       deprecation
@@ -355,7 +355,7 @@ DEPENDENCIES
   config
   debug
   dlss-capistrano
-  dor-services-client (~> 15.0)
+  dor-services-client (~> 15.1)
   dor-workflow-client (~> 7.0)
   druid-tools
   dry-struct (~> 1.0)


### PR DESCRIPTION
## Why was this change made? 🤔

Removal of the workflow param from the cleanup call (https://github.com/sul-dlss/dor-services-client/pull/475) means we should use the new gem.

## How was this change tested? 🤨

CI


