### PR TITLE
limit retries when SQS watcher picks up job

### DIFF
--- a/bin/speech_to_text_watcher
+++ b/bin/speech_to_text_watcher
@@ -18,7 +18,24 @@ stt_create_done_handler = Dor::TextExtraction::SpeechToTextCreateDoneHandler.new
 
 sqs_watcher = Dor::TextExtraction::SqsWatcher.new(role_arn: Settings.aws.speech_to_text.role_arn,
                                                    queue_url: Settings.aws.speech_to_text.sqs_done_queue_url)
-sqs_watcher.poll do |done_msg|
-  logger.debug("sqs_watcher.poll block received done_msg: #{done_msg}")
-  stt_create_done_handler.process_done_message(done_msg)
+
+# The whole #poll call is wrapped in this signal trapping begin/rescue, because
+# the handler block passed to #poll can only trap exceptions from within that
+# handler block.  But interrupts and signals may bubble up from #poll, not the
+# handler block passed to #poll.
+begin
+  # will poll indefinitely, until a signal or interrupt is received, or until an
+  # unhandled exception bubbles up.
+  sqs_watcher.poll do |done_msg|
+    logger.debug("sqs_watcher.poll block received done_msg: #{done_msg}")
+    stt_create_done_handler.process_done_message(done_msg)
+  end
+rescue SignalException, Interrupt => e
+  logger.info("Received signal or interrupt, exiting #{progname}")
+  logger.debug("signal or interrupt received by #{progname}: #{e} -- #{e.message} -- #{e.backtrace}")
+  exit 0
+rescue StandardError => e
+  logger.fatal("#{e} -- #{e.message} -- #{e.backtrace}")
+  Honeybadger.notify(e)
+  exit Errno::ENOMSG::Errno # cause is unknown/unexpected, hence the generic error
 end

--- a/bin/speech_to_text_watcher
+++ b/bin/speech_to_text_watcher
@@ -9,7 +9,9 @@ require_relative '../config/boot'
 
 # Set log level with LOG_LEVEL; share the logger across the stack
 progname = 'speech_to_text_watcher'
-logger = Logger.new(STDOUT, progname:, level: ENV['LOG_LEVEL'] || 'INFO')
+stdout_logger = Logger.new(STDOUT, progname:, level: ENV['LOG_LEVEL'] || 'INFO')
+file_logger = Logger.new("log/#{progname}.log", progname:, level: ENV['LOG_LEVEL'] || 'INFO')
+logger = ActiveSupport::BroadcastLogger.new(stdout_logger, file_logger)
 host = Socket.gethostname
 stt_create_done_handler = Dor::TextExtraction::SpeechToTextCreateDoneHandler.new(host:, progname:, logger:)
 

--- a/lib/dor/text_extraction/sqs_watcher.rb
+++ b/lib/dor/text_extraction/sqs_watcher.rb
@@ -5,28 +5,23 @@ module Dor
     # Watch an SQS queue for messages by long polling, allowing the consumer
     # of this class to specify the queue name and the processing logic.
     class SqsWatcher
-      attr_reader :logger, :queue_url, :role_arn, :visibility_timeout
+      attr_reader :logger, :queue_url, :role_arn, :visibility_timeout, :max_attempts
 
-      def initialize(queue_url:, role_arn: nil, logger: Logger.new($stdout), visibility_timeout: nil)
+      def initialize(queue_url:, role_arn: nil, logger: Logger.new($stdout), visibility_timeout: nil, max_attempts: nil)
         @queue_url = queue_url
         @role_arn = role_arn
         @logger = logger
         @visibility_timeout = visibility_timeout || default_visibility_timeout
+        @max_attempts = max_attempts || default_max_attempts
       end
 
+      # @yieldparam [Aws::SQS::Types::Message] an SQS message to be processed
       def poll
         logger.info("Starting indefinite long polling of #{queue_url}")
         poller.poll(visibility_timeout:) do |sqs_msg|
           yield sqs_msg
         rescue StandardError => e
-          # unexpected error occurred while processing message.
-          # log it, and skip delete so it can be re-processed later.
-          context = { sqs_msg:, error: e }
-          Honeybadger.notify('Error processing SQS message, skipping deletion to allow requeue', context:)
-          logger.error("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}")
-
-          # without this throw, the message would be deleted upon completion of the block, preventing retry
-          throw :skip_delete # TODO: use msg[:attributes]['ApproximateReceiveCount'] to stop retrying above a certain threshold?
+          handle_sqs_message_processing_error(sqs_msg:, error: e)
         end
       end
 
@@ -39,8 +34,27 @@ module Dor
         end
       end
 
+      def handle_sqs_message_processing_error(sqs_msg:, error:)
+        context = { sqs_msg:, error: }
+
+        if sqs_msg[:attributes]['ApproximateReceiveCount'].to_i <= max_attempts
+          logger.warn("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}")
+          Honeybadger.notify('Error processing SQS message, skipping deletion to allow requeue', context:)
+
+          # without this throw, the message would be deleted upon completion of the block, preventing retry
+          throw :skip_delete
+        else
+          logger.error("Max retries exceeded for message, message will be deleted from queue! Context: #{context}")
+          Honeybadger.notify('Max retries exceeded for message, message will be deleted from queue!', context:)
+        end
+      end
+
       def default_visibility_timeout
         120 # pick a reasonable default time by which the job should complete successfully, or allow the message to be requeued for retry
+      end
+
+      def default_max_attempts
+        3
       end
 
       def aws_provider

--- a/spec/lib/dor/text_extraction/sqs_watcher_spec.rb
+++ b/spec/lib/dor/text_extraction/sqs_watcher_spec.rb
@@ -8,7 +8,7 @@ describe Dor::TextExtraction::SqsWatcher do
   let(:access_key_id) { Settings.aws.access_key_id }
   let(:secret_access_key) { Settings.aws.secret_access_key }
   let(:role_arn) { Settings.aws.speech_to_text.role_arn }
-  let(:logger) { instance_double(Logger, info: nil, error: nil) }
+  let(:logger) { instance_double(Logger, info: nil, error: nil, warn: nil) }
   let(:visibility_timeout) { nil }
   let(:aws_provider) { instance_double(Dor::TextExtraction::AwsProvider, sqs: instance_double(Aws::SQS::Client)) }
   let(:aws_provider_opts) do
@@ -31,13 +31,19 @@ describe Dor::TextExtraction::SqsWatcher do
     # NOTE: This is a somewhat unrealistically simplified mocking of QueuePoller#poll,
     # as the real invocation of that method in this codebase should cause it to run indefinitely,
     # polling for messages and invoking its block whenever one is received. But this mock instead
-    # executes the block once.
+    # executes the block once.  Another deviation from the real Aws::SQS::QueuePoller is that our
+    # mocked #poll won't catch a thrown :skip_delete.  Instead of a complex high-fidelity mock,
+    # we go for something simple to make the test obvious, let such throw calls bubble up,
+    # and check for the throw on invocation of #poll.  Basically, trying to avoid subtle bugs in
+    # the test code, to make it more obvious that the test is exercising handler invocation, logging,
+    # and retry behavior in a way that doesn't hide bugs.
     # TODO: there is a ticket for investigating localstack for more realistic testing, see
     # https://github.com/sul-dlss/common-accessioning/issues/1364
     # Though then it will be necessary to somehow kill the poller thread, or provide the
     # option to run for only a limited time (via e.g. idle_timeout option to QueuePoller#poll).
     # Perhaps the infra integration test suite will suffice for realistic regression testing.
     allow(poller).to receive(:poll).and_yield(sqs_msg)
+    allow(sqs_msg).to receive(:[]).with(:attributes).and_return({ 'ApproximateReceiveCount' => '1' })
   end
 
   describe '#poll' do
@@ -78,7 +84,57 @@ describe Dor::TextExtraction::SqsWatcher do
         end
         context = { sqs_msg:, error: handler_error }
         expect(Honeybadger).to have_received(:notify).with('Error processing SQS message, skipping deletion to allow requeue', context:)
-        expect(logger).to have_received(:error).with("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}")
+        expect(logger).to have_received(:warn).with("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}")
+      end
+
+      describe 'retry' do
+        context 'when the operation succeeds before the max number of attempts is exceeded' do
+          before do
+            allow(message_handler).to receive(:process_done_message) do |msg|
+              approx_receive_count = msg[:attributes]['ApproximateReceiveCount'].to_i
+              msg[:attributes]['ApproximateReceiveCount'] = (approx_receive_count + 1).to_s
+              raise handler_error unless approx_receive_count > 2
+            end
+          end
+
+          it 'throws :skip_delete for the attempts that happen before the max number of attempts is reached, and notifies/warns accordingly' do
+            expect { sqs_watcher_poll }.to throw_symbol(:skip_delete)
+            expect { sqs_watcher_poll }.to throw_symbol(:skip_delete)
+            expect { sqs_watcher_poll }.not_to throw_symbol(:skip_delete)
+            context = { sqs_msg:, error: handler_error }
+            expect(logger).to have_received(:warn).with("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}").twice
+            expect(Honeybadger).to have_received(:notify).with('Error processing SQS message, skipping deletion to allow requeue', context:).twice
+            expect(logger).not_to have_received(:error)
+            expect(Honeybadger).not_to have_received(:notify).with(/retries exceeded for message/, context: anything)
+          end
+        end
+
+        context 'when the operation does not succeed before the max number of attempts is exceeded' do
+          before do
+            allow(message_handler).to receive(:process_done_message) do |msg|
+              approx_receive_count = msg[:attributes]['ApproximateReceiveCount'].to_i
+              msg[:attributes]['ApproximateReceiveCount'] = (approx_receive_count + 1).to_s
+              raise handler_error
+            end
+          end
+
+          it 'does not throw :skip_delete on the final attempt, and sends a Honeybadger alert' do
+            # as described above in a comment on Aws::SQS::QueuePoller mocking, we trade
+            # a mock of Aws::SQS::QueuePoller#poll that behaves exactly like the real thing,
+            # for a less complex and more readable test, that hopefully makes it more obvious
+            # that the right throws are happening, and that the right number of attempts to process
+            # an SQS message is made.  the real poller wouldn't have to be invoked multiple times,
+            # because it'd just poll indefinitely for new messages (it'd also catch :skip_delete internally).
+            expect { sqs_watcher_poll }.to throw_symbol(:skip_delete)
+            expect { sqs_watcher_poll }.to throw_symbol(:skip_delete)
+            expect { sqs_watcher_poll }.not_to throw_symbol(:skip_delete)
+            context = { sqs_msg:, error: handler_error }
+            expect(logger).to have_received(:warn).with("Error processing SQS message, skipping deletion to allow requeue. Context: #{context}").twice
+            expect(Honeybadger).to have_received(:notify).with('Error processing SQS message, skipping deletion to allow requeue', context:).twice
+            expect(logger).to have_received(:error).with("Max retries exceeded for message, message will be deleted from queue! Context: #{context}")
+            expect(Honeybadger).to have_received(:notify).with('Max retries exceeded for message, message will be deleted from queue!', context:)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

* fixes #1407
* other quality of life improvements (cleaner exit from watcher script, better logging)

## How was this change tested? 🤨

- [x] unit tests
- [x] run daemon on dev laptop and ctrl+c to exit
- [x] deploy to QA
  - [x] integration test (`spec/features/preassembly_speech_to_text_media_spec.rb` should suffice, since changes here are limited to speech-to-text code)
  - [x] queue a job manually using the speech-to-text container's one-off job creation function, with an identifier that isn't an actual druid.  this will lead to an error when the done message is processed by the watcher script, because there will be no workflow record server to find when trying to update the status.  two more attempts should be made before the job is abandoned.  there should be a log message and a honeybadger alert when the job is abandoned.
    - this worked, see retry HB alert from manual test, and retry exceeded alert from same: https://app.honeybadger.io/projects/52894/faults/114641176 and https://app.honeybadger.io/projects/52894/faults/114641232

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


what exit looked before this PR
```
^C** [Honeybadger] Unable to send error report: API key is missing.
jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/3.2.0/net/protocol.rb:229:in `wait_readable': Interrupt
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/3.2.0/net/protocol.rb:229:in `rbuf_fill'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/3.2.0/net/protocol.rb:199:in `readuntil'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/3.2.0/net/protocol.rb:209:in `readline'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-http-0.5.0/lib/net/http/response.rb:158:in `read_status_line'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-http-0.5.0/lib/net/http/response.rb:147:in `read_new'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-http-0.5.0/lib/net/http.rb:2420:in `block in transport_request'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-http-0.5.0/lib/net/http.rb:2411:in `catch'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-http-0.5.0/lib/net/http.rb:2411:in `transport_request'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/net-http-0.5.0/lib/net/http.rb:2384:in `request'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/connection_pool.rb:348:in `request'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:80:in `block in transmit'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:134:in `block in session'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/connection_pool.rb:106:in `session_for'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:129:in `session'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:77:in `transmit'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:46:in `block in call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:206:in `block in span_wrapper'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/aws-sdk-core/telemetry/no_op.rb:29:in `in_span'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:202:in `span_wrapper'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/net_http/handler.rb:45:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/plugins/content_length.rb:24:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/seahorse/client/plugins/request_callback.rb:118:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/aws-sdk-core/json/error_handler.rb:8:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/aws-sdk-core/plugins/sign.rb:53:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/aws-sdk-core/plugins/transfer_encoding.rb:27:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/aws-sdk-core/plugins/helpful_socket_errors.rb:12:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/aws-sdk-core/plugins/user_agent.rb:69:in `call'
  from jmartin-sul/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/aws-sdk-core-3.212.0/lib/aws-sdk-core/plugins/retry_errors.rb:365:in `block in call'
...lots more...
```

what it looks like after this PR:
```
^CI, [2024-11-14T19:24:06.311182 #36929]  INFO -- speech_to_text_watcher: Received signal or interrupt, exiting speech_to_text_watcher
```