### PR TITLE
Dor::TextExtraction::FileFetcher#write_file_with_retries: Preservation::Client::NotFoundError is also retriable

### DIFF
--- a/lib/dor/text_extraction/file_fetcher.rb
+++ b/lib/dor/text_extraction/file_fetcher.rb
@@ -31,7 +31,7 @@ module Dor
                     else
                       raise "Unknown location type: #{location.class}"
                     end
-        rescue Faraday::ResourceNotFound, Aws::S3::MultipartUploadError
+        rescue Preservation::Client::NotFoundError, Faraday::ResourceNotFound, Aws::S3::MultipartUploadError
           tries += 1
           logger.warn("received NotFoundError from Preservation try ##{tries}")
 

--- a/spec/lib/dor/text_extraction/file_fetcher_spec.rb
+++ b/spec/lib/dor/text_extraction/file_fetcher_spec.rb
@@ -48,7 +48,7 @@ describe Dor::TextExtraction::FileFetcher do
           count = 0
           allow(objects_client).to receive(:content) do |*args|
             count += 1
-            raise Faraday::ResourceNotFound, 'druid not available yet' unless count > 2
+            raise Preservation::Client::NotFoundError, 'druid not available yet' unless count > 2
 
             filepath = args.first.fetch(:filepath)
             args.first.fetch(:on_data).call("Content for: #{filepath}")


### PR DESCRIPTION
## Why was this change made? 🤔

part of https://github.com/sul-dlss/common-accessioning/issues/1420

## How was this change tested? 🤨

- [ ] updated an existing spec to test with the newly added error class
- [ ] deployed to stage and repeatedly run through `spec/features/preassembly_ocr_image_spec.rb` ([an infrastructure-integration-test branch that reverted the workflow step retry on the integration test side](https://github.com/sul-dlss/infrastructure-integration-test/pull/798) failed 6 times in a row on that spec against current common-accessioning `main`; same branch )

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


