### PR TITLE
shelving is not required for ocring

### DIFF
--- a/lib/dor/text_extraction/ocr.rb
+++ b/lib/dor/text_extraction/ocr.rb
@@ -139,7 +139,7 @@ module Dor
         end.compact
       end
 
-      # filter down fileset files that could possibly be OCRed to those that are in preservation and shelved and are of an allowed mimetype
+      # filter down fileset files that could possibly be OCRed to those that are in preservation and are of an allowed mimetype
       # if there is more than one file of the allowed mimetype, grab the preferred type
       def ocr_file(fileset)
         files ||=
@@ -163,9 +163,9 @@ module Dor
         end
       end
 
-      # indicates if the file is preserved, shelved and is of an allowed mimetype
+      # indicates if the file is preserved and is of an allowed mimetype
       def acceptable_file?(file)
-        file.administrative.sdrPreserve && file.administrative.shelve && allowed_mimetypes.include?(file.hasMimeType)
+        file.administrative.sdrPreserve && allowed_mimetypes.include?(file.hasMimeType)
       end
 
       # defines the mimetypes types for which files for which OCR can possibly be run

--- a/spec/lib/dor/text_extraction/ocr_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_spec.rb
@@ -166,8 +166,8 @@ RSpec.describe Dor::TextExtraction::Ocr do
     context 'when file is not shelved' do
       let(:file) { build_file('file1.tif', shelve: false) }
 
-      it 'returns false' do
-        expect(ocr.send(:acceptable_file?, file)).to be false
+      it 'returns true' do
+        expect(ocr.send(:acceptable_file?, file)).to be true
       end
     end
 


### PR DESCRIPTION
## Why was this change made? 🤔

This PR https://github.com/sul-dlss/common-accessioning/pull/1415/files inadventantly added an extra condition for files to be OCRable, which is that they are shelved as well as preserved.  Previously the condition had been that only preserved was required (since we pull them down from preservation for OCRing).  This makes the condition what it was previously.

Related question for a different PR: should I also do this for speech to text?

## How was this change tested? 🤨

Spec

