### PR TITLE
Create releaseWF for members not the collection.

### DIFF
--- a/lib/robots/dor_repo/release/release_members.rb
+++ b/lib/robots/dor_repo/release/release_members.rb
@@ -29,7 +29,8 @@ module Robots
         end
 
         def published?(member)
-          object_client.milestones.date(milestone_name: 'published', version: member.version).present?
+          # This is for the member, not the parent collection.
+          Dor::Services::Client.object(member.externalIdentifier).milestones.date(milestone_name: 'published', version: member.version).present?
         end
 
         # Here's an example of the kinds of tags we're dealing with:
@@ -43,7 +44,8 @@ module Robots
         end
 
         def create_release_workflow(member)
-          object_workflow.create(version: member.version, lane_id:)
+          # This is for the member, not the parent collection.
+          Dor::Services::Client.object(member.externalIdentifier).workflow('releaseWF').create(version: member.version, lane_id:)
         end
       end
     end


### PR DESCRIPTION
## Why was this change made? 🤔
releaseWF was being created for the collection, not the members. This was causing widespread mayhem.

## How was this change tested? 🤨
Unit
⚡ ⚠ If this change has cross service impact, including writes to shared file systems, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** and/or test in [stage|qa] environment, in addition to specs. ⚡


