### PR TITLE
Pass in workflow context when creating new version

### DIFF
--- a/lib/robots/dor_repo/accession/end_accession.rb
+++ b/lib/robots/dor_repo/accession/end_accession.rb
@@ -31,23 +31,26 @@ module Robots
           ocr = Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context: workflow.context)
           stt = Dor::TextExtraction::SpeechToText.new(cocina_object:, workflow_context: workflow.context)
 
-          # NOTE: since the first step of ocrWF or speechToTextWF opens a new version, we want this new WF to be associated
-          #       with the next object version (the current version is about to be closed)
-          next_version = (current_version.to_i + 1)
-
           if ocr.required?
             # user asked for OCR but the object is not OCRable
             raise 'Object cannot be OCRd' unless ocr.possible?
 
-            # start OCR workflow
-            workflow_service.create_workflow_by_name(druid, 'ocrWF', version: next_version, lane_id:)
+            start_caption_workflow('ocrWF')
           elsif stt.required?
             # user asked for SpeechToText but the object is not speech-to-textable
             raise 'Object cannot have speech-to-text applied' unless stt.possible?
 
-            # start speechToText workflow
-            workflow_service.create_workflow_by_name(druid, 'speechToTextWF', version: next_version, lane_id:)
+            start_caption_workflow('speechToTextWF')
           end
+        end
+
+        def start_caption_workflow(workflow_name)
+          # NOTES:
+          # 1. since the first step of ocrWF or speechToTextWF opens a new version, we want this new WF to be associated
+          #       with the next object version (the current version is about to be closed)
+          # 2. we need to pass in any existing workflow version context from the previous version because it can contain
+          #       user provided values (such as language selection)
+          workflow_service.create_workflow_by_name(druid, workflow_name, version: (current_version.to_i + 1), lane_id:, context: workflow.context)
         end
 
         # This returns any optional dissemination workflow such as wasDisseminationWF

--- a/lib/robots/dor_repo/ocr/xml_ticket_create.rb
+++ b/lib/robots/dor_repo/ocr/xml_ticket_create.rb
@@ -13,7 +13,7 @@ module Robots
         def perform_work
           workflow_context = workflow.context
           filepaths = Dor::TextExtraction::Ocr.new(cocina_object:, workflow_context:).filenames_to_ocr
-          Dor::TextExtraction::Abbyy::Ticket.new(filepaths:, druid:, ocr_languages: workflow_context[:ocrLanguages]).write_xml
+          Dor::TextExtraction::Abbyy::Ticket.new(filepaths:, druid:, ocr_languages: workflow_context['ocrLanguages']).write_xml
         end
       end
     end

--- a/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_multilingual.xml
+++ b/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_multilingual.xml
@@ -1,0 +1,34 @@
+<?xml version='1.0'?>
+<XmlTicket>
+    <RecognitionParams RecognitionQuality='Balanced' RecognitionMode='FullPage'
+        UsePullXTextAndRecognizeRest='false' LanguageDetectMode='Always'>
+        <TextType>Normal</TextType>
+        <Language>Spanish</Language>
+        <Language>Russian</Language>
+    </RecognitionParams>
+    <ExportParams XMLResultPublishingMethod='XMLResultToFolder'>
+        <ExportFormat OutputFileFormat='PDFA' OutputFlowType='SharedFolder'
+            PdfAComplianceMode='PDFAM_PdfA_2u' PdfVersion='Version17'
+            Scenario='MaxQuality' UseImprovedCompression='true' MRCMode='Normal'
+            PdfUACompatible='true'>
+            <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
+            <FileExistsAction>Overwrite</FileExistsAction>
+            <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+        </ExportFormat>
+        <ExportFormat OutputFileFormat='ALTO' OutputFlowType='SharedFolder' FormatVersion='3_1'
+            CoordinatesParticularity='Words' WriteWordConfidence='true'>
+            <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
+            <FileExistsAction>Overwrite</FileExistsAction>
+            <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+        </ExportFormat>
+        <ExportFormat OutputFileFormat='Text' OutputFlowType='SharedFolder' EncodingType='UTF8'>
+            <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
+            <FileExistsAction>Overwrite</FileExistsAction>
+            <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+        </ExportFormat>
+        <XMLResultLocation>S:\AbbyyShare\sdr-ocr-qa\RESULTXML</XMLResultLocation>
+    </ExportParams>
+    <InputFile Name='bb222cc3333\filename1.jp2' />
+    <InputFile Name='bb222cc3333\filename2.jp2' />
+    <InputFile Name='bb222cc3333\filename3.jp2' />
+</XmlTicket>

--- a/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_multilingual.xml
+++ b/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_multilingual.xml
@@ -1,5 +1,8 @@
 <?xml version='1.0'?>
 <XmlTicket>
+    <ImageProcessingProfile>
+        <ImageOperation Operation='Rotate' RotationType='Automatic' />
+    </ImageProcessingProfile>
     <RecognitionParams RecognitionQuality='Balanced' RecognitionMode='FullPage'
         UsePullXTextAndRecognizeRest='false' LanguageDetectMode='Always'>
         <TextType>Normal</TextType>
@@ -15,7 +18,7 @@
             <FileExistsAction>Overwrite</FileExistsAction>
             <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
         </ExportFormat>
-        <ExportFormat OutputFileFormat='ALTO' OutputFlowType='SharedFolder' FormatVersion='3_1'
+        <ExportFormat OutputFileFormat='ALTO' WriteOriginalImageCoordinates='true' OutputFlowType='SharedFolder' FormatVersion='3_1'
             CoordinatesParticularity='Words' WriteWordConfidence='true'>
             <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
             <FileExistsAction>Overwrite</FileExistsAction>

--- a/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_spanish.xml
+++ b/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_spanish.xml
@@ -1,0 +1,32 @@
+<?xml version='1.0'?>
+<XmlTicket>
+    <RecognitionParams RecognitionQuality='Balanced' RecognitionMode='FullPage' UsePullXTextAndRecognizeRest='false' LanguageDetectMode='Always'>
+        <TextType>Normal</TextType>
+        <Language>Spanish</Language>
+    </RecognitionParams>
+    <ExportParams XMLResultPublishingMethod='XMLResultToFolder'>
+        <ExportFormat OutputFileFormat='PDFA' OutputFlowType='SharedFolder'
+            PdfAComplianceMode='PDFAM_PdfA_2u' PdfVersion='Version17'
+            Scenario='MaxQuality' UseImprovedCompression='true' MRCMode='Normal'
+            PdfUACompatible='true'>
+            <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
+            <FileExistsAction>Overwrite</FileExistsAction>
+            <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+        </ExportFormat>
+        <ExportFormat OutputFileFormat='ALTO' OutputFlowType='SharedFolder' FormatVersion='3_1'
+            CoordinatesParticularity='Words' WriteWordConfidence='true'>
+            <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
+            <FileExistsAction>Overwrite</FileExistsAction>
+            <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+        </ExportFormat>
+        <ExportFormat OutputFileFormat='Text' OutputFlowType='SharedFolder' EncodingType='UTF8'>
+            <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
+            <FileExistsAction>Overwrite</FileExistsAction>
+            <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
+        </ExportFormat>
+        <XMLResultLocation>S:\AbbyyShare\sdr-ocr-qa\RESULTXML</XMLResultLocation>
+    </ExportParams>
+    <InputFile Name='bb222cc3333\filename1.jp2' />
+    <InputFile Name='bb222cc3333\filename2.jp2' />
+    <InputFile Name='bb222cc3333\filename3.jp2' />
+</XmlTicket>

--- a/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_spanish.xml
+++ b/spec/fixtures/ocr/bb222cc3333_abbyy_ticket_spanish.xml
@@ -1,5 +1,8 @@
 <?xml version='1.0'?>
 <XmlTicket>
+    <ImageProcessingProfile>
+        <ImageOperation Operation='Rotate' RotationType='Automatic' />
+    </ImageProcessingProfile>
     <RecognitionParams RecognitionQuality='Balanced' RecognitionMode='FullPage' UsePullXTextAndRecognizeRest='false' LanguageDetectMode='Always'>
         <TextType>Normal</TextType>
         <Language>Spanish</Language>
@@ -13,7 +16,7 @@
             <FileExistsAction>Overwrite</FileExistsAction>
             <NamingRule>bb222cc3333.&lt;Ext&gt;</NamingRule>
         </ExportFormat>
-        <ExportFormat OutputFileFormat='ALTO' OutputFlowType='SharedFolder' FormatVersion='3_1'
+        <ExportFormat OutputFileFormat='ALTO' WriteOriginalImageCoordinates='true' OutputFlowType='SharedFolder' FormatVersion='3_1'
             CoordinatesParticularity='Words' WriteWordConfidence='true'>
             <OutputLocation>S:\AbbyyShare\sdr-ocr-qa\OUTPUT/bb222cc3333</OutputLocation>
             <FileExistsAction>Overwrite</FileExistsAction>

--- a/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/ticket_spec.rb
@@ -33,6 +33,24 @@ describe Dor::TextExtraction::Abbyy::Ticket do
       abbyy.write_xml
       expect(File.exist?(abbyy.file_path)).to be true
     end
+
+    context 'when a language is provided' do
+      let(:ocr_languages) { ['Spanish'] }
+      let(:fixture_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{bare_druid}_abbyy_ticket_spanish.xml") }
+
+      it 'creates xml for files for images with a single language' do
+        expect(ticket_xml).to be_equivalent_to File.read(fixture_path)
+      end
+    end
+
+    context 'when multiple languages are provided' do
+      let(:ocr_languages) { %w[Spanish Russian] }
+      let(:fixture_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{bare_druid}_abbyy_ticket_multilingual.xml") }
+
+      it 'creates xml for files for images with multiple languages' do
+        expect(ticket_xml).to be_equivalent_to File.read(fixture_path)
+      end
+    end
   end
 
   context 'when the files have hierarchy' do

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
           it 'does not start ocrWF' do
             perform
-            expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default')
+            expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default', context:)
           end
         end
 
@@ -54,7 +54,18 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
           it 'starts ocrWF' do
             perform
-            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default')
+            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default', context:)
+          end
+        end
+
+        context 'when is required and possible and has incoming workflow context' do
+          let(:possible) { true }
+          let(:required) { true }
+          let(:context) { { 'requireOCR' => true, 'ocrLanguages' => ['Russian'] } }
+
+          it 'starts ocrWF' do
+            perform
+            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default', context:)
           end
         end
 
@@ -77,7 +88,7 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
           it 'does not start speechToTextWF' do
             perform
-            expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', version: 2, lane_id: 'default')
+            expect(workflow_client).not_to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', version: 2, lane_id: 'default', context:)
           end
         end
 
@@ -87,7 +98,7 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
 
           it 'starts speechToTextWF' do
             perform
-            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', version: 2, lane_id: 'default')
+            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', version: 2, lane_id: 'default', context:)
           end
         end
 

--- a/spec/robots/dor_repo/accession/end_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/end_accession_spec.rb
@@ -61,11 +61,12 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
         context 'when is required and possible and has incoming workflow context' do
           let(:possible) { true }
           let(:required) { true }
-          let(:context) { { 'requireOCR' => true, 'ocrLanguages' => ['Russian'] } }
+          let(:context) { { 'runOCR' => true, 'ocrLanguages' => ['Russian'] } }
+          let(:incoming_context) { { 'ocrLanguages' => ['Russian'] } }
 
-          it 'starts ocrWF' do
+          it 'starts ocrWF but removes runOCR from context' do
             perform
-            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default', context:)
+            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'ocrWF', version: 2, lane_id: 'default', context: incoming_context)
           end
         end
 
@@ -99,6 +100,18 @@ RSpec.describe Robots::DorRepo::Accession::EndAccession do
           it 'starts speechToTextWF' do
             perform
             expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', version: 2, lane_id: 'default', context:)
+          end
+        end
+
+        context 'when is required and possible and has incoming workflow context' do
+          let(:possible) { true }
+          let(:required) { true }
+          let(:context) { { 'runSpeechToText' => true, 'ocrLanguages' => ['Russian'] } }
+          let(:incoming_context) { { 'ocrLanguages' => ['Russian'] } }
+
+          it 'starts ocrWF but removes runSpeechToText from context' do
+            perform
+            expect(workflow_client).to have_received(:create_workflow_by_name).with(druid, 'speechToTextWF', version: 2, lane_id: 'default', context: incoming_context)
           end
         end
 

--- a/spec/robots/dor_repo/ocr/xml_ticket_create_spec.rb
+++ b/spec/robots/dor_repo/ocr/xml_ticket_create_spec.rb
@@ -43,7 +43,7 @@ describe Robots::DorRepo::Ocr::XmlTicketCreate do
   context 'when robot has user inputed languages' do
     let(:bare_druid) { 'bc123df4567' }
     let(:druid) { "druid:#{bare_druid}" }
-    let(:workflow_context) { { runOCR: true, ocrLanguages: %w[English Spanish German] } }
+    let(:workflow_context) { { 'runOCR' => true, 'ocrLanguages' => %w[English Spanish German] } }
     let(:filenames) { ['filename3.PDF', 'filename4.pdf'] }
     let(:object_type) { Cocina::Models::ObjectType.document }
 


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes https://github.com/sul-dlss/common-accessioning/issues/1495 

1. We need to ensure that when the new version is created with the captioning workflow (be it ocrWF or speechToTextWF), so we are preserving the workflow context from the previous version.  This is because pre-assembly will have set this version context (i.e. the  language selection) in v1, and we need this in the next version so that the ocr/speechToText workflows can use it when running.
2. Add some new specs to verify the abbyy ticket that is created has the languages passed in from the workflow context
3. Fix rubocop deprecation warnings and add new cops

~~HOLD:~~
~~- test again~~
~~- remove TODO debug lines~~
~~- rebase https://github.com/sul-dlss/common-accessioning/pull/1516 and then adjust new fixture files here~~

## How was this change tested? 🤨

Specs
Integration test
Manually on QA