### PR TITLE
Address S3 flakiness on upload

### DIFF
--- a/lib/dor/text_extraction/file_fetcher.rb
+++ b/lib/dor/text_extraction/file_fetcher.rb
@@ -55,18 +55,22 @@ module Dor
       private
 
       # fetch a file from preservation and send to cloud endpoint
+      # rubocop:disable Metrics/MethodLength
       def fetch_and_send_file_to_s3(filename:, s3_object:)
         logger.info("fetching #{filename} for #{druid} and sending to #{s3_object.bucket_name}")
-        s3_object.upload_stream do |upload_stream|
-          preservation_client.objects.content(
-            druid:,
-            filepath: filename,
-            on_data: proc { |data, _count| upload_stream.write(data) }
-          )
-        end
+        Thread.new do
+          s3_object.upload_stream do |upload_stream|
+            preservation_client.objects.content(
+              druid:,
+              filepath: filename,
+              on_data: proc { |data, _count| upload_stream.write(data) }
+            )
+          end
+        end.join
 
-        true # NOTE: return false on failure
+        true
       end
+      # rubocop:enable Metrics/MethodLength
 
       # fetch a file from perservation and write to disk
       def fetch_and_write_file_to_disk(filename:, path:)

--- a/lib/dor/text_extraction/file_fetcher.rb
+++ b/lib/dor/text_extraction/file_fetcher.rb
@@ -55,22 +55,18 @@ module Dor
       private
 
       # fetch a file from preservation and send to cloud endpoint
-      # rubocop:disable Metrics/MethodLength
       def fetch_and_send_file_to_s3(filename:, s3_object:)
         logger.info("fetching #{filename} for #{druid} and sending to #{s3_object.bucket_name}")
-        Thread.new do
-          s3_object.upload_stream do |upload_stream|
-            preservation_client.objects.content(
-              druid:,
-              filepath: filename,
-              on_data: proc { |data, _count| upload_stream.write(data) }
-            )
-          end
-        end.join
+        s3_object.upload_stream do |upload_stream|
+          preservation_client.objects.content(
+            druid:,
+            filepath: filename,
+            on_data: proc { |data, _count| upload_stream.write(data) }
+          )
+        end
 
         true
       end
-      # rubocop:enable Metrics/MethodLength
 
       # fetch a file from perservation and write to disk
       def fetch_and_write_file_to_disk(filename:, path:)

--- a/lib/dor/text_extraction/file_fetcher.rb
+++ b/lib/dor/text_extraction/file_fetcher.rb
@@ -31,7 +31,7 @@ module Dor
                     else
                       raise "Unknown location type: #{location.class}"
                     end
-        rescue Faraday::ResourceNotFound
+        rescue Faraday::ResourceNotFound, Aws::S3::MultipartUploadError
           tries += 1
           logger.warn("received NotFoundError from Preservation try ##{tries}")
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1392 by catching the 404 from preservation before we get to trying to pull from S3 and doing a retry (same as we do when trying to write to disk for OCR).

## How was this change tested? 🤨

Integration tests (worked three times in a row with integration test)


