### PR TITLE
adjust mimetype for allowed audio files for speech to text

### DIFF
--- a/lib/dor/text_extraction/speech_to_text.rb
+++ b/lib/dor/text_extraction/speech_to_text.rb
@@ -93,6 +93,7 @@ module Dor
       # defines the mimetypes types for which speech to text files can possibly be run
       def allowed_mimetypes
         %w[
+          audio/x-m4a
           audio/mp4
           video/mp4
         ]


### PR DESCRIPTION
## Why was this change made? 🤔

As per discussion here: https://stanfordlib.slack.com/archives/C06EVDJV45N/p1731011602548429

Should still work as is because of the `Assembly::ObjectFile` gem computes the mimetype as `audio/mp4` for our test object.  This would allow the other mimetype through to be captioned as well.

## How was this change tested? 🤨

Updated spec

