### PR TITLE
use object access rights when adding ocr/speech to text files

### DIFF
--- a/lib/dor/text_extraction/cocina_updater.rb
+++ b/lib/dor/text_extraction/cocina_updater.rb
@@ -201,10 +201,11 @@ module Dor
         nil
       end
 
+      # you can override this in a subclass to set the access attributes conditionally if needed, otherwise uses object default
       def access
         {
-          view: 'world',
-          download: 'world'
+          view: dro.access.view,
+          download: dro.access.download
         }
       end
 

--- a/spec/lib/dor/text_extraction/cocina_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/cocina_updater_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dor::TextExtraction::CocinaUpdater do
 
   let(:druid) { 'druid:bc123df4567' }
   let(:object_type) { Cocina::Models::ObjectType.image }
-  let(:dro) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, version: 1, type: object_type, structural:) }
+  let(:dro) { instance_double(Cocina::Models::DRO, externalIdentifier: druid, dro?: true, version: 1, type: object_type, structural:, access:) }
   let(:logger) { instance_double(Logger) }
   let(:path) { "/some/server/path/#{filename}" }
   let(:tiff_file) { instance_double(Cocina::Models::File, filename: 'file1.tiff') }
@@ -17,6 +17,25 @@ RSpec.describe Dor::TextExtraction::CocinaUpdater do
   let(:tiff_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [tiff_file]) }
   let(:other_tiff_fileset_structural) { instance_double(Cocina::Models::FileSetStructural, contains: [other_tiff_file]) }
   let(:structural) { instance_double(Cocina::Models::DROStructural, contains: [tiff_fileset, other_tiff_fileset]) }
+  let(:access) { instance_double(Cocina::Models::DROAccess, view:, download:) }
+  let(:download) { 'world' }
+  let(:view) { 'world' }
+
+  describe '#access' do
+    context 'when object has world/world rights' do
+      it 'sets world/world for all new files' do
+        expect(updater.send(:access)).to eq({ download: 'world', view: 'world' })
+      end
+    end
+
+    context 'when object has stanford/world rights' do
+      let(:download) { 'stanford' }
+
+      it 'sets stanford/world for all new files' do
+        expect(updater.send(:access)).to eq({ download: 'stanford', view: 'world' })
+      end
+    end
+  end
 
   describe '#find_resource_with_stem' do
     context 'when file has matching stem' do

--- a/spec/lib/dor/text_extraction/ocr_cocina_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_cocina_updater_spec.rb
@@ -11,11 +11,15 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
   let(:dro) do
     build(:dro, id: druid).new(
       type: item_type,
+      access: { download:, view: },
       structural: {
         contains: original_resources
       }
     )
   end
+  let(:download) { 'world' }
+  let(:view) { 'world' }
+
   # DruidTools needs to return the workspace_dir set up by "with workspace dir" context
   let(:druid_tools) do
     instance_double(DruidTools::Druid, id: bare_druid, content_dir: workspace_content_dir)
@@ -42,7 +46,8 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 filename: 'image1.tif',
-                hasMimeType: 'image/tiff'
+                hasMimeType: 'image/tiff',
+                access: { download: 'world', view: 'world' }
               }
             ]
           }
@@ -142,7 +147,8 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 filename: 'image1.tif',
-                hasMimeType: 'image/tiff'
+                hasMimeType: 'image/tiff',
+                access: { download: 'world', view: 'world' }
               }
             ]
           }
@@ -160,7 +166,8 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 filename: 'image2.tif',
-                hasMimeType: 'image/tiff'
+                hasMimeType: 'image/tiff',
+                access: { download: 'world', view: 'world' }
               }
             ]
           }
@@ -237,7 +244,8 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 filename: 'page_001.tif',
-                hasMimeType: 'image/tiff'
+                hasMimeType: 'image/tiff',
+                access: { download: 'world', view: 'world' }
               }
             ]
           }
@@ -255,7 +263,8 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 filename: 'page_002.tif',
-                hasMimeType: 'image/tiff'
+                hasMimeType: 'image/tiff',
+                access: { download: 'world', view: 'world' }
               }
             ]
           }
@@ -304,6 +313,21 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
       expect(resource.label).to eq 'Plain text OCR (uncorrected)'
       expect(resource.type).to eq Cocina::Models::FileSetType.object
       expect(resource.structural.contains[0].filename).to eq "#{bare_druid}.txt"
+    end
+
+    context 'when object access rights are restricted' do
+      let(:download) { 'stanford' }
+      let(:view) { 'stanford' }
+
+      it 'sets the file level access rights to restricted' do
+        expect(dro.structural.contains[0].structural.contains[0].access.view).to eq('world') # original file can have different rights
+        expect(dro.structural.contains[0].structural.contains[1].access.view).to eq('stanford') # new files below
+        expect(dro.structural.contains[0].structural.contains[2].access.view).to eq('stanford')
+        expect(dro.structural.contains[1].structural.contains[0].access.view).to eq('world') # original file can have different rights
+        expect(dro.structural.contains[1].structural.contains[1].access.view).to eq('stanford') # new files below
+        expect(dro.structural.contains[1].structural.contains[2].access.view).to eq('stanford')
+        expect(dro.structural.contains[2].structural.contains[0].access.view).to eq('stanford')
+      end
     end
   end
 

--- a/spec/lib/dor/text_extraction/speech_to_text_cocina_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_cocina_updater_spec.rb
@@ -11,12 +11,15 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
   let(:dro) do
     build(:dro, id: druid).new(
       type: item_type,
+      access: { download:, view: },
       structural: {
         contains: original_resources
       }
     )
   end
   let(:item_type) { Cocina::Models::ObjectType.media }
+  let(:download) { 'world' }
+  let(:view) { 'world' }
 
   # DruidTools needs to return the workspace_dir set up by "with workspace dir" context
   let(:druid_tools) do
@@ -44,7 +47,8 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 filename: 'file_1.mp4',
-                hasMimeType: 'video/mp4'
+                hasMimeType: 'video/mp4',
+                access: { download: 'world', view: 'world' }
               }
             ]
           }
@@ -62,7 +66,8 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
                 type: Cocina::Models::ObjectType.file,
                 version: 1,
                 filename: 'file_1.m4a',
-                hasMimeType: 'audio/m4a'
+                hasMimeType: 'audio/m4a',
+                access: { download: 'world', view: 'world' }
               }
             ]
           }
@@ -221,6 +226,28 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
       expect(file.administrative.shelve).to be true
       expect(file.hasMimeType).to eq 'text/vtt'
       expect(file.languageTag).to eq 'es'
+    end
+
+    context 'when object access rights are restricted' do
+      let(:download) { 'stanford' }
+      let(:view) { 'stanford' }
+
+      it 'sets the file level access rights to restricted' do
+        expect(resource1_files[0].access.view).to eq('world') # original file can have different rights
+        expect(resource1_files[1].access.view).to eq('stanford') # new files below
+        expect(resource1_files[2].access.view).to eq('stanford')
+        expect(resource1_files[3].access.view).to eq('stanford')
+        expect(resource1_files[1].access.download).to eq('stanford')
+        expect(resource1_files[2].access.download).to eq('stanford')
+        expect(resource1_files[3].access.download).to eq('stanford')
+        expect(resource2_files[0].access.view).to eq('world') # original file can have different rights
+        expect(resource2_files[1].access.view).to eq('stanford') # new files below
+        expect(resource2_files[2].access.view).to eq('stanford')
+        expect(resource2_files[3].access.view).to eq('stanford')
+        expect(resource2_files[1].access.download).to eq('stanford')
+        expect(resource2_files[2].access.download).to eq('stanford')
+        expect(resource2_files[3].access.download).to eq('stanford')
+      end
     end
     # rubocop:enable RSpec/ExampleLength
   end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #1536 - access rights for new files generated by OCR/speech-to-text should match the default object rights, and not "world/world"


## How was this change tested? 🤨

New specs

Todo:
 - [x] run integration tests
 - [x] run other tests on stage