### PR TITLE
skip files marked as corrected for accessibility

### DIFF
--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -141,16 +141,14 @@ module Dor
 
       # filter down fileset files that could possibly be OCRed to those that are in preservation and shelved and are one of an allowed mimetypes
       # if there is more than one file of the allowed mimetype, grab the preferred type
-      # rubocop:disable Metrics/AbcSize
       def ocr_file(fileset)
         files ||=
-          fileset.structural.contains.select { |file| file.administrative.sdrPreserve && allowed_mimetypes.include?(file.hasMimeType) }.sort_by { |pfile| allowed_mimetypes.index(pfile.hasMimeType) }
+          fileset.structural.contains.select { |file| acceptable_file?(file) }.sort_by { |pfile| allowed_mimetypes.index(pfile.hasMimeType) }
 
         return nil if files.empty? || existing_ocr_file_corrected_for_accessibility?(fileset, files.first.filename)
 
         files.first
       end
-      # rubocop:enable Metrics/AbcSize
 
       # look in resource structural metadata to find a matching OCR file that has been corrected for accessibility
       # e.g. if the original file is "page1.tif", look for a "page1.xml" in the same resource that is
@@ -163,6 +161,11 @@ module Dor
         fileset.structural.contains.find do |file|
           file.filename == corresponding_ocr_file && file.correctedForAccessibility
         end
+      end
+
+      # indicates if the file is preserved, shelved and is of an allowed mimetype
+      def acceptable_file?(file)
+        file.administrative.sdrPreserve && file.administrative.shelve && allowed_mimetypes.include?(file.hasMimeType)
       end
 
       # defines the mimetypes types for which files for which OCR can possibly be run

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -154,12 +154,12 @@ module Dor
       # e.g. if the original file is "page1.tif", look for a "page1.xml" in the same resource that is
       # marked as "correctedForAccessibility" in it's cocina attribute, and then return true or false
       # this allows us to skip this OCRing this file, since there is no point in doing it (since we wouldn't
-      # want to overwrite the existing manually corrected OCR file)
+      # want to overwrite the existing manually corrected OR non-SDR generated OCR file)
       def existing_ocr_file_corrected_for_accessibility?(fileset, filename)
         basename = File.basename(filename, File.extname(filename)) # filename without extension
         corresponding_ocr_file = "#{basename}.xml"
         fileset.structural.contains.find do |file|
-          file.filename == corresponding_ocr_file && file.correctedForAccessibility
+          file.filename == corresponding_ocr_file && (file.correctedForAccessibility || !file.sdrGeneratedText)
         end
       end
 

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -139,14 +139,30 @@ module Dor
         end.compact
       end
 
-      # filter down fileset files to those in preservation and are allowed mimetypes
-      # if there are more than one allowed mimetype, grab the preferred type
+      # filter down fileset files that could possibly be OCRed to those that are in preservation and shelved and are one of an allowed mimetypes
+      # if there is more than one file of the allowed mimetype, grab the preferred type
+      # rubocop:disable Metrics/AbcSize
       def ocr_file(fileset)
-        perservedfiles = fileset.structural.contains.select { |file| file.administrative.sdrPreserve && allowed_mimetypes.include?(file.hasMimeType) }
-        return perservedfiles[0] if perservedfiles.one?
+        files ||=
+          fileset.structural.contains.select { |file| file.administrative.sdrPreserve && allowed_mimetypes.include?(file.hasMimeType) }.sort_by { |pfile| allowed_mimetypes.index(pfile.hasMimeType) }
 
-        perservedfiles = perservedfiles.sort_by { |pfile| allowed_mimetypes.index(pfile.hasMimeType) }
-        perservedfiles[0]
+        return nil if files.empty? || existing_ocr_file_corrected_for_accessibility?(fileset, files.first.filename)
+
+        files.first
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      # look in resource structural metadata to find a matching OCR file that has been corrected for accessibility
+      # e.g. if the original file is "page1.tif", look for a "page1.xml" in the same resource that is
+      # marked as "correctedForAccessibility" in it's cocina attribute, and then return true or false
+      # this allows us to skip this OCRing this file, since there is no point in doing it (since we wouldn't
+      # want to overwrite the existing manually corrected OCR file)
+      def existing_ocr_file_corrected_for_accessibility?(fileset, filename)
+        basename = File.basename(filename, File.extname(filename)) # filename without extension
+        corresponding_ocr_file = "#{basename}.xml"
+        fileset.structural.contains.find do |file|
+          file.filename == corresponding_ocr_file && file.correctedForAccessibility
+        end
       end
 
       # defines the mimetypes types for which files for which OCR can possibly be run
@@ -169,6 +185,7 @@ module Dor
         }
       end
 
+      # the resource type we are looking for in the structural metadata for files to OCR
       def matchtype
         resource_type_mapping[cocina_object.type]
       end

--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -139,7 +139,7 @@ module Dor
         end.compact
       end
 
-      # filter down fileset files that could possibly be OCRed to those that are in preservation and shelved and are one of an allowed mimetypes
+      # filter down fileset files that could possibly be OCRed to those that are in preservation and shelved and are of an allowed mimetype
       # if there is more than one file of the allowed mimetype, grab the preferred type
       def ocr_file(fileset)
         files ||=

--- a/lib/dor/text_extraction/speech_to_text.rb
+++ b/lib/dor/text_extraction/speech_to_text.rb
@@ -94,12 +94,12 @@ module Dor
       # e.g. if the original file is "page1.tif", look for a "page1.txt" in the same resource that is
       # marked as "correctedForAccessibility" in it's cocina attribute, and then return true or false
       # this allows us to skip this captioning this file, since there is no point in doing it (since we wouldn't
-      # want to overwrite the existing manually corrected caption file)
+      # want to overwrite the existing manually corrected OR non-SDR generated caption file)
       def existing_stt_file_corrected_for_accessibility?(fileset, filename)
         basename = File.basename(filename, File.extname(filename)) # filename without extension
         corresponding_stt_file = "#{basename}.vtt"
         fileset.structural.contains.find do |file|
-          file.filename == corresponding_stt_file && file.correctedForAccessibility
+          file.filename == corresponding_stt_file && (file.correctedForAccessibility || !file.sdrGeneratedText)
         end
       end
 

--- a/lib/dor/text_extraction/speech_to_text.rb
+++ b/lib/dor/text_extraction/speech_to_text.rb
@@ -87,8 +87,7 @@ module Dor
       # filter down fileset files that could possibly be speech to texted to those that are in preservation
       # and shelved and are of an allowed mimetypes and return all of them
       def stt_files_in_fileset(fileset)
-        files = fileset.structural.contains.select { |file| file.administrative.sdrPreserve && file.administrative.shelve && allowed_mimetypes.include?(file.hasMimeType) }
-        files.reject { |file| existing_stt_file_corrected_for_accessibility?(fileset, file.filename) }
+        fileset.structural.contains.select { |file| acceptable_file?(file) }.reject { |file| existing_stt_file_corrected_for_accessibility?(fileset, file.filename) }
       end
 
       # look in resource structural metadata to find a matching speech to text file that has been corrected for accessibility
@@ -104,6 +103,11 @@ module Dor
         end
       end
 
+      # indicates if the file is preserved, shelved and is of an allowed mimetype
+      def acceptable_file?(file)
+        file.administrative.sdrPreserve && file.administrative.shelve && allowed_mimetypes.include?(file.hasMimeType)
+      end
+
       # defines the mimetypes types for which speech to text files can possibly be run
       def allowed_mimetypes
         %w[
@@ -115,7 +119,7 @@ module Dor
 
       # the allowed structural metadata resources types that can contain files that can be stt'd
       def allowed_resource_types
-        ['https://cocina.sul.stanford.edu/models/resources/audio', 'https://cocina.sul.stanford.edu/models/resources/video']
+        [Cocina::Models::FileSetType.audio, Cocina::Models::FileSetType.video]
       end
 
       # the allowed objects that can have speech to text run on them

--- a/spec/lib/dor/assembly/content_metadata_from_stub/structural_builder_spec.rb
+++ b/spec/lib/dor/assembly/content_metadata_from_stub/structural_builder_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
         end
 
         let(:expected) do
-          { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          { contains: [{ type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_1',
                          label: 'Image 1',
                          version: 1,
@@ -41,7 +41,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: false, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                       { type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_2',
                          label: 'Image 2',
                          version: 1,
@@ -55,7 +55,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                       { type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_3',
                          label: 'Image 3',
                          version: 1,
@@ -103,7 +103,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
         end
 
         let(:expected) do
-          { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          { contains: [{ type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_1',
                          label: 'Image 1',
                          version: 1,
@@ -177,7 +177,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                       { type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_2',
                          label: 'Image 2',
                          version: 1,
@@ -241,7 +241,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                       { type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_3',
                          label: 'Image 3',
                          version: 1,
@@ -295,7 +295,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
         end
 
         let(:expected) do
-          { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          { contains: [{ type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_1',
                          label: 'Image 1',
                          version: 1,
@@ -309,7 +309,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: false, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                       { type: Cocina::Models::FileSetType.image,
                          externalIdentifier: 'nx288wh8889_2',
                          label: 'Image 2',
                          version: 1,
@@ -343,7 +343,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
         end
 
         let(:expected) do
-          { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/page',
+          { contains: [{ type: Cocina::Models::FileSetType.page,
                          externalIdentifier: 'nx288wh8889_1',
                          label: 'Page 1',
                          version: 1,
@@ -357,7 +357,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/page',
+                       { type: Cocina::Models::FileSetType.page,
                          externalIdentifier: 'nx288wh8889_2',
                          label: 'Page 2',
                          version: 1,
@@ -396,7 +396,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
         end
 
         let(:expected) do
-          { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/file',
+          { contains: [{ type: Cocina::Models::FileSetType.file,
                          externalIdentifier: 'nx288wh8889_1',
                          label: 'File 1',
                          version: 1,
@@ -410,7 +410,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: false, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/file',
+                       { type: Cocina::Models::FileSetType.file,
                          externalIdentifier: 'nx288wh8889_2',
                          label: 'File 2',
                          version: 1,
@@ -424,7 +424,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: false, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/file',
+                       { type: Cocina::Models::FileSetType.file,
                          externalIdentifier: 'nx288wh8889_3',
                          label: 'File 3',
                          version: 1,
@@ -438,7 +438,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                     hasMessageDigests: [],
                                                     access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                     administrative: { publish: false, sdrPreserve: false, shelve: false } }] } },
-                       { type: 'https://cocina.sul.stanford.edu/models/resources/file',
+                       { type: Cocina::Models::FileSetType.file,
                          externalIdentifier: 'nx288wh8889_4',
                          label: 'File 4',
                          version: 1,
@@ -486,7 +486,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
       let(:object_type) { Cocina::Models::ObjectType.three_dimensional }
 
       let(:expected) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/3d',
+        { contains: [{ type: Cocina::Models::FileSetType.three_dimensional,
                        externalIdentifier: 'nx288wh8889_1',
                        label: '3d 1',
                        version: 1,
@@ -500,7 +500,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                   hasMessageDigests: [],
                                                   access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                   administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                     { type: 'https://cocina.sul.stanford.edu/models/resources/file',
+                     { type: Cocina::Models::FileSetType.file,
                        externalIdentifier: 'nx288wh8889_2',
                        label: 'File 1',
                        version: 1,
@@ -514,7 +514,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                   hasMessageDigests: [],
                                                   access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                   administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                     { type: 'https://cocina.sul.stanford.edu/models/resources/file',
+                     { type: Cocina::Models::FileSetType.file,
                        externalIdentifier: 'nx288wh8889_3',
                        label: 'File 2',
                        version: 1,
@@ -528,7 +528,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
                                                   hasMessageDigests: [],
                                                   access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                   administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                     { type: 'https://cocina.sul.stanford.edu/models/resources/file',
+                     { type: Cocina::Models::FileSetType.file,
                        externalIdentifier: 'nx288wh8889_4',
                        label: 'File 3',
                        version: 1,
@@ -559,7 +559,7 @@ RSpec.describe Dor::Assembly::ContentMetadataFromStub::StructuralBuilder do
       end
 
       let(:expected) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'nx288wh8889_1',
                        label: 'Image 1',
                        version: 1,

--- a/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
+++ b/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
         {
           contains: [
             {
-              type: 'https://cocina.sul.stanford.edu/models/resources/page',
+              type: Cocina::Models::FileSetType.page,
               externalIdentifier: 'bc234fg5678_1', label: 'Optional label',
               version: 1,
               structural: {
@@ -66,7 +66,7 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
                 ]
               }
             }, {
-              type: 'https://cocina.sul.stanford.edu/models/resources/page',
+              type: Cocina::Models::FileSetType.page,
               externalIdentifier: 'bc234fg5678_2', label: 'optional page 2 label',
               version: 1,
               structural: {
@@ -92,7 +92,7 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
                 ]
               }
             }, {
-              type: 'https://cocina.sul.stanford.edu/models/resources/object',
+              type: Cocina::Models::FileSetType.object,
               externalIdentifier: 'bc234fg5678_3', label: 'Object 1', version: 1,
               structural: {
                 contains: [
@@ -129,7 +129,7 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
         {
           contains: [
             {
-              type: 'https://cocina.sul.stanford.edu/models/resources/page',
+              type: Cocina::Models::FileSetType.page,
               externalIdentifier: 'bc234fg5678_1', label: 'Optional label',
               version: 1,
               structural: {
@@ -154,7 +154,7 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
                 ]
               }
             }, {
-              type: 'https://cocina.sul.stanford.edu/models/resources/page',
+              type: Cocina::Models::FileSetType.page,
               externalIdentifier: 'bc234fg5678_2', label: 'optional page 2 label',
               version: 1,
               structural: {
@@ -180,7 +180,7 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
                 ]
               }
             }, {
-              type: 'https://cocina.sul.stanford.edu/models/resources/object',
+              type: Cocina::Models::FileSetType.object,
               externalIdentifier: 'bc234fg5678_3', label: 'Object 1', version: 1,
               structural: {
                 contains: [

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -119,8 +119,17 @@ RSpec.describe Dor::TextExtraction::Ocr do
       end
     end
 
-    context 'when an OCR file exists and is NOT marked correctedForAccessibility' do
-      let(:xml_file) { build_file('file2.xml', corrected: false) }
+    context 'when an OCR file exists and is NOT marked correctedForAccessibility and is also NOT sdrGenerated' do
+      let(:xml_file) { build_file('file2.xml', corrected: false, sdr_generated: false) }
+      let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [tif_file, xml_file]) }
+
+      it 'returns nothing' do
+        expect(ocr.send(:filenames_to_ocr)).to eq([])
+      end
+    end
+
+    context 'when an OCR file exists and is NOT marked correctedForAccessibility but is sdrGenerated' do
+      let(:xml_file) { build_file('file2.xml', corrected: false, sdr_generated: true) }
       let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [tif_file, xml_file]) }
 
       it 'returns the tif file' do

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -5,11 +5,16 @@ require 'spec_helper'
 RSpec.describe Dor::TextExtraction::Ocr do
   let(:ocr) { described_class.new(cocina_object:, workflow_context:) }
   let(:ticket) { Dor::TextExtraction::Abbyy::Ticket.new(filepaths: [], druid:) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+  let(:druid) { 'druid:bc123df4567' }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: is_dro, type: object_type, structural:) }
+  let(:is_dro) { true }
+  let(:object_type) { Cocina::Models::ObjectType.image }
   let(:workflow_context) { {} }
   let(:structural) { instance_double(Cocina::Models::DROStructural, contains: [first_fileset, second_fileset]) }
-  let(:first_fileset) { instance_double(Cocina::Models::FileSet, type: 'https://cocina.sul.stanford.edu/models/resources/document', structural: first_fileset_structural) }
-  let(:second_fileset) { instance_double(Cocina::Models::FileSet, type: 'https://cocina.sul.stanford.edu/models/resources/image', structural: second_fileset_structural) }
+  let(:first_fileset) { instance_double(Cocina::Models::FileSet, type: first_fileset_type, structural: first_fileset_structural) }
+  let(:second_fileset) { instance_double(Cocina::Models::FileSet, type: second_fileset_type, structural: second_fileset_structural) }
+  let(:first_fileset_type) { Cocina::Models::FileSetType.document }
+  let(:second_fileset_type) { Cocina::Models::FileSetType.image }
   let(:first_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [pdf_file]) }
   let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [jpg_file, tif_file, text_file]) }
   let(:pdf_file) { build_file('file1.pdf') }
@@ -17,13 +22,12 @@ RSpec.describe Dor::TextExtraction::Ocr do
   let(:tif_file) { build_file('file2.tif') }
   let(:text_file) { build_file('file3.txt') }
   let(:xml_file) { build_file('file2.xml', corrected: true) }
-  let(:druid) { 'druid:bc123df4567' }
 
   before { allow(ocr).to receive(:sleep) } # effectively make the sleep a no-op so that the test doesn't take so long due to retries and backoff
 
   describe '#possible?' do
     context 'when the object is not a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::Collection, externalIdentifier: druid, dro?: false, type: object_type) }
+      let(:is_dro) { false }
 
       it 'returns false' do
         expect(ocr.possible?).to be false
@@ -31,10 +35,8 @@ RSpec.describe Dor::TextExtraction::Ocr do
     end
 
     context 'when the object is a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, type: object_type, structural:) }
-
       context 'when the object type is one that does not require OCR' do
-        let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+        let(:object_type) { Cocina::Models::ObjectType.media }
 
         it 'returns false' do
           expect(ocr.possible?).to be false
@@ -61,8 +63,6 @@ RSpec.describe Dor::TextExtraction::Ocr do
   end
 
   describe '#required?' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, type: object_type) }
-
     context 'when workflow context includes runOCR as true' do
       let(:workflow_context) { { 'runOCR' => true } }
 
@@ -89,8 +89,6 @@ RSpec.describe Dor::TextExtraction::Ocr do
   end
 
   describe '#filenames_to_ocr' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural:, type: object_type) }
-
     it 'returns a list of filenames that should be OCRed, preferring tif over jpeg' do
       expect(ocr.filenames_to_ocr).to eq(['file2.tif'])
     end
@@ -112,6 +110,7 @@ RSpec.describe Dor::TextExtraction::Ocr do
     end
 
     context 'when an OCR file exists with the same stem name, marked correctedForAccessibility, but is in a different resource' do
+      let(:first_fileset_type) { Cocina::Models::FileSetType.image }
       let(:first_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [jpg_file]) }
       let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [tif_file, xml_file]) }
 
@@ -131,15 +130,48 @@ RSpec.describe Dor::TextExtraction::Ocr do
   end
 
   describe '#ocr_files' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural:, type: Cocina::Models::ObjectType.document) }
+    let(:object_type) { Cocina::Models::ObjectType.document }
 
     it 'returns a list of all filenames' do
       expect(ocr.send(:ocr_files)).to eq([pdf_file])
     end
   end
 
+  describe '#acceptable_file?' do
+    context 'when file is preserved, shelved, and has an allowed mimetype' do
+      let(:file) { build_file('file1.tif') }
+
+      it 'returns true' do
+        expect(ocr.send(:acceptable_file?, file)).to be true
+      end
+    end
+
+    context 'when file is not preserved' do
+      let(:file) { build_file('file1.tif', preserve: false) }
+
+      it 'returns false' do
+        expect(ocr.send(:acceptable_file?, file)).to be false
+      end
+    end
+
+    context 'when file is not shelved' do
+      let(:file) { build_file('file1.tif', shelve: false) }
+
+      it 'returns false' do
+        expect(ocr.send(:acceptable_file?, file)).to be false
+      end
+    end
+
+    context 'when file has a disallowed mimetype for OCR' do
+      let(:file) { build_file('file1.txt') }
+
+      it 'returns false' do
+        expect(ocr.send(:acceptable_file?, file)).to be false
+      end
+    end
+  end
+
   describe '#cleanup' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, type: object_type, structural:) }
     let(:result_path) { File.join(Settings.sdr.abbyy.local_result_path, "#{druid}.xml.result.xml") }
     let(:abbyy_exception_file) { File.join(Settings.sdr.abbyy.local_exception_path, "#{druid}.xml.result.xml") }
 

--- a/spec/lib/dor/text_extraction/speech_to_text_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_spec.rb
@@ -4,12 +4,17 @@ require 'spec_helper'
 
 RSpec.describe Dor::TextExtraction::SpeechToText do
   let(:stt) { described_class.new(cocina_object:, workflow_context:) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+  let(:druid) { 'druid:bc123df4567' }
+  let(:bare_druid) { 'bc123df4567' }
+  let(:cocina_object) { instance_double(Cocina::Models::DRO, version:, structural:, externalIdentifier: druid, dro?: is_dro, type: object_type) }
+  let(:is_dro) { true }
+  let(:version) { 1 }
+  let(:object_type) { Cocina::Models::ObjectType.media }
   let(:workflow_context) { {} }
   let(:structural) { instance_double(Cocina::Models::DROStructural, contains: [first_fileset, second_fileset, third_fileset]) }
-  let(:first_fileset) { instance_double(Cocina::Models::FileSet, type: 'https://cocina.sul.stanford.edu/models/resources/audio', structural: first_fileset_structural) }
-  let(:second_fileset) { instance_double(Cocina::Models::FileSet, type: 'https://cocina.sul.stanford.edu/models/resources/video', structural: second_fileset_structural) }
-  let(:third_fileset) { instance_double(Cocina::Models::FileSet, type: 'https://cocina.sul.stanford.edu/models/resources/file', structural: third_fileset_structural) }
+  let(:first_fileset) { instance_double(Cocina::Models::FileSet, type: Cocina::Models::FileSetType.audio, structural: first_fileset_structural) }
+  let(:second_fileset) { instance_double(Cocina::Models::FileSet, type: Cocina::Models::FileSetType.video, structural: second_fileset_structural) }
+  let(:third_fileset) { instance_double(Cocina::Models::FileSet, type: Cocina::Models::FileSetType.file, structural: third_fileset_structural) }
   let(:first_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [m4a_file, text_file]) }
   let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [mp4_file, mp4_file_not_shelved, mp4_file_not_preserved]) }
   let(:third_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [text_file2]) }
@@ -19,12 +24,10 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
   let(:mp4_file_not_preserved) { build_file('file3.mp4', preserve: false) }
   let(:text_file) { build_file('file1.txt') }
   let(:text_file2) { build_file('file2.txt') }
-  let(:druid) { 'druid:bc123df4567' }
-  let(:bare_druid) { 'bc123df4567' }
 
   describe '#possible?' do
     context 'when the object is not a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::Collection, externalIdentifier: druid, dro?: false, type: object_type) }
+      let(:is_dro) { false }
 
       it 'returns false' do
         expect(stt.possible?).to be false
@@ -32,10 +35,8 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
     end
 
     context 'when the object is a DRO' do
-      let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, type: object_type, structural:) }
-
       context 'when the object type is one that does not require STT' do
-        let(:object_type) { 'https://cocina.sul.stanford.edu/models/document' }
+        let(:object_type) { Cocina::Models::ObjectType.document }
 
         it 'returns false' do
           expect(stt.possible?).to be false
@@ -62,8 +63,6 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
   end
 
   describe '#required?' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, type: object_type) }
-
     context 'when workflow context includes runSpeechToText as true' do
       let(:workflow_context) { { 'runSpeechToText' => true } }
 
@@ -90,7 +89,6 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
   end
 
   describe '#cleanup' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, type: object_type, version:) }
     let(:client) { instance_double(Aws::S3::Client, list_objects:) }
     let(:list_objects) { instance_double(Aws::S3::Types::ListObjectsOutput, contents: [m4a_object, mp4_object]) }
     let(:m4a_object) { instance_double(Aws::S3::Types::Object, key: "#{bare_druid}-v#{version}/file1.m4a") }
@@ -110,8 +108,6 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
   end
 
   describe '#filenames_to_stt' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural:, type: object_type) }
-
     it 'returns a list of filenames that should be STTed, ignoring those not in preservation or shelved' do
       expect(stt.send(:filenames_to_stt)).to eq(['file1.m4a', 'file1.mp4'])
     end
@@ -136,15 +132,46 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
   end
 
   describe '#stt_files' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, structural:, type: object_type) }
-
     it 'returns a list of all filenames' do
       expect(stt.send(:stt_files)).to eq([m4a_file, mp4_file])
     end
   end
 
+  describe '#acceptable_file?' do
+    context 'when file is preserved, shelved, and has an allowed mimetype' do
+      let(:file) { build_file('file1.mp4') }
+
+      it 'returns true' do
+        expect(stt.send(:acceptable_file?, file)).to be true
+      end
+    end
+
+    context 'when file is not preserved' do
+      let(:file) { build_file('file1.mp4', preserve: false) }
+
+      it 'returns false' do
+        expect(stt.send(:acceptable_file?, file)).to be false
+      end
+    end
+
+    context 'when file is not shelved' do
+      let(:file) { build_file('file1.mp4', shelve: false) }
+
+      it 'returns false' do
+        expect(stt.send(:acceptable_file?, file)).to be false
+      end
+    end
+
+    context 'when file has a disallowed mimetype for speech to text' do
+      let(:file) { build_file('file1.txt') }
+
+      it 'returns false' do
+        expect(stt.send(:acceptable_file?, file)).to be false
+      end
+    end
+  end
+
   describe '#s3_location' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, version:, externalIdentifier: druid, dro?: true, type: object_type) }
     let(:version) { 3 }
 
     it 'returns the s3 filename key for a given filename' do
@@ -153,7 +180,6 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
   end
 
   describe '#job_id' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, version:, externalIdentifier: druid, dro?: true, type: object_type) }
     let(:version) { 3 }
 
     it 'returns the job_id for the STT job' do
@@ -162,7 +188,6 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
   end
 
   describe '#output_location' do
-    let(:cocina_object) { instance_double(Cocina::Models::DRO, version:, externalIdentifier: druid, dro?: true, type: object_type) }
     let(:version) { 3 }
 
     it 'returns the output_location for the STT job' do

--- a/spec/lib/dor/text_extraction/speech_to_text_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_spec.rb
@@ -121,11 +121,20 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
       end
     end
 
-    context 'when an OCR file exists and is NOT marked correctedForAccessibility' do
-      let(:vtt_file) { build_file('file1.vtt', corrected: false) }
+    context 'when an OCR file exists and is NOT marked correctedForAccessibility and is also NOT sdrGenerated' do
+      let(:vtt_file) { build_file('file1.vtt', corrected: false, sdr_generated: false) }
       let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [mp4_file, vtt_file]) }
 
-      it 'returns the mp4 file which has a corresponding vtt file which has not been corrected for accessibility' do
+      it 'ignores the mp4 file which has a corresponding vtt file which has not been corrected for accessibility but was also not sdr generated' do
+        expect(stt.send(:filenames_to_stt)).to eq(['file1.m4a'])
+      end
+    end
+
+    context 'when an OCR file exists and is NOT marked correctedForAccessibility but is sdrGenerated' do
+      let(:vtt_file) { build_file('file1.vtt', corrected: false, sdr_generated: true) }
+      let(:second_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [mp4_file, vtt_file]) }
+
+      it 'returns the both the m4a and mp4 file which has a corresponding vtt file which has not been corrected for accessibility but is sdr generated' do
         expect(stt.send(:filenames_to_stt)).to eq(['file1.m4a', 'file1.mp4'])
       end
     end

--- a/spec/robots/dor_repo/assembly/checksum_compute_spec.rb
+++ b/spec/robots/dor_repo/assembly/checksum_compute_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe Robots::DorRepo::Assembly::ChecksumCompute do
     let(:cocina_object) { build(:dro, id: druid).new(structural:) }
 
     let(:structural) do
-      { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+      { contains: [{ type: Cocina::Models::FileSetType.image,
                      externalIdentifier: 'bb222cc3333_1',
                      label: 'Image 1',
                      version: 1,
@@ -60,7 +60,7 @@ RSpec.describe Robots::DorRepo::Assembly::ChecksumCompute do
                                                 hasMessageDigests: [{ type: 'md5', digest: '42616f9e6c1b7e7b7a71b4fa0c5ef794' }],
                                                 access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                 administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                   { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                   { type: Cocina::Models::FileSetType.image,
                      externalIdentifier: 'bb222cc3333_2',
                      label: 'Image 2',
                      version: 1,
@@ -74,7 +74,7 @@ RSpec.describe Robots::DorRepo::Assembly::ChecksumCompute do
                                                                     { type: 'md5', digest: 'ac440802bd590ce0899dafecc5a5ab1b' }],
                                                 access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                 administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                   { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                   { type: Cocina::Models::FileSetType.image,
                      externalIdentifier: 'bb222cc3333_3',
                      label: 'Image 3',
                      version: 1,
@@ -88,7 +88,7 @@ RSpec.describe Robots::DorRepo::Assembly::ChecksumCompute do
                                                 access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                 administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
                    # This file does not exist in the workspace.
-                   { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                   { type: Cocina::Models::FileSetType.image,
                      externalIdentifier: 'bb222cc3333_4',
                      label: 'Image 4',
                      version: 1,

--- a/spec/robots/dor_repo/assembly/exif_collect_spec.rb
+++ b/spec/robots/dor_repo/assembly/exif_collect_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
 
     context 'when there are no existing mimetypes and filesizes in file nodes' do
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 1',
                        version: 1,
@@ -75,7 +75,7 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
                                                   hasMessageDigests: [{ type: 'md5', digest: '42616f9e6c1b7e7b7a71b4fa0c5ef794' }],
                                                   access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                   administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                     { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                     { type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_2',
                        label: 'Image 2',
                        version: 1,
@@ -89,7 +89,7 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
                                                                       { type: 'md5', digest: 'ac440802bd590ce0899dafecc5a5ab1b' }],
                                                   access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                                   administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                     { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                     { type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_3',
                        label: 'Image 3',
                        version: 1,
@@ -132,7 +132,7 @@ RSpec.describe Robots::DorRepo::Assembly::ExifCollect do
 
     context 'when there are existing mimetypes and filesizes in file nodes' do
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'cc333dd4444_1',
                        label: 'Image 1',
                        version: 1,

--- a/spec/robots/dor_repo/assembly/jp2_create_spec.rb
+++ b/spec/robots/dor_repo/assembly/jp2_create_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
   let(:cocina_model) { build(:dro, id: druid).new(structural:, access:) }
 
   let(:structural) do
-    { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+    { contains: [{ type: Cocina::Models::FileSetType.image,
                    externalIdentifier: 'bb111bb2222_1',
                    label: 'Image 1',
                    version: 1,
@@ -26,7 +26,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
                                               hasMessageDigests: [{ type: 'md5', digest: '42616f9e6c1b7e7b7a71b4fa0c5ef794' }],
                                               access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                               administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                 { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                 { type: Cocina::Models::FileSetType.image,
                    externalIdentifier: 'bb111bb2222_2',
                    label: 'Image 2',
                    version: 1,
@@ -41,7 +41,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
                                                                   { type: 'md5', digest: 'ac440802bd590ce0899dafecc5a5ab1b' }],
                                               access: { view: 'dark', download: 'none', controlledDigitalLending: false },
                                               administrative: { publish: false, sdrPreserve: true, shelve: false } }] } },
-                 { type: 'https://cocina.sul.stanford.edu/models/resources/image',
+                 { type: Cocina::Models::FileSetType.image,
                    externalIdentifier: 'bb111bb2222_3',
                    label: 'Image 3',
                    version: 1,
@@ -129,7 +129,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
     context 'with a fileset that is not page or image' do
       let(:structural) do
         # This is an audio fileset (but contains an image for testing)
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/audio',
+        { contains: [{ type: Cocina::Models::FileSetType.audio,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 1',
                        version: 1,
@@ -155,7 +155,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
 
     context 'with a file that has an existing mimetype that is not an image' do
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/page',
+        { contains: [{ type: Cocina::Models::FileSetType.page,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Doc 1',
                        version: 1,
@@ -183,7 +183,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
 
     context 'with a file that does not have an existing mimetype and is not an image' do
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/page',
+        { contains: [{ type: Cocina::Models::FileSetType.page,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Doc 1',
                        version: 1,
@@ -211,7 +211,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
 
     context 'when the image file does not exist and there is a jp2 cocina file and jp2 file' do
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 4',
                        version: 1,
@@ -250,7 +250,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       let(:jp2_filepath) { "#{TMP_ROOT_DIR}/ff/222/cc/3333/image112.jp2" }
 
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 2',
                        version: 1,
@@ -286,7 +286,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
 
     context 'when the image file exists and there is a jp2 cocina file' do
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 1',
                        version: 1,
@@ -316,7 +316,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
 
       it 'replaces the jp2 cocina file and creates a jp2 file' do
         expect(file_sets).to eq(
-          [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          [{ type: Cocina::Models::FileSetType.image,
              externalIdentifier: 'bb111bb2222_1',
              label: 'Image 1',
              version: 1,
@@ -349,7 +349,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       let(:jp2_filepath) { "#{TMP_ROOT_DIR}/ff/222/cc/3333/image112.jp2" }
 
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 2',
                        version: 1,
@@ -370,7 +370,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       it 'creates a jp2 cocina file' do
         expect(File.exist?("#{TMP_ROOT_DIR}/ff/222/cc/3333/image112.jp2")).to be true
         expect(file_sets).to eq(
-          [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          [{ type: Cocina::Models::FileSetType.image,
              externalIdentifier: 'bb111bb2222_1',
              label: 'Image 2',
              version: 1,
@@ -404,7 +404,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       let(:jp2_filepath) { "#{TMP_ROOT_DIR}/ff/222/cc/3333/sub/image113.jp2" }
 
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 3',
                        version: 1,
@@ -425,7 +425,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
       it 'adds the jp2 cocina file' do
         expect(File.exist?("#{TMP_ROOT_DIR}/ff/222/cc/3333/sub/image113.jp2")).to be true
         expect(file_sets).to eq(
-          [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          [{ type: Cocina::Models::FileSetType.image,
              externalIdentifier: 'bb111bb2222_1',
              label: 'Image 3',
              version: 1,
@@ -457,7 +457,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
     context 'when the image file does not exist and there is no jp2 file' do
       let(:image_filepath) { "#{TMP_ROOT_DIR}/ff/222/cc/3333/image114.tif" }
       let(:structural) do
-        { contains: [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+        { contains: [{ type: Cocina::Models::FileSetType.image,
                        externalIdentifier: 'bb111bb2222_1',
                        label: 'Image 4',
                        version: 1,
@@ -488,7 +488,7 @@ RSpec.describe Robots::DorRepo::Assembly::Jp2Create do
 
       it 'retrieves the file from preservation and creates a jp2' do
         expect(file_sets).to eq(
-          [{ type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          [{ type: Cocina::Models::FileSetType.image,
              externalIdentifier: 'bb111bb2222_1',
              label: 'Image 4',
              version: 1,

--- a/spec/robots/dor_repo/ocr/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/ocr/fetch_files_spec.rb
@@ -9,7 +9,7 @@ describe Robots::DorRepo::Ocr::FetchFiles do
   let(:robot) { described_class.new }
   let(:ocr) { instance_double(Dor::TextExtraction::Ocr, abbyy_input_path:, filenames_to_ocr: ['file1.txt', 'file2.pdf']) }
   let(:cocina_model) { build(:dro, id: druid).new(structural: {}, type: object_type, access: { view: 'world' }) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+  let(:object_type) { Cocina::Models::ObjectType.image }
   let(:file_fetcher) { instance_double(Dor::TextExtraction::FileFetcher, write_file_with_retries: written) }
   let(:dsa_object_client) do
     instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)

--- a/spec/robots/dor_repo/ocr/update_cocina_spec.rb
+++ b/spec/robots/dor_repo/ocr/update_cocina_spec.rb
@@ -21,12 +21,12 @@ describe Robots::DorRepo::Ocr::UpdateCocina do
 
   # set up a Cocina object with one image in it
   let(:cocina_model) { build(:dro, id: druid).new(structural:, type: object_type) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+  let(:object_type) { Cocina::Models::ObjectType.image }
   let(:structural) do
     {
       contains: [
         {
-          type: 'https://cocina.sul.stanford.edu/models/resources/image',
+          type: Cocina::Models::FileSetType.image,
           externalIdentifier: "#{bare_druid}_1",
           label: 'Image 1',
           version: 1,

--- a/spec/robots/dor_repo/ocr/xml_ticket_create_spec.rb
+++ b/spec/robots/dor_repo/ocr/xml_ticket_create_spec.rb
@@ -15,7 +15,7 @@ describe Robots::DorRepo::Ocr::XmlTicketCreate do
     instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)
   end
   let(:cocina_model) { build(:dro, id: druid).new(structural: {}, type: object_type, access: { view: 'world' }) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/image' }
+  let(:object_type) { Cocina::Models::ObjectType.image }
   let(:workflow_context) { { runOCR: true } }
   let(:workflow) { instance_double(LyberCore::Workflow, context: workflow_context) }
   let(:fixture_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{bare_druid}_abbyy_ticket.xml") }

--- a/spec/robots/dor_repo/speech_to_text/fetch_files_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/fetch_files_spec.rb
@@ -11,7 +11,7 @@ describe Robots::DorRepo::SpeechToText::FetchFiles do
   let(:file_fetcher) { instance_double(Dor::TextExtraction::FileFetcher, write_file_with_retries: written) }
   let(:stt) { instance_double(Dor::TextExtraction::SpeechToText, job_id:, filenames_to_stt: ['file1.mov', 'file2.mp3']) }
   let(:cocina_model) { build(:dro, id: druid).new(structural: {}, type: object_type, access: { view: 'world' }) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+  let(:object_type) { Cocina::Models::ObjectType.media }
   let(:dsa_object_client) do
     instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)
   end

--- a/spec/robots/dor_repo/speech_to_text/stage_files_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/stage_files_spec.rb
@@ -13,7 +13,7 @@ describe Robots::DorRepo::SpeechToText::StageFiles do
   let(:structural) { instance_double(Cocina::Models::DROStructural, contains: [fileset]) }
   let(:fileset) { instance_double(Cocina::Models::FileSet, type: 'https://cocina.sul.stanford.edu/models/resources/audio', structural: fileset_structural) }
   let(:fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [m4a_file]) }
-  let(:m4a_file) { build_file(true, true, 'file1.m4a') }
+  let(:m4a_file) { build_file('file1.m4a') }
   let(:fake_workspace_path) { 'tmp/fake/workspace' }
   let(:workspace_client) do
     instance_double(Dor::Services::Client::Workspace, create: fake_workspace_path)

--- a/spec/robots/dor_repo/speech_to_text/stage_files_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/stage_files_spec.rb
@@ -9,9 +9,9 @@ describe Robots::DorRepo::SpeechToText::StageFiles do
   let(:version) { 1 }
   let(:robot) { described_class.new }
   let(:cocina_object) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, type: object_type, structural:) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+  let(:object_type) { Cocina::Models::ObjectType.media }
   let(:structural) { instance_double(Cocina::Models::DROStructural, contains: [fileset]) }
-  let(:fileset) { instance_double(Cocina::Models::FileSet, type: 'https://cocina.sul.stanford.edu/models/resources/audio', structural: fileset_structural) }
+  let(:fileset) { instance_double(Cocina::Models::FileSet, type: Cocina::Models::FileSetType.audio, structural: fileset_structural) }
   let(:fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [m4a_file]) }
   let(:m4a_file) { build_file('file1.m4a') }
   let(:fake_workspace_path) { 'tmp/fake/workspace' }

--- a/spec/robots/dor_repo/speech_to_text/stt_create_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/stt_create_spec.rb
@@ -12,7 +12,7 @@ describe Robots::DorRepo::SpeechToText::SttCreate do
   let(:aws_s3_client) { instance_double(Aws::S3::Client) }
   let(:stt) { instance_double(Dor::TextExtraction::SpeechToText, job_id:, filenames_to_stt: ['file1.mov', 'file2.mp3']) }
   let(:cocina_model) { build(:dro, id: druid).new(structural: {}, type: object_type, access: { view: 'world' }) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+  let(:object_type) { Cocina::Models::ObjectType.media }
   let(:dsa_object_client) do
     instance_double(Dor::Services::Client::Object, find: cocina_model, update: true)
   end

--- a/spec/robots/dor_repo/speech_to_text/update_cocina_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/update_cocina_spec.rb
@@ -20,12 +20,12 @@ describe Robots::DorRepo::SpeechToText::UpdateCocina do
 
   # set up a Cocina object with one audio file in it
   let(:cocina_model) { build(:dro, id: druid).new(structural:, type: object_type) }
-  let(:object_type) { 'https://cocina.sul.stanford.edu/models/media' }
+  let(:object_type) { Cocina::Models::ObjectType.media }
   let(:structural) do
     {
       contains: [
         {
-          type: 'https://cocina.sul.stanford.edu/models/resources/file',
+          type: Cocina::Models::FileSetType.file,
           externalIdentifier: "#{bare_druid}_1",
           label: 'Audio 1',
           version: 1,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,7 @@ end
 def build_file(filename, preserve: true, shelve: true, corrected: false)
   extension = File.extname(filename)
   mimetype = { '.pdf' => 'application/pdf', '.tif' => 'image/tiff', '.jpg' => 'image/jpeg', '.txt' => 'text/plain',
-               '.m4a' => 'audio/mp4', '.mp4' => 'video/mp4', '.vtt' => 'text/vtt' }
+               '.m4a' => 'audio/mp4', '.mp4' => 'video/mp4', '.vtt' => 'text/vtt', '.xml' => 'application/xml' }
   sdr_value = instance_double(Cocina::Models::FileAdministrative, sdrPreserve: preserve, shelve:)
   instance_double(Cocina::Models::File, administrative: sdr_value, hasMimeType: mimetype[extension], filename:, correctedForAccessibility: corrected)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,10 +40,11 @@ def clone_test_input(destination)
   system "rsync -rqOlt --delete #{source}/ #{destination}/"
 end
 
-def build_file(filename, preserve: true, shelve: true, corrected: false)
+def build_file(filename, preserve: true, shelve: true, corrected: false, sdr_generated: false)
   extension = File.extname(filename)
   mimetype = { '.pdf' => 'application/pdf', '.tif' => 'image/tiff', '.jpg' => 'image/jpeg', '.txt' => 'text/plain',
                '.m4a' => 'audio/mp4', '.mp4' => 'video/mp4', '.vtt' => 'text/vtt', '.xml' => 'application/xml' }
   sdr_value = instance_double(Cocina::Models::FileAdministrative, sdrPreserve: preserve, shelve:)
-  instance_double(Cocina::Models::File, administrative: sdr_value, hasMimeType: mimetype[extension], filename:, correctedForAccessibility: corrected)
+  instance_double(Cocina::Models::File, administrative: sdr_value, hasMimeType: mimetype[extension],
+                                        filename:, correctedForAccessibility: corrected, sdrGeneratedText: sdr_generated)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,9 +40,10 @@ def clone_test_input(destination)
   system "rsync -rqOlt --delete #{source}/ #{destination}/"
 end
 
-def build_file(sdr_preserve, shelve, filename)
+def build_file(filename, preserve: true, shelve: true, corrected: false)
   extension = File.extname(filename)
-  mimetype = { '.m4a' => 'audio/mp4', '.mp4' => 'video/mp4', '.txt' => 'text/plain' }
-  sdr_value = instance_double(Cocina::Models::FileAdministrative, sdrPreserve: sdr_preserve, shelve:)
-  instance_double(Cocina::Models::File, administrative: sdr_value, hasMimeType: mimetype[extension], filename:)
+  mimetype = { '.pdf' => 'application/pdf', '.tif' => 'image/tiff', '.jpg' => 'image/jpeg', '.txt' => 'text/plain',
+               '.m4a' => 'audio/mp4', '.mp4' => 'video/mp4', '.vtt' => 'text/vtt' }
+  sdr_value = instance_double(Cocina::Models::FileAdministrative, sdrPreserve: preserve, shelve:)
+  instance_double(Cocina::Models::File, administrative: sdr_value, hasMimeType: mimetype[extension], filename:, correctedForAccessibility: corrected)
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1403 and fixes #1404

Do not send files that will not be OCRed or captioned off to the service (i.e. ignore things that are marked as correctedForAccessibility OR were not sdr generated)

Question: should we look at the role instead of the extension? 

Also: refactor the tests and code to use cocina model constants instead of strings, e.g. `Cocina::Models::FileSetType.image` instead of `https://cocina.sul.stanford.edu/models/resources/image` and similar for object types

I tried to make the logic match what is used at the end in cocina-updater, which is ignoring a file if there is a corresponding caption/ocr file that is (1) marked as "correctedForAccessibility" OR (2) NOT "sdrGenerated".  The logic is we are only overwriting caption/ocr files in the case they were both sdrGenerated and not correctedForAccessibility.

This PR is looking for matching files of type .XML (for OCR) or .VTT (for speech to text) within a resource.  So if a resource has a "some_cool_movie.mp4", I would look for "some_cool_movie.vtt" and check the attributes on that file.  And for OCR, it would be "some_cool_image.tif" and looking for "some_cool_image.xml".  We could also check the role attribute on the OCR/caption file (e.g. looking for "transcription" or "caption") instead of relying on filename extensions, but not doing that in the PR.

HOLD for PO verification

## How was this change tested? 🤨

Spec
Integration test