### PR TITLE
add retries around stub content metadata generation

### DIFF
--- a/lib/robots/dor_repo/assembly/content_metadata_create.rb
+++ b/lib/robots/dor_repo/assembly/content_metadata_create.rb
@@ -11,19 +11,35 @@ module Robots
         end
 
         # Generate the structural metadata for this object from stub content metadata (if present).
+        # rubocop:disable Metrics/MethodLength
         def perform_work
           return LyberCore::ReturnState.new(status: :skipped, note: 'object is not an item') unless assembly_item.item? # not an item, skip
 
           return LyberCore::ReturnState.new(status: :skipped, note: 'No stubContentMetadata to load from the filesystem') unless assembly_item.stub_content_metadata_exists?
 
-          updated = assembly_item.cocina_model.new(structural: assembly_item.convert_stub_content_metadata)
-          assembly_item.object_client.update(params: updated)
+          tries = 0
+          max_tries = 3
+          begin
+            updated = assembly_item.cocina_model.new(structural: assembly_item.convert_stub_content_metadata)
+            assembly_item.object_client.update(params: updated)
+          # sometimes the stubContentMetadata.xml is in process of being written and is invalid
+          # this is a workaround that gives it more time to complete
+          # see https://github.com/sul-dlss/common-accessioning/issues/1477
+          rescue RuntimeError => e
+            tries += 1
+            sleep(3**tries)
+            logger.info "Retry #{tries} for content-metadata-create; after exception #{e.message}"
+
+            retry unless tries > max_tries
+            raise e
+          end
 
           # Remove the stubContentMetadata.xml
           FileUtils.rm(assembly_item.stub_cm_file_name)
 
           LyberCore::ReturnState.new(status: 'completed')
         end
+        # rubocop:enable Metrics/MethodLength
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Follow on for #1477 

We discovered that the stubContentMetadata.xml file seems to be complete if you wait for a bit.

This could be because:
(1) goobi is writing the files at the same time as the make the API call (synchronously) and we have a race condition
(2) our shared mounts are out of date (i.e. goobi writes to a shared file system, but when we try and read the same file from a different VM what mounts that shared file system, it takes some time for the file to appear complete).

If (1) is true, then goobi should fix this on their end and we shouldn't need this code (but it will help in the meantime).
If (2) is true, then this may be the most expedient solution and mimics what we do in other places (like speech to text and OCR work) to get around the shared file system latency issue.


## How was this change tested? 🤨

Specs
