### PR TITLE
manage speech_to_text_watcher using capistrano and systemd

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,3 +45,6 @@ before 'deploy:publishing', 'shared_configs:update'
 
 # restart abbyy watcher systemd service each deploy
 before 'deploy:publishing', 'abbyy_watcher_systemd:restart'
+
+# restart speech-to-text watcher systemd service each deploy
+before 'deploy:publishing', 'speech_to_text_watcher_systemd:restart'

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -17,3 +17,4 @@ set :default_env, robot_environment: fetch(:deploy_environment)
 # https://github.com/honeybadger-io/honeybadger-ruby/blob/7eea24a47d44aed663e315be970e501b7cf092fc/vendor/capistrano-honeybadger/README.md
 set :honeybadger_server, primary(:app)
 set :abbyy_watcher_server, primary(:worker)
+set :speech_to_text_watcher_server, primary(:worker)

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -11,3 +11,4 @@ set :default_env, robot_environment: fetch(:deploy_environment)
 # https://github.com/honeybadger-io/honeybadger-ruby/blob/7eea24a47d44aed663e315be970e501b7cf092fc/vendor/capistrano-honeybadger/README.md
 set :honeybadger_server, primary(:app)
 set :abbyy_watcher_server, primary(:worker)
+set :speech_to_text_watcher_server, primary(:worker)

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -11,3 +11,4 @@ set :default_env, robot_environment: fetch(:deploy_environment)
 # https://github.com/honeybadger-io/honeybadger-ruby/blob/7eea24a47d44aed663e315be970e501b7cf092fc/vendor/capistrano-honeybadger/README.md
 set :honeybadger_server, primary(:app)
 set :abbyy_watcher_server, primary(:worker)
+set :speech_to_text_watcher_server, primary(:worker)

--- a/lib/capistrano/tasks/speech_to_text_watcher_systemd.cap
+++ b/lib/capistrano/tasks/speech_to_text_watcher_systemd.cap
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+namespace :speech_to_text_watcher_systemd do
+  desc 'Restart the speech_to_text_watcher systemd service'
+  task restart: ['controlmaster:setup', 'otk:generate'] do
+    on fetch(:speech_to_text_watcher_server) do
+      within release_path do
+        execute 'sudo systemctl restart speech_to_text_watcher'
+      end
+    end
+  end
+
+  desc 'Check that the speech_to_text_watcher systemd service is running'
+  task status: ['controlmaster:setup', 'otk:generate'] do
+    on fetch(:speech_to_text_watcher_server) do
+      within release_path do
+        execute 'systemctl status speech_to_text_watcher'
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Why was this change made? 🤔

closes #1413 

hold for (depends on)
- [x] https://github.com/sul-dlss/operations-tasks/issues/3932
- [x] re-do of https://github.com/sul-dlss/puppet/pull/11574

## How was this change tested? 🤨

i was able to successfully run the `status` task against stage and qa, e.g.:

```
% be cap stage speech_to_text_watcher_systemd:status
Pseudo-terminal will not be allocated because stdin is not a terminal.
Pseudo-terminal will not be allocated because stdin is not a terminal.
00:00 speech_to_text_watcher_systemd:status
      01 systemctl status speech_to_text_watcher
      01 ● speech_to_text_watcher.service - speech_to_text_watcher
      01      Loaded: loaded (/etc/systemd/system/speech_to_text_watcher.service; enabled; vendor preset: enabled)
      01      Active: active (running) since Sun 2024-11-24 09:53:19 PST; 1 weeks 5 days ago
      01    Main PID: 903 (ruby)
      01       Tasks: 3 (limit: 9457)
      01      Memory: 92.0M
      01      CGroup: /system.slice/speech_to_text_watcher.service
      01              └─903 bin/speech_to_text_watcher
      01
      01 Nov 24 09:53:19 common-accessioning-stage-a.stanford.edu systemd[1]: Started speech_to_text_watcher.
      01 Nov 24 09:53:22 common-accessioning-stage-a.stanford.edu speech_to_text_watcher[903]: I, [2024-11-24T09:53:22.…
      01 Nov 24 09:53:22 common-accessioning-stage-a.stanford.edu speech_to_text_watcher[903]: I, [2024-11-24T09:53:22.…
    ✔ 01 lyberadmin@common-accessioning-stage-a.stanford.edu 0.243s
```

`speech_to_text_watcher` was already up and running on those VMs as a systemd service because of https://github.com/sul-dlss/puppet/pull/11366 (which successfully started up the service without our noticing it when it was merged and auto-applied on nov 21; the then stale `speech_to_text_watcher` daemons that i'd manually started in a screen session on each VM were shut down when systems were brought down for UIT network maintenance on nov 23, which was good because i'd meant to do that but forgot).

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


