### PR TITLE
raise an error on invalid stubContentMetadata

### DIFF
--- a/lib/dor/assembly/stub_content_metadata_parser.rb
+++ b/lib/dor/assembly/stub_content_metadata_parser.rb
@@ -38,7 +38,14 @@ module Dor
         # Loads stub content metadata XML into a Nokogiri document.
         raise "Stub content metadata file #{Settings.assembly.stub_cm_file_name} not found for #{druid.id} in any of the root directories: #{@root_dir.join(',')}" unless stub_content_metadata_exists?
 
-        @stub_cm = Nokogiri.XML(File.open(stub_cm_file_name)) { |conf| conf.default_xml.noblanks }
+        @stub_cm = begin
+          Nokogiri.XML(File.open(stub_cm_file_name)) do |conf|
+            conf.default_xml.noblanks
+            conf.default_xml.strict
+          end
+        rescue Nokogiri::XML::SyntaxError
+          raise 'Invalid stubContentMetadata.xml'
+        end
       end
 
       # this determines the reading order from the stub_object_type (default ltr unless the object type contains one of the possible "rtl" designations)

--- a/lib/robots/dor_repo/assembly/content_metadata_create.rb
+++ b/lib/robots/dor_repo/assembly/content_metadata_create.rb
@@ -19,8 +19,8 @@ module Robots
           updated = assembly_item.cocina_model.new(structural: assembly_item.convert_stub_content_metadata)
           assembly_item.object_client.update(params: updated)
 
-          # Backup the stubContentMetadata.xml
-          FileUtils.mv(assembly_item.stub_cm_file_name, File.join('/dor/stopped', "#{druid}-#{Settings.assembly.stub_cm_file_name}"))
+          # Remove the stubContentMetadata.xml
+          FileUtils.rm(assembly_item.stub_cm_file_name)
 
           LyberCore::ReturnState.new(status: 'completed')
         end

--- a/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
+++ b/spec/lib/dor/assembly/stub_content_metadata_parser_spec.rb
@@ -210,5 +210,13 @@ RSpec.describe Dor::Assembly::StubContentMetadataParser do
         expect(structural.to_h).to eq expected_content_metadata
       end
     end
+
+    context 'with malformed XML' do
+      let(:druid) { 'druid:bb111bb7777' }
+
+      it 'raises an error' do
+        expect { item.convert_stub_content_metadata }.to raise_error(RuntimeError, /Invalid stubContentMetadata.xml/)
+      end
+    end
   end
 end

--- a/spec/test_input/bb/111/bb/7777/stubContentMetadata.xml
+++ b/spec/test_input/bb/111/bb/7777/stubContentMetadata.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<content type="Book (rtl)">
+   <resource>
+      <label>This is truncated</label>
+      <file name="page1.tif"/>
+      <file name="page1.txt" publish="no" preserve="no" shelve="no"/>
+   </resource>
+   <resource>
+      <label>Where is the rest?</label>
+      <file name="page2.tif"/>


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1477 

Currently partial and malformed stubContentMetadata.xml that is exported from Goobi is happily processed but results in incomplete objects.  This change will now cause an error to be raised and thus put the content-metadata-create step to be placed in error with an appropriate message if this happens.

See https://stanfordlib.slack.com/archives/C0EAZ09QF/p1743445147202589 for the reasoning behind this change.

Note: it also reverts #1475 since we don't need that anymore (this will put the step in error, leaving the file in the workspace for further debugging)

## How was this change tested? 🤨

New specs