### PR TITLE
Submit speech-to-text job to AWS Batch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,9 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 gem 'activesupport', '~> 7.0'
 gem 'assembly-image', '~> 2.0' # ruby-vips is used by 2.0.0 for improved image processing
 gem 'assembly-objectfile', '~> 2.1'
+gem 'aws-sdk-batch' # used for submitting jobs for speech-to-text workflow
 gem 'aws-sdk-s3' # used for sending files to S3 for the speech-to-text workflow
-gem 'aws-sdk-sqs' # used for sending sqs mssages for the speech-to-text workflow
+gem 'aws-sdk-sqs' # used for receiving sqs messages from the speech-to-text workflow
 gem 'config'
 gem 'dor-services-client', '~> 15.1'
 gem 'dor-workflow-client', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,9 @@ GEM
     attr_extras (7.1.0)
     aws-eventstream (1.3.0)
     aws-partitions (1.1040.0)
+    aws-sdk-batch (1.108.0)
+      aws-sdk-core (~> 3, >= 3.216.0)
+      aws-sigv4 (~> 1.5)
     aws-sdk-core (3.216.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -352,6 +355,7 @@ DEPENDENCIES
   activesupport (~> 7.0)
   assembly-image (~> 2.0)
   assembly-objectfile (~> 2.1)
+  aws-sdk-batch
   aws-sdk-s3
   aws-sdk-sqs
   capistrano (~> 3.0)

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -59,9 +59,11 @@ aws:
   access_key_id: 'fake-access'
   secret_access_key: 'fake-secret'
   speech_to_text:
+    # values below can be found by running `terraform output` in terraform_aws/organizations/{env}/speech_to_text
     role_arn: 'arn:aws:iam::1234567890123:role/DevelopersRole'
-    base_s3_bucket: 'sul-speech-to-text-dev' # default bucket for storing speech-to-text file
-    sqs_todo_queue_url: 'https://sqs.us-west-2.amazonaws.com/queue_url' # queue to send new speech-to-text jobs
+    base_s3_bucket: 'bucket-name' # default bucket for storing speech-to-text file
+    batch_job_queue: 'arn:aws:batch:us-west-2:1234567890123:job-queue/queue-name' # AWS Batch queue to submit jobs to
+    batch_job_definition: 'arn:aws:batch:us-west-2:1234567890123:job-definition/queue-name' # AWS Batch job definition to use for job
     sqs_done_queue_url: 'https://sqs.us-west-2.amazonaws.com/queue_url_done' # queue to receive completed speech-to-text jobs
 
 

--- a/lib/dor/text_extraction/aws_provider.rb
+++ b/lib/dor/text_extraction/aws_provider.rb
@@ -24,11 +24,6 @@ module Dor
       end
 
       # @return [String]
-      def sqs_todo_queue_url
-        Settings.aws.speech_to_text.sqs_todo_queue_url
-      end
-
-      # @return [String]
       def sqs_done_queue_url
         Settings.aws.speech_to_text.sqs_done_queue_url
       end
@@ -41,6 +36,35 @@ module Dor
       # @return [::Aws::S3::Resource]
       def resource
         ::Aws::S3::Resource.new(aws_client_args)
+      end
+
+      # @return [::Aws::Batch::Client]
+      def batch
+        ::Aws::Batch::Client.new(aws_client_args)
+      end
+
+      # @return [String]
+      def batch_job_queue
+        Settings.aws.speech_to_text.batch_job_queue
+      end
+
+      # @return [String]
+      def batch_job_definition
+        Settings.aws.speech_to_text.batch_job_definition
+      end
+
+      # @return [::Aws::Batch::Types::SubmitJobResponse]
+      def submit_job(job)
+        batch.submit_job(
+          {
+            job_name: job[:id],
+            job_definition: batch_job_definition,
+            job_queue: batch_job_queue,
+            parameters: {
+              job: job.to_json
+            }
+          }
+        )
       end
 
       private

--- a/spec/lib/dor/text_extraction/aws_provider_spec.rb
+++ b/spec/lib/dor/text_extraction/aws_provider_spec.rb
@@ -6,7 +6,8 @@ describe Dor::TextExtraction::AwsProvider do
   let(:access_key_id) { 'some_key' }
   let(:secret_access_key) { 'secret' }
   let(:bucket_name) { Settings.aws.speech_to_text.base_s3_bucket }
-  let(:sqs_todo_queue_url) { Settings.aws.speech_to_text.sqs_todo_queue_url }
+  let(:batch_job_queue) { Settings.aws.speech_to_text.batch_job_queue }
+  let(:batch_job_definition) { Settings.aws.speech_to_text.batch_job_definition }
   let(:sqs_done_queue_url) { Settings.aws.speech_to_text.sqs_done_queue_url }
 
   describe '.bucket_name' do
@@ -15,9 +16,15 @@ describe Dor::TextExtraction::AwsProvider do
     end
   end
 
-  describe '.sqs_todo_queue_url' do
+  describe '.batch_job_queue' do
     it 'returns value from Settings' do
-      expect(provider.sqs_todo_queue_url).to eq sqs_todo_queue_url
+      expect(provider.batch_job_queue).to eq batch_job_queue
+    end
+  end
+
+  describe '.batch_job_definition' do
+    it 'returns value from Settings' do
+      expect(provider.batch_job_definition).to eq batch_job_definition
     end
   end
 

--- a/spec/lib/dor/text_extraction/speech_to_text_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_spec.rb
@@ -131,8 +131,8 @@ RSpec.describe Dor::TextExtraction::SpeechToText do
 
     it 'removes all files from s3' do
       expect(stt.cleanup).to be true
-      expect(client).to have_received(:delete_object).with(bucket: 'sul-speech-to-text-dev', key: "#{bare_druid}-v#{version}/file1.m4a").once
-      expect(client).to have_received(:delete_object).with(bucket: 'sul-speech-to-text-dev', key: "#{bare_druid}-v#{version}/file1.mp4").once
+      expect(client).to have_received(:delete_object).with(bucket: Settings.aws.speech_to_text.base_s3_bucket, key: "#{bare_druid}-v#{version}/file1.m4a").once
+      expect(client).to have_received(:delete_object).with(bucket: Settings.aws.speech_to_text.base_s3_bucket, key: "#{bare_druid}-v#{version}/file1.mp4").once
     end
   end
 

--- a/spec/robots/dor_repo/speech_to_text/stt_create_spec.rb
+++ b/spec/robots/dor_repo/speech_to_text/stt_create_spec.rb
@@ -8,8 +8,8 @@ describe Robots::DorRepo::SpeechToText::SttCreate do
   let(:druid) { 'druid:bb222cc3333' }
   let(:bare_druid) { 'bb222cc3333' }
   let(:robot) { described_class.new }
-  let(:aws_client) { instance_double(Aws::SQS::Client) }
   let(:aws_s3_client) { instance_double(Aws::S3::Client) }
+  let(:aws_batch_client) { instance_double(Aws::Batch::Client) }
   let(:filenames_to_stt) { ['file1.mov', 'file2.mp3'] }
   let(:stt) { instance_double(Dor::TextExtraction::SpeechToText, job_id:, filenames_to_stt:) }
   let(:cocina_model) { build(:dro, id: druid).new(structural: {}, type: object_type, access: { view: 'world' }) }
@@ -26,16 +26,18 @@ describe Robots::DorRepo::SpeechToText::SttCreate do
   let(:job_id) { "#{bare_druid}-v1" }
   let(:media) { [{ name: "#{job_id}/#{filenames_to_stt[0]}", options: { language: 'en' } }, { name: "#{job_id}/#{filenames_to_stt[1]}", options: { language: 'es' } }] }
   let(:list_objects) { instance_double(Aws::S3::Types::ListObjectsOutput, contents: [mov_object, mp3_object]) }
+  let(:job_response) { instance_double(Aws::Batch::Types::SubmitJobResponse) }
   let(:mov_object) { instance_double(Aws::S3::Types::Object, key: media[0][:name]) }
   let(:mp3_object) { instance_double(Aws::S3::Types::Object, key: media[1][:name]) }
 
   before do
     allow(Aws::S3::Client).to receive(:new).and_return(aws_s3_client)
-    allow(Aws::SQS::Client).to receive(:new).and_return(aws_client)
+    allow(Aws::Batch::Client).to receive(:new).and_return(aws_batch_client)
     allow(Dor::Services::Client).to receive(:object).and_return(dsa_object_client)
     allow(Dor::TextExtraction::SpeechToText).to receive(:new).and_return(stt)
     allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
     allow(aws_s3_client).to receive(:list_objects).and_return(list_objects)
+    allow(aws_batch_client).to receive(:submit_job).and_return(job_response)
     allow(stt).to receive(:language_tag).with(filenames_to_stt[0]).and_return('en')
     allow(stt).to receive(:language_tag).with(filenames_to_stt[1]).and_return('es')
   end
@@ -43,25 +45,28 @@ describe Robots::DorRepo::SpeechToText::SttCreate do
   context 'when the message is sent successfully' do
     let(:message_body) { { id: job_id, druid:, media: }.merge(Settings.speech_to_text.whisper.to_h).to_json }
 
-    before do
-      allow(aws_client).to receive(:send_message).with({ queue_url: Settings.aws.speech_to_text.sqs_todo_queue_url, message_body: }).and_return(true)
-    end
-
-    it 'sends SQS messages but does not complete the step' do
+    it 'sends AWS Batch job but does not complete the step' do
       expect(perform.status).to eq 'noop'
-      expect(aws_client).to have_received(:send_message).with({ queue_url: Settings.aws.speech_to_text.sqs_todo_queue_url, message_body: }).once
+      expect(aws_batch_client).to have_received(:submit_job).with(
+        {
+          job_name: job_id,
+          job_definition: Settings.aws.speech_to_text.batch_job_definition,
+          job_queue: Settings.aws.speech_to_text.batch_job_queue,
+          parameters: { job: message_body }
+        }
+      ).once
     end
   end
 
   context 'when the message is not sent successfully' do
     before do
-      allow(aws_client).to receive(:send_message).and_raise(Aws::SQS::Errors::ServiceError.new(nil, 'blam'))
+      allow(aws_batch_client).to receive(:submit_job).and_raise(Aws::Batch::Errors::ServiceError.new(nil, 'blam'))
       allow(Honeybadger).to receive(:notify)
     end
 
     it 'raises an exception and alerts HB' do
-      expect { perform }.to raise_error(RuntimeError, 'Error sending SQS message: blam')
-      expect(Honeybadger).to have_received(:notify).with('Problem sending SQS Message to AWS for SpeechToText', context: { druid:, job_id:, error: instance_of(Aws::SQS::Errors::ServiceError) }).once
+      expect { perform }.to raise_error(RuntimeError, 'Error sending Batch job: blam')
+      expect(Honeybadger).to have_received(:notify).with('Problem sending Batch job to AWS for SpeechToText', context: { druid:, job_id:, error: instance_of(Aws::Batch::Errors::ServiceError) }).once
     end
   end
 
@@ -70,13 +75,13 @@ describe Robots::DorRepo::SpeechToText::SttCreate do
 
     before do
       allow(stt).to receive(:language_tag).with(filenames_to_stt[0]).and_return(nil)
-      allow(aws_client).to receive(:send_message).with({ queue_url: Settings.aws.speech_to_text.sqs_todo_queue_url, message_body: }).and_return(true)
+      allow(aws_batch_client).to receive(:submit_job).and_return(true)
       allow(aws_s3_client).to receive(:list_objects).and_return(instance_double(Aws::S3::Types::ListObjectsOutput, contents: [mov_object]))
     end
 
-    it 'sends SQS message without language options' do
+    it 'sends Batch job without language options' do
       expect(perform.status).to eq 'noop'
-      expect(aws_client).to have_received(:send_message).with({ queue_url: Settings.aws.speech_to_text.sqs_todo_queue_url, message_body: }).once
+      expect(aws_batch_client).to have_received(:submit_job).once
     end
   end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

To allow for automatic provisioning of GPU ready EC2 instances we are going to use AWS Batch instead of running a dedicated EC2 instance. This means that work needs to be submitted to a Batch Queue instead of SQS. Since Batch doesn't have any facility for sending notifications on job completion we are still going to keep the "done" SQS queue.

These changes are dependent on Terraform configuration work for AWS Batch in https://github.com/sul-dlss/terraform-aws/pull/1197

Resolves #1453

## How was this change tested? 🤨

CI and Integration Tests in QA