### PR TITLE
Check files are present before starting accessioning.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rspec
@@ -22,9 +22,8 @@ Metrics/BlockLength:
     - spec/**/*_spec.rb
     - config/environments/*.rb
 
-Naming/PredicateName:
-  ForbiddenPrefixes:
-    - is_
+Naming/PredicatePrefix:
+  Enabled: false
 
 RSpec/MultipleExpectations:
   Enabled: false
@@ -399,4 +398,41 @@ Style/ItAssignment: # new in 1.70
 Style/KeywordArgumentsMerging: # new in 1.68
   Enabled: true
 Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
+
+Gemspec/AttributeAssignment: # new in 1.77
+  Enabled: true
+Lint/CopDirectiveSyntax: # new in 1.72
+  Enabled: true
+Lint/RedundantTypeConversion: # new in 1.72
+  Enabled: true
+Lint/SuppressedExceptionInNumberConversion: # new in 1.72
+  Enabled: true
+Lint/UselessConstantScoping: # new in 1.72
+  Enabled: true
+Lint/UselessDefaultValueArgument: # new in 1.76
+  Enabled: true
+Lint/UselessOr: # new in 1.76
+  Enabled: true
+Naming/PredicateMethod: # new in 1.76
+  Enabled: false
+Style/CollectionQuerying: # new in 1.77
+  Enabled: true
+Style/ComparableBetween: # new in 1.74
+  Enabled: true
+Style/EmptyStringInsideInterpolation: # new in 1.76
+  Enabled: true
+Style/HashFetchChain: # new in 1.75
+  Enabled: true
+Style/ItBlockParameter: # new in 1.75
+  Enabled: true
+Style/RedundantArrayFlatten: # new in 1.76
+  Enabled: true
+Style/RedundantFormat: # new in 1.72
+  Enabled: true
+Capybara/FindAllFirst: # new in 2.22
+  Enabled: true
+Capybara/NegationMatcherAfterVisit: # new in 2.22
+  Enabled: true
+RSpec/IncludeExamples: # new in 3.6
   Enabled: true

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -295,7 +295,7 @@ GEM
     rspec-support (3.13.4)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
-    rubocop (1.77.0)
+    rubocop (1.78.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)

--- a/spec/fixtures/staging/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story4u.txt
+++ b/spec/fixtures/staging/dd/116/zh/0343/dd116zh0343/content/folder1PuSu/story4u.txt
@@ -1,0 +1,171 @@
+The Story of the Merchant and the Genius
+
+Sire, there was once upon a time a merchant who possessed great wealth,
+in land and merchandise, as well as in ready money.  He was obliged
+from time to time to take journeys to arrange his affairs.  One day,
+having to go a long way from home, he mounted his horse, taking with
+him a small wallet in which he had put a few biscuits and dates,
+because he had to pass through the desert where no food was to be got.
+He arrived without any mishap, and, having finished his business, set
+out on his return.  On the fourth day of his journey, the heat of the
+sun being very great, he turned out of his road to rest under some
+trees.  He found at the foot of a large walnut-tree a fountain of clear
+and running water.  He dismounted, fastened his horse to a branch of
+the tree, and sat by the fountain, after having taken from his wallet
+some of his dates and biscuits.  When he had finished this frugal meal
+he washed his face and hands in the fountain.
+
+When he was thus employed he saw an enormous genius, white with rage,
+coming towards him, with a scimitar in his hand.
+
+"Arise," he cried in a terrible voice, "and let me kill you as you have
+killed my son!"
+
+As he uttered these words he gave a frightful yell.  The merchant,
+quite as much terrified at the hideous face of the monster as at his
+words, answered him tremblingly, "Alas, good sir, what can I have done
+to you to deserve death?"
+
+"I shall kill you," repeated the genius, "as you have killed my son."
+
+"But," said the merchant, "how can I have killed your son?  I do not
+know him, and I have never even seen him."
+
+"When you arrived here did you not sit down on the ground?" asked the
+genius, "and did you not take some dates from your wallet, and whilst
+eating them did not you throw the stones about?"
+
+"Yes," said the merchant, "I certainly did so."
+
+"Then," said the genius, "I tell you you have killed my son, for whilst
+you were throwing about the stones, my son passed by, and one of them
+struck him in the eye and killed him.  So I shall kill you."
+
+"Ah, sir, forgive me!" cried the merchant.
+
+"I will have no mercy on you," answered the genius.
+
+"But I killed your son quite unintentionally, so I implore you to spare
+my life."
+
+"No," said the genius, "I shall kill you as you killed my son," and so
+saying, he seized the merchant by the arm, threw him on the ground, and
+lifted his sabre to cut off his head.
+
+The merchant, protesting his innocence, bewailed his wife and children,
+and tried pitifully to avert his fate.  The genius, with his raised
+scimitar, waited till he had finished, but was not in the least touched.
+
+Scheherazade, at this point, seeing that it was day, and knowing that
+the Sultan always rose very early to attend the council, stopped
+speaking.
+
+"Indeed, sister," said Dinarzade, "this is a wonderful story."
+
+"The rest is still more wonderful," replied Scheherazade, "and you
+would say so, if the sultan would allow me to live another day, and
+would give me leave to tell it to you the next night."
+
+Schahriar, who had been listening to Scheherazade with pleasure, said
+to himself, "I will wait till to-morrow; I can always have her killed
+when I have heard the end of her story."
+
+All this time the grand-vizir was in a terrible state of anxiety.  But
+he was much delighted when he saw the Sultan enter the council-chamber
+without giving the terrible command that he was expecting.
+
+The next morning, before the day broke, Dinarzade said to her sister,
+"Dear sister, if you are awake I pray you to go on with your story."
+
+The Sultan did not wait for Scheherazade to ask his leave.  "Finish,"
+said he, "the story of the genius and the merchant.  I am curious to
+hear the end."
+
+So Scheherazade went on with the story.  This happened every morning.
+The Sultana told a story, and the Sultan let her live to finish it.
+
+When the merchant saw that the genius was determined to cut off his
+head, he said:  "One word more, I entreat you.  Grant me a little
+delay; just a short time to go home and bid my wife and children
+farewell, and to make my will.  When I have done this I will come back
+here, and you shall kill me."
+
+"But," said the genius, "if I grant you the delay you ask, I am afraid
+that you will not come back."
+
+"I give you my word of honour," answered the merchant, "that I will
+come back without fail."
+
+"How long do you require?" asked the genius.
+
+"I ask you for a year's grace," replied the merchant.  "I promise you
+that to-morrow twelvemonth, I shall be waiting under these trees to
+give myself up to you."
+
+On this the genius left him near the fountain and disappeared.
+
+The merchant, having recovered from his fright, mounted his horse and
+went on his road.
+
+When he arrived home his wife and children received him with the
+greatest joy.  But instead of embracing them he began to weep so
+bitterly that they soon guessed that something terrible was the matter.
+
+"Tell us, I pray you," said his wife, "what has happened."
+
+"Alas!" answered her husband, "I have only a year to live."
+
+Then he told them what had passed between him and the genius, and how
+he had given his word to return at the end of a year to be killed.
+When they heard this sad news they were in despair, and wept much.
+
+The next day the merchant began to settle his affairs, and first of all
+to pay his debts.  He gave presents to his friends, and large alms to
+the poor.  He set his slaves at liberty, and provided for his wife and
+children.  The year soon passed away, and he was obliged to depart.
+When he tried to say good-bye he was quite overcome with grief, and
+with difficulty tore himself away.  At length he reached the place
+where he had first seen the genius, on the very day that he had
+appointed.  He dismounted, and sat down at the edge of the fountain,
+where he awaited the genius in terrible suspense.
+
+Whilst he was thus waiting an old man leading a hind came towards him.
+They greeted one another, and then the old man said to him, "May I ask,
+brother, what brought you to this desert place, where there are so many
+evil genii about?  To see these beautiful trees one would imagine it
+was inhabited, but it is a dangerous place to stop long in."
+
+The merchant told the old man why he was obliged to come there.  He
+listened in astonishment.
+
+"This is a most marvellous affair.  I should like to be a witness of
+your interview with the genius."  So saying he sat down by the merchant.
+
+While they were talking another old man came up, followed by two black
+dogs.  He greeted them, and asked what they were doing in this place.
+The old man who was leading the hind told him the adventure of the
+merchant and the genius.  The second old man had not sooner heard the
+story than he, too, decided to stay there to see what would happen.  He
+sat down by the others, and was talking, when a third old man arrived.
+He asked why the merchant who was with them looked so sad.  They told
+him the story, and he also resolved to see what would pass between the
+genius and the merchant, so waited with the rest.
+
+They soon saw in the distance a thick smoke, like a cloud of dust.
+This smoke came nearer and nearer, and then, all at once, it vanished,
+and they saw the genius, who, without speaking to them, approached the
+merchant, sword in hand, and, taking him by the arm, said, "Get up and
+let me kill you as you killed my son."
+
+The merchant and the three old men began to weep and groan.
+
+Then the old man leading the hind threw himself at the monster's feet
+and said, "O Prince of the Genii, I beg of you to stay your fury and to
+listen to me.  I am going to tell you my story and that of the hind I
+have with me, and if you find it more marvellous than that of the
+merchant whom you are about to kill, I hope that you will do away with
+a third part of his punishment?"
+
+The genius considered some time, and then he said, "Very well, I agree
+to this."
+

--- a/spec/robots/dor_repo/accession/start_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/start_accession_spec.rb
@@ -5,31 +5,229 @@ require 'spec_helper'
 RSpec.describe Robots::DorRepo::Accession::StartAccession do
   subject(:robot) { described_class.new }
 
-  let(:druid) { 'druid:zz000zz0001' }
-  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client) }
+  let(:druid) { 'druid:dd116zh0343' }
+  let(:object_client) { instance_double(Dor::Services::Client::Object, version: version_client, find: cocina_object) }
   let(:version_client) do
     instance_double(Dor::Services::Client::ObjectVersion,
                     status: instance_double(Dor::Services::Client::ObjectVersion::VersionStatus, open?: version_open))
   end
   let(:version_open) { false }
+  let(:preservation_client) { instance_double(Preservation::Client, objects: preservation_objects_client) }
+  let(:preservation_objects_client) { instance_double(Preservation::Client::Objects, checksum: checksums) }
+  let(:checksums) { [] }
 
   before do
     allow(Dor::Services::Client).to receive(:object).with(druid).and_return(object_client)
+    allow(Settings.sdr).to receive_messages(local_workspace_root: 'spec/fixtures/workspace', staging_root: 'spec/fixtures/staging')
+    allow(Preservation::Client).to receive(:configure).and_return(preservation_client)
   end
 
   describe '#perform' do
     subject(:perform) { test_perform(robot, druid) }
 
-    it 'does not raise' do
-      expect { perform }.not_to raise_error
+    context 'when not a DRO and object is not open' do
+      let(:cocina_object) { build(:collection, id: druid) }
+
+      it 'does not raise' do
+        expect { perform }.not_to raise_error
+      end
     end
 
     context 'when object is still open' do
+      let(:cocina_object) { build(:collection, id: druid) }
       let(:version_open) { true }
 
       it 'raises an error' do
         expect { perform }.to raise_error 'Accessioning has been started with an object that is still open'
       end
     end
+
+    context 'when DRO without files' do
+      let(:cocina_object) { build(:dro, id: druid) }
+
+      it 'does not raise' do
+        expect { perform }.not_to raise_error
+      end
+    end
+
+    context 'when DRO with files' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(structural:)
+      end
+
+      let(:structural) do
+        {
+          contains: [
+            # This file is in workspace.
+            {
+              externalIdentifier: '222',
+              type: Cocina::Models::FileSetType.file,
+              label: 'my workspace repository object',
+              version: 1,
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: '222-1',
+                    label: 'folder1PuSu/story1u.txt',
+                    filename: 'folder1PuSu/story1u.txt',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    access: {},
+                    size: 7888,
+                    administrative: { publish: true, sdrPreserve: true, shelve: false },
+                    hasMessageDigests: [{ type: 'md5', digest: '123' }]
+                  }
+                ]
+              }
+            },
+            # This file is in staging.
+            {
+              externalIdentifier: '223',
+              type: Cocina::Models::FileSetType.file,
+              label: 'my staging repository object',
+              version: 1,
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: '223-1',
+                    label: 'folder1PuSu/story4u.txt',
+                    filename: 'folder1PuSu/story4u.txt',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    access: {},
+                    size: 7888,
+                    administrative: { publish: true, sdrPreserve: true, shelve: false },
+                    hasMessageDigests: [{ type: 'md5', digest: '123' }]
+                  }
+                ]
+              }
+            },
+            # This file is in preservation.
+            {
+              externalIdentifier: '224',
+              type: Cocina::Models::FileSetType.file,
+              label: 'my preservation repository object',
+              version: 1,
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: '224-1',
+                    label: 'folder1PuSu/story5u.txt',
+                    filename: 'folder1PuSu/story5u.txt',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    access: {},
+                    size: 7888,
+                    administrative: { publish: true, sdrPreserve: true, shelve: false },
+                    hasMessageDigests: [{ type: 'md5', digest: '123' }]
+                  }
+                ]
+              }
+            }
+          ],
+          hasMemberOrders: [],
+          isMemberOf: []
+        }
+      end
+
+      let(:checksums) do
+        [
+          { filename: 'folder1PuSu/story1u.txt', md5: '234' },
+          { filename: 'folder1PuSu/story5u.txt', md5: '123' }
+        ]
+      end
+
+      it 'does not raise' do
+        expect { perform }.not_to raise_error
+      end
+    end
+
+    context 'when DRO with missing file and staging directory not present' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(structural:)
+      end
+
+      let(:structural) do
+        {
+          contains: [
+            {
+              externalIdentifier: '222',
+              type: Cocina::Models::FileSetType.file,
+              label: 'my missing repository object',
+              version: 1,
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: '222-1',
+                    label: 'folder1PuSu/story1x.txt',
+                    filename: 'folder1PuSu/story1x.txt',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    access: {},
+                    size: 7888,
+                    administrative: { publish: true, sdrPreserve: true, shelve: false },
+                    hasMessageDigests: [{ type: 'md5', digest: '123' }]
+                  }
+                ]
+              }
+            }
+          ],
+          hasMemberOrders: [],
+          isMemberOf: []
+        }
+      end
+
+      it 'raises an error' do
+        expect { perform }.to raise_error(RuntimeError, 'Files missing from staging, workspace, and preservation: folder1PuSu/story1x.txt')
+      end
+    end
+
+    # rubocop:disable RSpec/SubjectStub
+    context 'when DRO with missing file' do
+      let(:cocina_object) do
+        build(:dro, id: druid).new(structural:)
+      end
+
+      let(:structural) do
+        {
+          contains: [
+            {
+              externalIdentifier: '222',
+              type: Cocina::Models::FileSetType.file,
+              label: 'my missing repository object',
+              version: 1,
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: '222-1',
+                    label: 'folder1PuSu/story1x.txt',
+                    filename: 'folder1PuSu/story1x.txt',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    access: {},
+                    size: 7888,
+                    administrative: { publish: true, sdrPreserve: true, shelve: false },
+                    hasMessageDigests: [{ type: 'md5', digest: '123' }]
+                  }
+                ]
+              }
+            }
+          ],
+          hasMemberOrders: [],
+          isMemberOf: []
+        }
+      end
+
+      before do
+        allow(Settings.sdr).to receive(:staging_root).and_return('spec/fixtures/xstaging')
+        allow(robot).to receive(:sleep)
+      end
+
+      it 'retries before raising an error' do
+        expect { perform }.to raise_error(RuntimeError, 'Files missing from staging, workspace, and preservation: folder1PuSu/story1x.txt')
+        expect(robot).to have_received(:sleep).exactly(3).times
+      end
+    end
+    # rubocop:enable RSpec/SubjectStub
   end
 end


### PR DESCRIPTION
closes #1513

## Why was this change made? 🤔
To address a latency between files being written to staging and files being visible on all staging mounts.


## How was this change tested? 🤨
Unit, qa

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


