### PR TITLE
Handles dark files when auditing in start-accession.

### DIFF
--- a/lib/robots/dor_repo/accession/start_accession.rb
+++ b/lib/robots/dor_repo/accession/start_accession.rb
@@ -37,8 +37,10 @@ module Robots
         end
 
         # @return [Array<String>] list of files that are missing from staging, workspace, and preservation
-        def audit_files
+        def audit_files # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrrics/PerceivedComplexity
           cocina_files.filter_map do |file|
+            # Files that are dark (not published or shelved) are not accessioned.
+            next unless file.administrative.publish || file.administrative.shelve
             # Every file should be in staging, workspace, shelf, or preservation.
             next if check_file(dir_pathname: staging_pathname, file: file)
             next if check_file(dir_pathname: workspace_pathname, file: file)

--- a/lib/robots/dor_repo/accession/start_accession.rb
+++ b/lib/robots/dor_repo/accession/start_accession.rb
@@ -37,7 +37,7 @@ module Robots
         end
 
         # @return [Array<String>] list of files that are missing from staging, workspace, and preservation
-        def audit_files # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrrics/PerceivedComplexity
+        def audit_files # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           cocina_files.filter_map do |file|
             # Files that are dark (not published or shelved) are not accessioned.
             next unless file.administrative.publish || file.administrative.shelve

--- a/spec/robots/dor_repo/accession/start_accession_spec.rb
+++ b/spec/robots/dor_repo/accession/start_accession_spec.rb
@@ -149,6 +149,28 @@ RSpec.describe Robots::DorRepo::Accession::StartAccession do
                   }
                 ]
               }
+            },
+            # This file is unshelved and unpreserved. Therefore, it should not be present.
+            {
+              externalIdentifier: '226',
+              type: Cocina::Models::FileSetType.file,
+              label: 'my unshelved and unpreserved repository object',
+              version: 1,
+              structural: {
+                contains: [
+                  {
+                    externalIdentifier: '226-1',
+                    label: 'folder1PuSu/story1u.jp2',
+                    filename: 'folder1PuSu/story1u.jp2',
+                    type: Cocina::Models::ObjectType.file,
+                    version: 1,
+                    access: {},
+                    size: 7888,
+                    administrative: { publish: false, sdrPreserve: false, shelve: false },
+                    hasMessageDigests: [{ type: 'md5', digest: '123' }]
+                  }
+                ]
+              }
             }
           ],
           hasMemberOrders: [],


### PR DESCRIPTION
## Why was this change made? 🤔
Auditing was failing for dark files.


## How was this change tested? 🤨
Unit

⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


