### PR TITLE
Fix stage robot to only check size.

### DIFF
--- a/lib/robots/dor_repo/accession/stage.rb
+++ b/lib/robots/dor_repo/accession/stage.rb
@@ -21,7 +21,7 @@ module Robots
           FileUtils.cp_r(staging_pathname, workspace_pathname.parent)
 
           # Audit the workspace directory
-          check_expected_files!
+          check_expected_file_sizes!
         end
 
         private
@@ -34,12 +34,13 @@ module Robots
           @workspace_pathname ||= DruidTools::Druid.new(druid, Settings.sdr.local_workspace_root).pathname
         end
 
-        # @return [Boolean] true if all expected files are present in the workspace and have the correct file size.
-        def check_expected_files!
+        def check_expected_file_sizes! # rubocop:disable Metrics/AbcSize
           cocina_object.structural.contains.each do |fileset|
             fileset.structural.contains.each do |file|
               file_pathname = workspace_pathname.join('content', file.filename)
-              raise "File missing or incorrect size: #{file_pathname}" unless file_pathname.exist? && file_pathname.size == file.size
+              next unless file_pathname.exist? && file_pathname.size != file.size
+
+              raise "File incorrect size: #{file_pathname} expected #{file.size} but actually #{file_pathname.size}"
             end
           end
         end

--- a/spec/robots/dor_repo/accession/stage_spec.rb
+++ b/spec/robots/dor_repo/accession/stage_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Robots::DorRepo::Accession::Stage do
     let(:druid) { 'druid:dd116zh0343' }
     let(:object_client) { instance_double(Dor::Services::Client::Object, find: object) }
     let(:workflow_client) { instance_double(Dor::Workflow::Client) }
-    # let(:process) { instance_double(Dor::Workflow::Response::Process, lane_id: 'low') }
     let(:workspace_root) { File.join(Dir.tmpdir, 'workspace') }
     let(:object_workspace_root) { "#{workspace_root}/dd/116/zh/0343/dd116zh0343" }
 
@@ -20,8 +19,8 @@ RSpec.describe Robots::DorRepo::Accession::Stage do
     before do
       allow(Dor::Services::Client).to receive(:object).and_return(object_client)
       allow(LyberCore::WorkflowClientFactory).to receive(:build).and_return(workflow_client)
-      # Workspace fixtures being used for staging.
 
+      # Workspace fixtures being used for staging.
       allow(Settings.sdr).to receive_messages(staging_root: 'spec/fixtures/workspace', local_workspace_root: workspace_root)
     end
 
@@ -91,7 +90,7 @@ RSpec.describe Robots::DorRepo::Accession::Stage do
       end
     end
 
-    context 'when files missing' do
+    context 'when file already accessioned (and therefore missing)' do
       let(:object) do
         build(:dro, id: druid).new(
           structural: {
@@ -104,8 +103,8 @@ RSpec.describe Robots::DorRepo::Accession::Stage do
                 contains: [
                   {
                     externalIdentifier: '222-1',
-                    label: 'folder1PuSu/story1u.txt',
-                    filename: 'folder1PuSu/story1ux.txt',
+                    label: 'folder1PuSu/already_accessioned.txt',
+                    filename: 'folder1PuSu/already_accessioned.txt',
                     type: Cocina::Models::ObjectType.file,
                     version: 1,
                     access: {},
@@ -121,7 +120,7 @@ RSpec.describe Robots::DorRepo::Accession::Stage do
       end
 
       it 'raises' do
-        expect { perform }.to raise_error(StandardError, /File missing or incorrect size/)
+        expect { perform }.not_to raise_error
       end
     end
 
@@ -155,7 +154,7 @@ RSpec.describe Robots::DorRepo::Accession::Stage do
       end
 
       it 'raises' do
-        expect { perform }.to raise_error(StandardError, /File missing or incorrect size/)
+        expect { perform }.to raise_error(StandardError, /File incorrect size/)
       end
     end
   end


### PR DESCRIPTION
closes #1496

## Why was this change made? 🤔
The existing robot had the mistaken assumption that all files in the cocina would be present on disk; only the new/changed files are present.

## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


