### PR TITLE
preserve json output file from whisper

### DIFF
--- a/lib/dor/text_extraction/cocina_updater.rb
+++ b/lib/dor/text_extraction/cocina_updater.rb
@@ -183,7 +183,7 @@ module Dor
           file_attributes[:hasMessageDigests] = message_digests(object_file)
           file_attributes[:size] = object_file.filesize
           file_attributes[:access] = access
-          file_attributes[:administrative] = administrative
+          file_attributes[:administrative] = administrative(object_file)
         end
       end
       # rubocop:enable Metrics/MethodLength
@@ -206,7 +206,8 @@ module Dor
         raise 'Override this in a subclass'
       end
 
-      def administrative
+      # you can override this in a subclass to set the administrative attributes conditionally if needed
+      def administrative(_object_file)
         {
           publish: true,
           sdrPreserve: true,

--- a/lib/dor/text_extraction/speech_to_text_cocina_updater.rb
+++ b/lib/dor/text_extraction/speech_to_text_cocina_updater.rb
@@ -6,11 +6,9 @@ module Dor
     class SpeechToTextCocinaUpdater < CocinaUpdater
       private
 
-      # When adding files to the object, we will skip everything except .vtt and .txt files
-      # Note that we will have also .json files in the workspace, but these are only parsed for language tag
-      # to add to cocina and not actually stored in the object itself and will be cleaned up later
+      # When adding files to the object, we will skip everything except .vtt, .txt and .json files
       def include_file?(file)
-        %w[.vtt .txt].any? { |ext| file.basename.to_s.end_with?(ext) }
+        %w[.vtt .txt .json].any? { |ext| file.basename.to_s.end_with?(ext) }
       end
 
       def add_file_to_new_resource(_path)
@@ -25,6 +23,18 @@ module Dor
 
         json = JSON.parse(corresponding_json_file.read)
         json['language']
+      end
+
+      # set the administrative attributes based on the mimetype
+      # all speech to text files are preserved, shelved and published EXCEPT json files, which are only preserved
+      def administrative(object_file)
+        preserve = true
+        publish = shelve = object_file.mimetype != 'application/json'
+        {
+          publish:,
+          sdrPreserve: preserve,
+          shelve:
+        }
       end
 
       # set the use attribute based on the mimetype

--- a/spec/lib/dor/text_extraction/speech_to_text_cocina_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_cocina_updater_spec.rb
@@ -65,11 +65,11 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
       expect(dro.structural.contains.length).to eq 1
     end
 
-    it 'first resource has expected number of files (mp4, txt and vtt) - and skips the json' do
-      expect(resource1_files.length).to be 3
+    it 'first resource has expected number of files (mp4, txt, vtt, json)' do
+      expect(resource1_files.length).to be 4
     end
 
-    it 'first resource still has first file set correctly' do
+    it 'first resource still has video file set correctly' do
       file = resource1_files[0]
       expect(file.label).to eq 'Video 1'
       expect(file.filename).to eq 'file1.mp4'
@@ -78,8 +78,28 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
     end
 
     # rubocop:disable RSpec/ExampleLength
-    it 'first resource has txt file set correctly with language pulled from json' do
+    it 'first resource has json file set correctly with shelve and publish as false' do
       file = resource1_files[1]
+      expect(file.label).to eq 'file1.json'
+      expect(file.filename).to eq 'file1.json'
+      expect(file.use).to be_nil
+      expect(file.sdrGeneratedText).to be true
+      expect(file.correctedForAccessibility).to be false
+      expect(file.access.view).to be 'world'
+      expect(file.access.download).to be 'world'
+      expect(file.administrative.publish).to be false
+      expect(file.administrative.sdrPreserve).to be true
+      expect(file.administrative.shelve).to be false
+      expect(file.hasMimeType).to eq 'application/json'
+      expect(file.hasMessageDigests[0].type).to eq 'md5'
+      expect(file.hasMessageDigests[0].digest).to eq '8b43304039be0e1cc7be600cf77818bb'
+      expect(file.hasMessageDigests[1].type).to eq 'sha1'
+      expect(file.hasMessageDigests[1].digest).to eq '0cc8fa02921cac04613ff6c4dae56f4f8ae183af'
+      expect(file.languageTag).to eq 'es'
+    end
+
+    it 'first resource has txt file set correctly with language pulled from json and shelve and publish as true' do
+      file = resource1_files[2]
       expect(file.label).to eq 'file1.txt'
       expect(file.filename).to eq 'file1.txt'
       expect(file.use).to eq 'transcription'
@@ -98,8 +118,8 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
       expect(file.languageTag).to eq 'es'
     end
 
-    it 'first resource has vtt file set correctly with language pulled from json' do
-      file = resource1_files[2]
+    it 'first resource has vtt file set correctly with language pulled from json and shelve and publish as true' do
+      file = resource1_files[3]
       expect(file.label).to eq 'file1.vtt'
       expect(file.filename).to eq 'file1.vtt'
       expect(file.use).to eq 'caption'

--- a/spec/robots/dor_repo/speech_to_text/update_cocina_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/update_cocina_spec.rb
@@ -62,9 +62,12 @@ describe Robots::DorRepo::SpeechToText::UpdateCocina do
 
     it 'runs the update cocina robot and sets the caption role' do
       new_cocina = test_perform(robot, druid)
-      new_file = new_cocina.structural.contains[0].structural.contains[1]
-      expect(new_file.filename).to eq 'file1.vtt'
-      expect(new_file.use).to eq 'caption'
+      new_json_file = new_cocina.structural.contains[0].structural.contains[1]
+      new_vtt_file = new_cocina.structural.contains[0].structural.contains[2]
+      expect(new_json_file.filename).to eq 'file1.json'
+      expect(new_json_file.use).to be_nil
+      expect(new_vtt_file.filename).to eq 'file1.vtt'
+      expect(new_vtt_file.use).to eq 'caption'
     end
   end
 
@@ -77,9 +80,12 @@ describe Robots::DorRepo::SpeechToText::UpdateCocina do
 
     it 'runs the update cocina robot and sets the transcription role' do
       new_cocina = test_perform(robot, druid)
-      new_file = new_cocina.structural.contains[0].structural.contains[1]
-      expect(new_file.filename).to eq 'file1.txt'
-      expect(new_file.use).to eq 'transcription'
+      new_json_file = new_cocina.structural.contains[0].structural.contains[1]
+      new_txt_file = new_cocina.structural.contains[0].structural.contains[2]
+      expect(new_json_file.filename).to eq 'file1.json'
+      expect(new_json_file.use).to be_nil
+      expect(new_txt_file.filename).to eq 'file1.txt'
+      expect(new_txt_file.use).to eq 'transcription'
     end
   end
 


### PR DESCRIPTION
## Why was this change made? 🤔

Preserve json files coming from whisper

Example integration test object: https://argo-qa.stanford.edu/view/druid:ys412hp1997

Updated integration test to go with this: https://github.com/sul-dlss/infrastructure-integration-test/pull/801

closes #1430 

## How was this change tested? 🤨

Updated specs
integration test