### PR TITLE
Remove explicit one-time key setup

### DIFF
--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -9,8 +9,6 @@ server 'common-accessioning-prod-f.stanford.edu', user: 'lyberadmin', roles: %w[
 server 'common-accessioning-prod-g.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 server 'common-accessioning-prod-h.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)
 # See https://github.com/honeybadger-io/honeybadger-ruby/issues/129 &

--- a/config/deploy/qa.rb
+++ b/config/deploy/qa.rb
@@ -3,8 +3,6 @@
 server 'common-accessioning-qa-a.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 server 'common-accessioning-qa-b.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)
 # See https://github.com/honeybadger-io/honeybadger-ruby/issues/129 &

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,8 +3,6 @@
 server 'common-accessioning-stage-a.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 server 'common-accessioning-stage-b.stanford.edu', user: 'lyberadmin', roles: %w[worker app]
 
-Capistrano::OneTimeKey.generate_one_time_key!
-
 set :deploy_environment, 'production'
 set :default_env, robot_environment: fetch(:deploy_environment)
 # See https://github.com/honeybadger-io/honeybadger-ruby/issues/129 &


### PR DESCRIPTION
This line has been a no-op since dlss-capistrano 5.2.0. Setting up the one-time key is done automatically in dlss-capistrano now.