### PR TITLE
only include .txt and .vtt files produced by whisper in object

### DIFF
--- a/lib/robots/dor_repo/speech_to_text/stage_files.rb
+++ b/lib/robots/dor_repo/speech_to_text/stage_files.rb
@@ -37,9 +37,9 @@ module Robots
         end
 
         # array of media files in the s3 output bucket folder for this job
-        # TODO: filter to only files we actually care about?
+        # only includes .txt and .vtt files
         def output_files
-          @output_files ||= aws_provider.client.list_objects(bucket: aws_provider.bucket_name, prefix: s3_output_folder).contents.map(&:key)
+          @output_files ||= aws_provider.client.list_objects(bucket: aws_provider.bucket_name, prefix: s3_output_folder).contents.map(&:key).select { |filename| filename.end_with?('.txt', '.vtt') }
         end
 
         # the s3 output folder for this job


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1408 - filter out unnecessary caption files when pulling them from S3

~~HOLD for integration test~~

## How was this change tested? 🤨

Updated spec
Integration test