### PR TITLE
temporarily remove any retries

### DIFF
--- a/lib/robots/dor_repo/assembly/content_metadata_create.rb
+++ b/lib/robots/dor_repo/assembly/content_metadata_create.rb
@@ -18,7 +18,7 @@ module Robots
           return LyberCore::ReturnState.new(status: :skipped, note: 'No stubContentMetadata to load from the filesystem') unless assembly_item.stub_content_metadata_exists?
 
           tries = 0
-          max_tries = 3
+          max_tries = 0
           begin
             updated = assembly_item.cocina_model.new(structural: assembly_item.convert_stub_content_metadata)
             assembly_item.object_client.update(params: updated)

--- a/spec/robots/dor_repo/assembly/content_metadata_create_spec.rb
+++ b/spec/robots/dor_repo/assembly/content_metadata_create_spec.rb
@@ -99,6 +99,7 @@ RSpec.describe Robots::DorRepo::Assembly::ContentMetadataCreate do
       end
 
       it 'updates cocina after successful retry' do
+        skip 'Temporarily remove retry logic for testing'
         expect(object_client).to receive(:update)
         expect(FileUtils).to receive(:rm).with(stub_content_file_name)
         expect(result.status).to eq('completed')


### PR DESCRIPTION
## Why was this change made? 🤔

We can add a delay via a config file (see https://docs.goobi.io/workflow-plugins/en/export/goobi-plugin-export-stanford) on the goobi end between when they create the XML file and when they call the start accession API endpoint.  This temporarily removes any retries so we can see if changing the delay on the goobi end makes a difference.  If it does, we could consider remove the retries logic completely (i.e. revert #1478), though it probably doesn't do any harm to leave it in.