### PR TITLE
Splitting of ALTO XML should work when there is a mismatch in the alto file

### DIFF
--- a/lib/robots/dor_repo/ocr/split_ocr_xml.rb
+++ b/lib/robots/dor_repo/ocr/split_ocr_xml.rb
@@ -15,7 +15,7 @@ module Robots
           alto_path = File.join(base_output_path, "#{bare_druid}.xml")
           return LyberCore::ReturnState.new(status: :skipped, note: 'No full object XML file') unless File.exist?(alto_path)
 
-          Dor::TextExtraction::Abbyy::SplitAlto.new(alto_path:).write_files
+          Dor::TextExtraction::Abbyy::SplitAlto.new(alto_path:, logger:).write_files
         end
       end
     end

--- a/spec/fixtures/ocr/bb222cc3333_abbyy_alto_fewer_files.xml
+++ b/spec/fixtures/ocr/bb222cc3333_abbyy_alto_fewer_files.xml
@@ -1,0 +1,3127 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v3#" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.loc.gov/standards/alto/ns-v3# http://www.loc.gov/alto/v3/alto-3-1.xsd">
+    <Description>
+        <MeasurementUnit>pixel</MeasurementUnit>
+        <sourceImageInformation>
+            <fileIdentifier>bb222cc3333_00_0001.tif</fileIdentifier>
+            <fileIdentifier>bb222cc3333_00_0002.tif</fileIdentifier>
+        </sourceImageInformation>
+        <OCRProcessing ID="IdOcr">
+            <ocrProcessingStep>
+                <processingDateTime>2024-05-14</processingDateTime>
+                <processingSoftware>
+                    <softwareCreator>ABBYY</softwareCreator>
+                    <softwareName>ABBYY FineReader Server</softwareName>
+                    <softwareVersion>14.0</softwareVersion>
+                </processingSoftware>
+            </ocrProcessingStep>
+        </OCRProcessing>
+    </Description>
+    <Styles>
+        <ParagraphStyle ID="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." LINESPACE="12.719999313354492" />
+        <ParagraphStyle ID="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." LINESPACE="10.909999847412109" />
+        <ParagraphStyle ID="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." LINESPACE="9.9200000762939453" />
+        <ParagraphStyle ID="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." LINESPACE="12.719999313354492" />
+        <ParagraphStyle ID="StyleId-579500E1-308F-4B83-B9ED-DE8E7E9C7282-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="28." LINESPACE="18.399999618530273" />
+        <ParagraphStyle ID="StyleId-B4146B38-739B-475D-888D-EDF33A4315F9-" ALIGN="Left" LEFT="0."
+            RIGHT="9.5" FIRSTLINE="0." LINESPACE="20.69999885559082" />
+        <ParagraphStyle ID="StyleId-3AE23056-D223-4C13-8810-C00D458ECDD5-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." LINESPACE="32.200000762939453" />
+        <ParagraphStyle ID="StyleId-FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." />
+        <ParagraphStyle ID="StyleId-DD7FABF2-64E0-4458-A002-DC066A1FE17B-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." />
+        <ParagraphStyle ID="StyleId-62986A33-7515-4E99-BCAB-3719BD0078D1-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." />
+        <ParagraphStyle ID="StyleId-81DAF23E-7B97-4A45-98B5-D886E9874B1F-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." />
+        <ParagraphStyle ID="StyleId-D1D3A353-9161-4671-98E1-DD7B9D990438-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." />
+        <ParagraphStyle ID="StyleId-44B0F6CE-B77C-4378-B4F7-1CCA36C002B3-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." />
+        <ParagraphStyle ID="StyleId-D40750C1-ED42-4B5E-A658-06B58631CB5D-" ALIGN="Left" LEFT="0."
+            RIGHT="0." FIRSTLINE="0." />
+    </Styles>
+    <Layout>
+        <Page ID="Page1" PHYSICAL_IMG_NR="1" HEIGHT="10698" WIDTH="6927">
+            <TopMargin HEIGHT="683" WIDTH="6927" VPOS="0" HPOS="0">
+</TopMargin>
+            <LeftMargin HEIGHT="9699" WIDTH="542" VPOS="683" HPOS="0">
+</LeftMargin>
+            <RightMargin HEIGHT="9699" WIDTH="445" VPOS="683" HPOS="6482">
+</RightMargin>
+            <BottomMargin HEIGHT="316" WIDTH="6927" VPOS="10382" HPOS="0">
+</BottomMargin>
+            <PrintSpace HEIGHT="9699" WIDTH="5940" VPOS="683" HPOS="542">
+                <TextBlock ID="Page1_Block1" HEIGHT="1308" WIDTH="2390" VPOS="684" HPOS="606"
+                    LANG="en-US" STYLEREFS="StyleId-B4146B38-739B-475D-888D-EDF33A4315F9-">
+                    <TextLine BASELINE="823" HEIGHT="172" WIDTH="2282" VPOS="697" HPOS="693">
+                        <String WC="0.22750000655651093" CONTENT="Send" HEIGHT="122" WIDTH="384"
+                            VPOS="709" HPOS="693" />
+                        <SP HEIGHT="104" WIDTH="50" VPOS="721" HPOS="1078" />
+                        <String WC="0.36666667461395264" CONTENT="check." HEIGHT="112" WIDTH="424"
+                            VPOS="713" HPOS="1129" />
+                        <SP HEIGHT="74" WIDTH="40" VPOS="747" HPOS="1554" />
+                        <String WC="0.41499999165534973" CONTENT="or" HEIGHT="74" WIDTH="154"
+                            VPOS="747" HPOS="1595" />
+                        <SP HEIGHT="72" WIDTH="62" VPOS="745" HPOS="1750" />
+                        <String WC="0.57181817293167114" CONTENT="m0x\c^order" HEIGHT="142"
+                            WIDTH="882" VPOS="727" HPOS="1813" />
+                        <SP HEIGHT="140" WIDTH="50" VPOS="697" HPOS="2696" />
+                        <String WC="0.54333335161209106" CONTENT="Ao*" HEIGHT="146" WIDTH="228"
+                            VPOS="697" HPOS="2747" />
+                    </TextLine>
+                    <TextLine BASELINE="1246" HEIGHT="118" WIDTH="2290" VPOS="1153" HPOS="621"
+                        LANG="de">
+                        <String WC="0.45399999618530273" CONTENT="NAHE." HEIGHT="110" WIDTH="446"
+                            VPOS="1153" HPOS="621" />
+                        <String WC="0.2800000011920929" LANG="en-US" CONTENT="," HEIGHT="30"
+                            WIDTH="18" VPOS="1237" HPOS="1113" />
+                        <SP HEIGHT="26" WIDTH="1782" VPOS="1245" HPOS="1129" />
+                    </TextLine>
+                    <TextLine BASELINE="1484" HEIGHT="142" WIDTH="2312" VPOS="1373" HPOS="619">
+                        <String WC="0.56999999284744263" LANG="en-US" CONTENT="ADD®" HEIGHT="118"
+                            WIDTH="384" VPOS="1373" HPOS="619" />
+                        <SP HEIGHT="102" WIDTH="18" VPOS="1387" HPOS="1004" />
+                        <String WC="0.47499999403953552" LANG="fr" CONTENT="ES" HEIGHT="90"
+                            WIDTH="176" VPOS="1395" HPOS="1023" />
+                        <SP HEIGHT="96" WIDTH="18" VPOS="1395" HPOS="1200" />
+                        <String WC="0.81000000238418579" LANG="en-US" CONTENT="S" HEIGHT="96"
+                            WIDTH="82" VPOS="1395" HPOS="1219" />
+                        <SP HEIGHT="30" WIDTH="1614" VPOS="1485" HPOS="1317" />
+                    </TextLine>
+                    <TextLine BASELINE="1976" HEIGHT="80" WIDTH="210" VPOS="1901" HPOS="2475"
+                        STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                        <String WC="0.43999999761581421" CONTENT="Z3P" HEIGHT="80" WIDTH="210"
+                            VPOS="1901" HPOS="2475" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page1_Block2" HEIGHT="512" WIDTH="1958" VPOS="712" HPOS="3158"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="826" HEIGHT="122" WIDTH="1932" VPOS="725" HPOS="3173">
+                        <String WC="1." CONTENT="PEOPLE’S" HEIGHT="108" WIDTH="596" VPOS="725"
+                            HPOS="3173" />
+                        <SP HEIGHT="96" WIDTH="60" VPOS="733" HPOS="3770" />
+                        <String WC="0.20874999463558197" CONTENT="CGWPUXGQ" HEIGHT="102" WIDTH="644"
+                            VPOS="733" HPOS="3831" />
+                        <SP HEIGHT="100" WIDTH="48" VPOS="731" HPOS="4476" />
+                        <String WC="1." CONTENT="COMPANY" HEIGHT="116" WIDTH="580" VPOS="731"
+                            HPOS="4525" />
+                    </TextLine>
+                    <TextLine BASELINE="949" HEIGHT="136" WIDTH="750" VPOS="861" HPOS="3171">
+                        <String WC="0.35333332419395447" CONTENT="Ojo" HEIGHT="136" WIDTH="170"
+                            VPOS="861" HPOS="3171" />
+                        <SP HEIGHT="88" WIDTH="74" VPOS="865" HPOS="3342" />
+                        <String WC="0.50249999761581421" CONTENT="WtA^" HEIGHT="92" WIDTH="504"
+                            VPOS="865" HPOS="3417" />
+                    </TextLine>
+                    <TextLine BASELINE="1069" HEIGHT="100" WIDTH="784" VPOS="977" HPOS="3173">
+                        <String WC="0.60500001907348633" CONTENT="P.O." HEIGHT="86" WIDTH="202"
+                            VPOS="983" HPOS="3173" />
+                        <SP HEIGHT="94" WIDTH="52" VPOS="977" HPOS="3376" />
+                        <String WC="0.36000001430511475" CONTENT="Box" HEIGHT="100" WIDTH="250"
+                            VPOS="977" HPOS="3429" />
+                        <SP HEIGHT="86" WIDTH="68" VPOS="991" HPOS="3680" />
+                        <String WC="0.41999998688697815" CONTENT="3X0" HEIGHT="80" WIDTH="208"
+                            VPOS="991" HPOS="3749" />
+                    </TextLine>
+                    <TextLine BASELINE="1189" HEIGHT="128" WIDTH="1526" VPOS="1085" HPOS="3197">
+                        <String WC="0.91600000858306885" CONTENT="Menlo" HEIGHT="94" WIDTH="352"
+                            VPOS="1103" HPOS="3197" />
+                        <SP HEIGHT="110" WIDTH="42" VPOS="1089" HPOS="3550" />
+                        <String WC="0.31799998879432678" CONTENT="Ikrtj" HEIGHT="124" WIDTH="384"
+                            VPOS="1089" HPOS="3593" />
+                        <SP HEIGHT="128" WIDTH="50" VPOS="1085" HPOS="3978" />
+                        <String WC="0.62000000476837158" CONTENT="Co.." HEIGHT="106" WIDTH="214"
+                            VPOS="1085" HPOS="4029" />
+                        <SP HEIGHT="98" WIDTH="56" VPOS="1103" HPOS="4244" />
+                        <String WC="1." CONTENT="94025" HEIGHT="98" WIDTH="422" VPOS="1103"
+                            HPOS="4301" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page1_Block3" HEIGHT="516" WIDTH="1248" VPOS="1422" HPOS="3350"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="1540" HEIGHT="118" WIDTH="1156" VPOS="1435" HPOS="3363">
+                        <String WC="0.5" LANG="en-US" CONTENT="^4" HEIGHT="112" WIDTH="194"
+                            VPOS="1441" HPOS="3363" />
+                        <SP HEIGHT="116" WIDTH="72" VPOS="1435" HPOS="3558" />
+                        <String WC="0.5" LANG="en-US" CONTENT="^r" HEIGHT="112" WIDTH="230"
+                            VPOS="1435" HPOS="3631" />
+                        <SP HEIGHT="86" WIDTH="58" VPOS="1455" HPOS="3862" />
+                        <String WC="0.2800000011920929" LANG="en-US" CONTENT="5" HEIGHT="84"
+                            WIDTH="86" VPOS="1455" HPOS="3921" />
+                        <SP HEIGHT="84" WIDTH="68" VPOS="1455" HPOS="4008" />
+                        <String WC="1." LANG="fr" CONTENT="ISSUS" HEIGHT="82" WIDTH="442"
+                            VPOS="1459" HPOS="4077" />
+                    </TextLine>
+                    <TextLine BASELINE="1666" HEIGHT="112" WIDTH="1162" VPOS="1575" HPOS="3389">
+                        <String WC="0.12250000238418579" CONTENT="each" HEIGHT="96" WIDTH="324"
+                            VPOS="1577" HPOS="3389" />
+                        <SP HEIGHT="96" WIDTH="76" VPOS="1577" HPOS="3714" />
+                        <String WC="0.33000001311302185" CONTENT="school" HEIGHT="90" WIDTH="442"
+                            VPOS="1575" HPOS="3791" />
+                        <SP HEIGHT="110" WIDTH="56" VPOS="1577" HPOS="4234" />
+                        <String WC="0.4166666567325592" CONTENT="v^r" HEIGHT="98" WIDTH="260"
+                            VPOS="1589" HPOS="4291" />
+                    </TextLine>
+                    <TextLine BASELINE="1898" HEIGHT="136" WIDTH="1210" VPOS="1791" HPOS="3377">
+                        <String WC="0.125" CONTENT="$5" HEIGHT="106" WIDTH="188" VPOS="1791"
+                            HPOS="3377" />
+                        <SP HEIGHT="90" WIDTH="44" VPOS="1803" HPOS="3566" />
+                        <String WC="0.30222222208976746" CONTENT="ooerseois" HEIGHT="78" WIDTH="610"
+                            VPOS="1819" HPOS="3611" />
+                        <SP HEIGHT="114" WIDTH="62" VPOS="1813" HPOS="4222" />
+                        <String WC="0.66666668653488159" CONTENT="^h^" HEIGHT="114" WIDTH="302"
+                            VPOS="1813" HPOS="4285" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page1_Block4" HEIGHT="470" WIDTH="4446" VPOS="2178" HPOS="600"
+                    STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="2333" HEIGHT="192" WIDTH="3192" VPOS="2189" HPOS="613">
+                        <String WC="0.55750000476837158" LANG="en-US" CONTENT="Mho^" HEIGHT="114"
+                            WIDTH="372" VPOS="2237" HPOS="613" />
+                        <SP HEIGHT="122" WIDTH="66" VPOS="2229" HPOS="986" />
+                        <String WC="0.75" LANG="en-US" CONTENT="Kina" HEIGHT="116" WIDTH="348"
+                            VPOS="2229" HPOS="1053" />
+                        <SP HEIGHT="120" WIDTH="46" VPOS="2231" HPOS="1402" />
+                        <String WC="0." LANG="en-US" CONTENT="9" HEIGHT="120" WIDTH="126"
+                            VPOS="2231" HPOS="1449" />
+                        <SP HEIGHT="120" WIDTH="48" VPOS="2231" HPOS="1576" />
+                        <String WC="0.28888890147209167" LANG="ru" CONTENT="едАмрикег" HEIGHT="138"
+                            WIDTH="616" VPOS="2235" HPOS="1625" />
+                        <SP HEIGHT="98" WIDTH="58" VPOS="2233" HPOS="2242" />
+                        <String WC="0.29499998688697815" LANG="en-US" CONTENT="do" HEIGHT="92"
+                            WIDTH="150" VPOS="2233" HPOS="2301" />
+                        <SP HEIGHT="108" WIDTH="62" VPOS="2261" HPOS="2452" />
+                        <String WC="0.56857144832611084" LANG="en-US" CONTENT="^ou.use" HEIGHT="112"
+                            WIDTH="498" VPOS="2257" HPOS="2515" />
+                        <SP HEIGHT="148" WIDTH="90" VPOS="2209" HPOS="3014" />
+                        <String WC="0.56749999523162842" LANG="en-US" CONTENT="(\i\)ou.do)?"
+                            HEIGHT="192" WIDTH="700" VPOS="2189" HPOS="3105" />
+                    </TextLine>
+                    <TextLine BASELINE="2589" HEIGHT="160" WIDTH="4022" VPOS="2473" HPOS="631">
+                        <String WC="0." LANG="en-US" CONTENT="A" HEIGHT="102" WIDTH="92" VPOS="2473"
+                            HPOS="631" />
+                        <SP HEIGHT="106" WIDTH="70" VPOS="2473" HPOS="724" />
+                        <String WC="0.20916666090488434" LANG="ru" CONTENT="зиЪъегЧрЛлоп"
+                            HEIGHT="128" WIDTH="860" VPOS="2483" HPOS="795" />
+                        <SP HEIGHT="94" WIDTH="58" VPOS="2487" HPOS="1656" />
+                        <String WC="0.5625" LANG="ru" CONTENT="^оЛь" HEIGHT="96" WIDTH="394"
+                            VPOS="2487" HPOS="1715" />
+                        <SP HEIGHT="90" WIDTH="60" VPOS="2499" HPOS="2110" />
+                        <String WC="0.76200002431869507" LANG="ru" CONTENT="^Ъх^е" HEIGHT="100"
+                            WIDTH="542" VPOS="2493" HPOS="2171" />
+                        <SP HEIGHT="90" WIDTH="54" VPOS="2499" HPOS="2714" />
+                        <String WC="0.5899999737739563" LANG="en-US" CONTENT="1.^" HEIGHT="92"
+                            WIDTH="232" VPOS="2493" HPOS="2769" />
+                        <SP HEIGHT="108" WIDTH="44" VPOS="2479" HPOS="3002" />
+                        <String WC="0.476666659116745" LANG="en-US" CONTENT="X^suie" HEIGHT="114"
+                            WIDTH="326" VPOS="2479" HPOS="3047" />
+                        <SP HEIGHT="80" WIDTH="68" VPOS="2513" HPOS="3374" />
+                        <String WC="0.125" LANG="en-US" CONTENT="cA" HEIGHT="110" WIDTH="120"
+                            VPOS="2473" HPOS="3443" />
+                        <SP HEIGHT="110" WIDTH="24" VPOS="2473" HPOS="3564" />
+                        <String WC="0.34000000357627869" LANG="en-US" CONTENT="-the" HEIGHT="102"
+                            WIDTH="224" VPOS="2495" HPOS="3589" />
+                        <SP HEIGHT="78" WIDTH="58" VPOS="2519" HPOS="3814" />
+                        <String WC="0.54500001668930054" LANG="en-US" CONTENT="schoo\" HEIGHT="110"
+                            WIDTH="400" VPOS="2493" HPOS="3873" />
+                        <SP HEIGHT="140" WIDTH="42" VPOS="2493" HPOS="4274" />
+                        <String WC="0.82499998807907104" LANG="ru" CONTENT="^^аг*." HEIGHT="106"
+                            WIDTH="336" VPOS="2527" HPOS="4317" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page1_Block5" HEIGHT="2186" WIDTH="3660" VPOS="2714" HPOS="542" />
+                <TextBlock ID="Page1_Block6" HEIGHT="218" WIDTH="1052" VPOS="3576" HPOS="4952"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="3659" HEIGHT="82" WIDTH="508" VPOS="3594" HPOS="5206">
+                        <String WC="0.87999999523162842" CONTENT="Sample" HEIGHT="80" WIDTH="276"
+                            VPOS="3596" HPOS="5206" />
+                        <SP HEIGHT="65" WIDTH="29" VPOS="3594" HPOS="5483" />
+                        <String WC="0.92500001192092896" CONTENT="Copy" HEIGHT="81" WIDTH="201"
+                            VPOS="3594" HPOS="5513" />
+                    </TextLine>
+                    <TextLine BASELINE="3768" HEIGHT="80" WIDTH="1026" VPOS="3703" HPOS="4964">
+                        <String WC="0.92166668176651001" CONTENT="Please" HEIGHT="67" WIDTH="217"
+                            VPOS="3705" HPOS="4964" />
+                        <SP HEIGHT="47" WIDTH="33" VPOS="3724" HPOS="5182" />
+                        <String WC="0.78374999761581421" CONTENT="consider" HEIGHT="66" WIDTH="315"
+                            VPOS="3705" HPOS="5216" />
+                        <SP HEIGHT="45" WIDTH="29" VPOS="3724" HPOS="5532" />
+                        <String WC="0.91909092664718628" CONTENT="subscribing" HEIGHT="80"
+                            WIDTH="428" VPOS="3703" HPOS="5562" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page1_Block7" HEIGHT="5190" WIDTH="5888" VPOS="5192" HPOS="594" />
+                <GraphicalElement ID="Page1_Block8" HEIGHT="20" WIDTH="1794" VPOS="1250" HPOS="1114" />
+                <GraphicalElement ID="Page1_Block9" HEIGHT="28" WIDTH="1612" VPOS="1486" HPOS="1318" />
+                <GraphicalElement ID="Page1_Block10" HEIGHT="22" WIDTH="1602" VPOS="1664"
+                    HPOS="1320" />
+                <GraphicalElement ID="Page1_Block11" HEIGHT="28" WIDTH="1600" VPOS="1848"
+                    HPOS="1316" />
+                <GraphicalElement ID="Page1_Block12" HEIGHT="16" WIDTH="1200" VPOS="2320"
+                    HPOS="3834" />
+                <GraphicalElement ID="Page1_Block13" HEIGHT="22" WIDTH="542" VPOS="5634" HPOS="4658" />
+                <GraphicalElement ID="Page1_Block14" HEIGHT="28" WIDTH="546" VPOS="5994" HPOS="4676" />
+                <GraphicalElement ID="Page1_Block15" HEIGHT="28" WIDTH="482" VPOS="6768" HPOS="4738" />
+                <GraphicalElement ID="Page1_Block16" HEIGHT="38" WIDTH="472" VPOS="7134" HPOS="4744" />
+                <GraphicalElement ID="Page1_Block17" HEIGHT="36" WIDTH="538" VPOS="7476" HPOS="4404" />
+                <GraphicalElement ID="Page1_Block18" HEIGHT="30" WIDTH="380" VPOS="7494" HPOS="3896" />
+                <GraphicalElement ID="Page1_Block19" HEIGHT="30" WIDTH="444" VPOS="7540" HPOS="3880" />
+                <GraphicalElement ID="Page1_Block20" HEIGHT="30" WIDTH="734" VPOS="7546" HPOS="4536" />
+                <GraphicalElement ID="Page1_Block21" HEIGHT="38" WIDTH="666" VPOS="7548" HPOS="3122" />
+                <GraphicalElement ID="Page1_Block22" HEIGHT="34" WIDTH="614" VPOS="7602" HPOS="3170" />
+                <GraphicalElement ID="Page1_Block23" HEIGHT="36" WIDTH="682" VPOS="7864" HPOS="4584" />
+                <GraphicalElement ID="Page1_Block24" HEIGHT="30" WIDTH="476" VPOS="8490" HPOS="3540" />
+                <GraphicalElement ID="Page1_Block25" HEIGHT="26" WIDTH="342" VPOS="8886" HPOS="4184" />
+                <GraphicalElement ID="Page1_Block26" HEIGHT="32" WIDTH="402" VPOS="9208" HPOS="3550" />
+                <GraphicalElement ID="Page1_Block27" HEIGHT="26" WIDTH="372" VPOS="9538" HPOS="3618" />
+                <GraphicalElement ID="Page1_Block28" HEIGHT="444" WIDTH="28" VPOS="7918" HPOS="1060" />
+                <GraphicalElement ID="Page1_Block29" HEIGHT="362" WIDTH="30" VPOS="4062" HPOS="1926" />
+                <GraphicalElement ID="Page1_Block30" HEIGHT="402" WIDTH="18" VPOS="6886" HPOS="1976" />
+                <GraphicalElement ID="Page1_Block31" HEIGHT="192" WIDTH="12" VPOS="8290" HPOS="2038" />
+                <GraphicalElement ID="Page1_Block32" HEIGHT="298" WIDTH="10" VPOS="7138" HPOS="2046" />
+                <GraphicalElement ID="Page1_Block33" HEIGHT="280" WIDTH="14" VPOS="9372" HPOS="2382" />
+                <GraphicalElement ID="Page1_Block34" HEIGHT="298" WIDTH="18" VPOS="8536" HPOS="4562" />
+                <GraphicalElement ID="Page1_Block35" HEIGHT="364" WIDTH="26" VPOS="7152" HPOS="4740" />
+                <GraphicalElement ID="Page1_Block36" HEIGHT="342" WIDTH="16" VPOS="7540" HPOS="5258" />
+            </PrintSpace>
+        </Page>
+        <Page ID="Page2" PHYSICAL_IMG_NR="2" HEIGHT="10698" WIDTH="6927">
+            <TopMargin HEIGHT="538" WIDTH="6927" VPOS="0" HPOS="0">
+</TopMargin>
+            <LeftMargin HEIGHT="10160" WIDTH="338" VPOS="538" HPOS="0">
+                <GraphicalElement ID="Page2_Block1" HEIGHT="36" WIDTH="338" VPOS="10588" HPOS="0" />
+            </LeftMargin>
+            <PrintSpace HEIGHT="10160" WIDTH="6589" VPOS="538" HPOS="338">
+                <TextBlock ID="Page2_Block2" HEIGHT="92" WIDTH="862" VPOS="1466" HPOS="4572"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="1542" HEIGHT="68" WIDTH="838" VPOS="1479" HPOS="4585">
+                        <String WC="1." CONTENT="WE" HEIGHT="60" WIDTH="124" VPOS="1479" HPOS="4585" />
+                        <SP HEIGHT="60" WIDTH="36" VPOS="1479" HPOS="4710" />
+                        <String WC="0.93333333730697632" CONTENT="DID" HEIGHT="58" WIDTH="158"
+                            VPOS="1483" HPOS="4747" />
+                        <SP HEIGHT="60" WIDTH="32" VPOS="1481" HPOS="4906" />
+                        <String WC="0.95999997854232788" CONTENT="THIS" HEIGHT="62" WIDTH="204"
+                            VPOS="1481" HPOS="4939" />
+                        <SP HEIGHT="58" WIDTH="36" VPOS="1485" HPOS="5144" />
+                        <String WC="0.98199999332427979" CONTENT="ISSUE" HEIGHT="62" WIDTH="242"
+                            VPOS="1485" HPOS="5181" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block3" HEIGHT="110" WIDTH="626" VPOS="4030" HPOS="338"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="4109" HEIGHT="84" WIDTH="496" VPOS="4043" HPOS="351">
+                        <String WC="0.87749999761581421" CONTENT="help" HEIGHT="84" WIDTH="162"
+                            VPOS="4043" HPOS="351" />
+                        <SP HEIGHT="60" WIDTH="30" VPOS="4067" HPOS="514" />
+                        <String WC="0.8399999737739563" CONTENT="us" HEIGHT="46" WIDTH="80"
+                            VPOS="4065" HPOS="545" />
+                        <SP HEIGHT="44" WIDTH="24" VPOS="4065" HPOS="626" />
+                        <String WC="0.86000001430511475" CONTENT="write" HEIGHT="66" WIDTH="196"
+                            VPOS="4043" HPOS="651" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block4" HEIGHT="420" WIDTH="1216" VPOS="2134" HPOS="4550"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="2210" HEIGHT="64" WIDTH="450" VPOS="2147" HPOS="4589">
+                        <String WC="0.73769229650497437" CONTENT="Contributors:" HEIGHT="64"
+                            WIDTH="450" VPOS="2147" HPOS="4589" />
+                    </TextLine>
+                    <TextLine BASELINE="2337" HEIGHT="88" WIDTH="1182" VPOS="2273" HPOS="4573">
+                        <String WC="0.72750002145767212" LANG="fr" CONTENT="Marc" HEIGHT="60"
+                            WIDTH="160" VPOS="2273" HPOS="4573" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="2275" HPOS="4734" />
+                        <String WC="1." CONTENT="LeBrun" HEIGHT="64" WIDTH="248" VPOS="2275"
+                            HPOS="4757" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="2279" HPOS="5006" />
+                        <String WC="0.77166664600372314" CONTENT="(cover" HEIGHT="68" WIDTH="204"
+                            VPOS="2279" HPOS="5033" />
+                        <SP HEIGHT="38" WIDTH="18" VPOS="2303" HPOS="5238" />
+                        <String WC="0.80750000476837158" CONTENT="art," HEIGHT="60" WIDTH="114"
+                            VPOS="2295" HPOS="5257" />
+                        <SP HEIGHT="56" WIDTH="18" VPOS="2305" HPOS="5372" />
+                        <String WC="0.75" CONTENT="page" HEIGHT="56" WIDTH="150" VPOS="2305"
+                            HPOS="5391" />
+                        <SP HEIGHT="56" WIDTH="24" VPOS="2285" HPOS="5542" />
+                        <String WC="1." CONTENT="2" HEIGHT="56" WIDTH="40" VPOS="2285" HPOS="5567" />
+                        <SP HEIGHT="58" WIDTH="22" VPOS="2285" HPOS="5608" />
+                        <String WC="0.9100000262260437" CONTENT="art)" HEIGHT="68" WIDTH="124"
+                            VPOS="2285" HPOS="5631" />
+                    </TextLine>
+                    <TextLine BASELINE="2428" HEIGHT="84" WIDTH="782" VPOS="2365" HPOS="4563">
+                        <String WC="0.85250002145767212" CONTENT="Jane" HEIGHT="64" WIDTH="152"
+                            VPOS="2365" HPOS="4563" />
+                        <SP HEIGHT="60" WIDTH="30" VPOS="2365" HPOS="4716" />
+                        <String WC="0.74599999189376831" CONTENT="n&apos;ood" HEIGHT="62"
+                            WIDTH="184" VPOS="2365" HPOS="4747" />
+                        <SP HEIGHT="70" WIDTH="28" VPOS="2369" HPOS="4932" />
+                        <String WC="0.81800001859664917" CONTENT="(page" HEIGHT="78" WIDTH="170"
+                            VPOS="2371" HPOS="4961" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="2375" HPOS="5132" />
+                        <String WC="0.97000002861022949" CONTENT="4" HEIGHT="56" WIDTH="38"
+                            VPOS="2375" HPOS="5161" />
+                        <SP HEIGHT="58" WIDTH="20" VPOS="2375" HPOS="5200" />
+                        <String WC="0.88249999284744263" CONTENT="art)" HEIGHT="68" WIDTH="124"
+                            VPOS="2375" HPOS="5221" />
+                    </TextLine>
+                    <TextLine BASELINE="2521" HEIGHT="88" WIDTH="918" VPOS="2455" HPOS="4575">
+                        <String WC="0.72333335876464844" CONTENT="Tom" HEIGHT="60" WIDTH="146"
+                            VPOS="2455" HPOS="4575" />
+                        <SP HEIGHT="58" WIDTH="24" VPOS="2459" HPOS="4722" />
+                        <String WC="0.76875001192092896" CONTENT="Albrecht" HEIGHT="62" WIDTH="292"
+                            VPOS="2459" HPOS="4747" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="2463" HPOS="5040" />
+                        <String WC="0.56199997663497925" CONTENT="(page" HEIGHT="80" WIDTH="172"
+                            VPOS="2463" HPOS="5067" />
+                        <SP HEIGHT="56" WIDTH="30" VPOS="2469" HPOS="5240" />
+                        <String WC="0.63499999046325684" CONTENT="15" HEIGHT="56" WIDTH="74"
+                            VPOS="2469" HPOS="5271" />
+                        <SP HEIGHT="56" WIDTH="26" VPOS="2469" HPOS="5346" />
+                        <String WC="0.94499999284744263" CONTENT="art)" HEIGHT="68" WIDTH="120"
+                            VPOS="2467" HPOS="5373" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block5" HEIGHT="414" WIDTH="950" VPOS="1640" HPOS="4566"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="1716" HEIGHT="64" WIDTH="692" VPOS="1655" HPOS="4587">
+                        <String WC="0.86333334445953369" CONTENT="BOB" HEIGHT="58" WIDTH="172"
+                            VPOS="1655" HPOS="4587" />
+                        <SP HEIGHT="58" WIDTH="30" VPOS="1655" HPOS="4760" />
+                        <String WC="0.99500000476837158" CONTENT="ALBRECHT" HEIGHT="62" WIDTH="488"
+                            VPOS="1657" HPOS="4791" />
+                    </TextLine>
+                    <TextLine BASELINE="1823" HEIGHT="66" WIDTH="920" VPOS="1761" HPOS="4585">
+                        <String WC="0.89499998092651367" CONTENT="MARY" HEIGHT="60" WIDTH="266"
+                            VPOS="1761" HPOS="4585" />
+                        <SP HEIGHT="60" WIDTH="28" VPOS="1763" HPOS="4852" />
+                        <String WC="1." CONTENT="JO" HEIGHT="58" WIDTH="104" VPOS="1765" HPOS="4881" />
+                        <SP HEIGHT="60" WIDTH="30" VPOS="1765" HPOS="4986" />
+                        <String WC="0.97000002861022949" CONTENT="ALBRECHT" HEIGHT="60" WIDTH="488"
+                            VPOS="1767" HPOS="5017" />
+                    </TextLine>
+                    <TextLine BASELINE="1928" HEIGHT="62" WIDTH="654" VPOS="1869" HPOS="4579">
+                        <String WC="1." CONTENT="JERRY" HEIGHT="58" WIDTH="296" VPOS="1869"
+                            HPOS="4579" />
+                        <SP HEIGHT="58" WIDTH="32" VPOS="1871" HPOS="4876" />
+                        <String WC="0.99199998378753662" CONTENT="BROWN" HEIGHT="58" WIDTH="324"
+                            VPOS="1873" HPOS="4909" />
+                    </TextLine>
+                    <TextLine BASELINE="2038" HEIGHT="68" WIDTH="700" VPOS="1975" HPOS="4583">
+                        <String WC="1." LANG="fr" CONTENT="LE" HEIGHT="60" WIDTH="104" VPOS="1975"
+                            HPOS="4583" />
+                        <SP HEIGHT="60" WIDTH="32" VPOS="1975" HPOS="4688" />
+                        <String WC="1." CONTENT="ROY" HEIGHT="58" WIDTH="194" VPOS="1977"
+                            HPOS="4721" />
+                        <SP HEIGHT="58" WIDTH="34" VPOS="1977" HPOS="4916" />
+                        <String WC="0.83166664838790894" CONTENT="FINKEL" HEIGHT="66" WIDTH="332"
+                            VPOS="1977" HPOS="4951" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page2_Block6" HEIGHT="6622" WIDTH="5330" VPOS="628" HPOS="576">
+                    <Shape>
+                        <Polygon
+                            POINTS="3224,628 3972,628 3972,792 4550,792 4550,3562 3918,3562 3918,4840 4398,4840 4398,5338 5906,5338 5906,6424 5854,6424 5854,6446 5484,6446 5484,7250 3714,7250 3714,5554 3216,5554 3216,5334 3166,5334 3166,5058 3026,5058 3026,3562 2386,3562 2386,2938 576,2938 576,792 3224,792 3224,628" />
+                    </Shape>
+                </Illustration>
+                <TextBlock ID="Page2_Block7" HEIGHT="92" WIDTH="138" VPOS="3588" HPOS="714"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3666" HEIGHT="56" WIDTH="114" VPOS="3613" HPOS="727">
+                        <String WC="1." CONTENT="and" HEIGHT="56" WIDTH="114" VPOS="3613" HPOS="727" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block8" HEIGHT="202" WIDTH="140" VPOS="3264" HPOS="714"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3331" HEIGHT="55" WIDTH="114" VPOS="3276" HPOS="728">
+                        <String WC="0.6966666579246521" CONTENT="and" HEIGHT="55" WIDTH="114"
+                            VPOS="3276" HPOS="728" />
+                    </TextLine>
+                    <TextLine BASELINE="3454" HEIGHT="55" WIDTH="115" VPOS="3399" HPOS="727">
+                        <String WC="1." CONTENT="and" HEIGHT="55" WIDTH="115" VPOS="3399" HPOS="727" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block9" HEIGHT="344" WIDTH="330" VPOS="6408" HPOS="5806"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <Shape>
+                        <Polygon
+                            POINTS="5838,6408 6136,6408 6136,6752 5806,6752 5806,6612 5840,6612 5840,6588 5838,6588 5838,6408" />
+                    </Shape>
+                    <TextLine BASELINE="6544" HEIGHT="156" WIDTH="280" VPOS="6422" HPOS="5854">
+                        <String WC="0.53666669130325317" CONTENT="X»^" HEIGHT="156" WIDTH="280"
+                            VPOS="6422" HPOS="5854" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block10" HEIGHT="418" WIDTH="726" VPOS="4240" HPOS="540"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="4320" HEIGHT="72" WIDTH="532" VPOS="4253" HPOS="553">
+                        <String WC="0.95333331823348999" CONTENT="the" HEIGHT="72" WIDTH="118"
+                            VPOS="4253" HPOS="553" />
+                        <SP HEIGHT="44" WIDTH="30" VPOS="4279" HPOS="672" />
+                        <String WC="0.99250000715255737" CONTENT="next" HEIGHT="50" WIDTH="168"
+                            VPOS="4273" HPOS="703" />
+                        <SP HEIGHT="64" WIDTH="32" VPOS="4257" HPOS="872" />
+                        <String WC="1." CONTENT="issue" HEIGHT="64" WIDTH="180" VPOS="4257"
+                            HPOS="905" />
+                    </TextLine>
+                    <TextLine BASELINE="4425" HEIGHT="70" WIDTH="698" VPOS="4361" HPOS="555">
+                        <String WC="0.97666668891906738" CONTENT="and" HEIGHT="66" WIDTH="128"
+                            VPOS="4365" HPOS="555" />
+                        <SP HEIGHT="64" WIDTH="36" VPOS="4365" HPOS="684" />
+                        <String WC="0.84333330392837524" CONTENT="the" HEIGHT="66" WIDTH="120"
+                            VPOS="4363" HPOS="721" />
+                        <SP HEIGHT="46" WIDTH="34" VPOS="4381" HPOS="842" />
+                        <String WC="1." CONTENT="next" HEIGHT="56" WIDTH="166" VPOS="4371"
+                            HPOS="877" />
+                        <SP HEIGHT="64" WIDTH="34" VPOS="4361" HPOS="1044" />
+                        <String WC="0.83799999952316284" CONTENT="issue" HEIGHT="66" WIDTH="174"
+                            VPOS="4361" HPOS="1079" />
+                    </TextLine>
+                    <TextLine BASELINE="4534" HEIGHT="68" WIDTH="698" VPOS="4471" HPOS="557">
+                        <String WC="1." CONTENT="and" HEIGHT="66" WIDTH="132" VPOS="4473" HPOS="557" />
+                        <SP HEIGHT="66" WIDTH="30" VPOS="4473" HPOS="690" />
+                        <String WC="1." CONTENT="the" HEIGHT="64" WIDTH="124" VPOS="4473" HPOS="721" />
+                        <SP HEIGHT="48" WIDTH="28" VPOS="4489" HPOS="846" />
+                        <String WC="1." CONTENT="next" HEIGHT="60" WIDTH="168" VPOS="4475"
+                            HPOS="875" />
+                        <SP HEIGHT="62" WIDTH="34" VPOS="4471" HPOS="1044" />
+                        <String WC="1." CONTENT="issue" HEIGHT="62" WIDTH="176" VPOS="4471"
+                            HPOS="1079" />
+                    </TextLine>
+                    <TextLine BASELINE="4644" HEIGHT="66" WIDTH="132" VPOS="4581" HPOS="555">
+                        <String WC="0.8566666841506958" CONTENT="and" HEIGHT="66" WIDTH="132"
+                            VPOS="4581" HPOS="555" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block11" HEIGHT="96" WIDTH="1472" VPOS="3262" HPOS="930"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3330" HEIGHT="70" WIDTH="1018" VPOS="3275" HPOS="949">
+                        <String WC="0.96875" CONTENT="learning" HEIGHT="70" WIDTH="256" VPOS="3275"
+                            HPOS="949" />
+                        <SP HEIGHT="68" WIDTH="28" VPOS="3277" HPOS="1206" />
+                        <String WC="1." CONTENT="how" HEIGHT="56" WIDTH="136" VPOS="3277"
+                            HPOS="1235" />
+                        <SP HEIGHT="48" WIDTH="24" VPOS="3283" HPOS="1372" />
+                        <String WC="1." CONTENT="to" HEIGHT="48" WIDTH="66" VPOS="3283" HPOS="1397" />
+                        <SP HEIGHT="40" WIDTH="26" VPOS="3291" HPOS="1464" />
+                        <String WC="1." CONTENT="use" HEIGHT="42" WIDTH="102" VPOS="3291"
+                            HPOS="1491" />
+                        <SP HEIGHT="40" WIDTH="24" VPOS="3293" HPOS="1594" />
+                        <String WC="1." CONTENT="computers" HEIGHT="58" WIDTH="348" VPOS="3285"
+                            HPOS="1619" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block12" HEIGHT="188" WIDTH="1472" VPOS="3384" HPOS="930"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3453" HEIGHT="70" WIDTH="1439" VPOS="3397" HPOS="947">
+                        <String WC="1." CONTENT="how" HEIGHT="56" WIDTH="138" VPOS="3399" HPOS="947" />
+                        <SP HEIGHT="50" WIDTH="20" VPOS="3405" HPOS="1086" />
+                        <String WC="1." CONTENT="to" HEIGHT="50" WIDTH="68" VPOS="3405" HPOS="1107" />
+                        <SP HEIGHT="56" WIDTH="26" VPOS="3399" HPOS="1176" />
+                        <String WC="1." CONTENT="buy" HEIGHT="68" WIDTH="124" VPOS="3399"
+                            HPOS="1203" />
+                        <SP HEIGHT="54" WIDTH="24" VPOS="3413" HPOS="1328" />
+                        <String WC="1." CONTENT="a" HEIGHT="42" WIDTH="32" VPOS="3413" HPOS="1353" />
+                        <SP HEIGHT="42" WIDTH="26" VPOS="3413" HPOS="1386" />
+                        <String WC="1." CONTENT="minicomputer" HEIGHT="70" WIDTH="466" VPOS="3397"
+                            HPOS="1413" />
+                        <SP HEIGHT="56" WIDTH="20" VPOS="3399" HPOS="1880" />
+                        <String WC="0.83333331346511841" CONTENT="for" HEIGHT="56" WIDTH="100"
+                            VPOS="3399" HPOS="1901" />
+                        <SP HEIGHT="52" WIDTH="22" VPOS="3415" HPOS="2002" />
+                        <String WC="0.93500000238418579" CONTENT="yourself" HEIGHT="68" WIDTH="272"
+                            VPOS="3399" HPOS="2025" />
+                        <SP HEIGHT="56" WIDTH="22" VPOS="3399" HPOS="2298" />
+                        <String WC="1." CONTENT="or" HEIGHT="40" WIDTH="65" VPOS="3415" HPOS="2321" />
+                    </TextLine>
+                    <TextLine BASELINE="3543" HEIGHT="70" WIDTH="388" VPOS="3489" HPOS="943">
+                        <String WC="1." CONTENT="your" HEIGHT="54" WIDTH="156" VPOS="3505"
+                            HPOS="943" />
+                        <SP HEIGHT="40" WIDTH="24" VPOS="3505" HPOS="1100" />
+                        <String WC="1." CONTENT="school" HEIGHT="56" WIDTH="206" VPOS="3489"
+                            HPOS="1125" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block13" HEIGHT="82" WIDTH="1548" VPOS="3598" HPOS="930"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3667" HEIGHT="58" WIDTH="1522" VPOS="3611" HPOS="945">
+                        <String WC="0.96714287996292114" CONTENT="books.." HEIGHT="58" WIDTH="258"
+                            VPOS="3611" HPOS="945" />
+                        <SP HEIGHT="12" WIDTH="30" VPOS="3657" HPOS="1204" />
+                        <String WC="1." CONTENT=".and" HEIGHT="56" WIDTH="132" VPOS="3613"
+                            HPOS="1235" />
+                        <SP HEIGHT="56" WIDTH="24" VPOS="3611" HPOS="1368" />
+                        <String WC="0.92285716533660889" CONTENT="films.." HEIGHT="58" WIDTH="226"
+                            VPOS="3611" HPOS="1393" />
+                        <SP HEIGHT="42" WIDTH="22" VPOS="3627" HPOS="1620" />
+                        <String WC="0.2199999988079071" CONTENT=";" HEIGHT="42" WIDTH="18"
+                            VPOS="3627" HPOS="1643" />
+                        <SP HEIGHT="42" WIDTH="22" VPOS="3627" HPOS="1662" />
+                        <String WC="1." CONTENT="and" HEIGHT="56" WIDTH="116" VPOS="3613"
+                            HPOS="1685" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="3613" HPOS="1802" />
+                        <String WC="0.98600000143051147" CONTENT="tools" HEIGHT="56" WIDTH="164"
+                            VPOS="3613" HPOS="1831" />
+                        <SP HEIGHT="42" WIDTH="18" VPOS="3627" HPOS="1996" />
+                        <String WC="0.77999997138977051" CONTENT="of" HEIGHT="56" WIDTH="72"
+                            VPOS="3613" HPOS="2015" />
+                        <SP HEIGHT="56" WIDTH="20" VPOS="3613" HPOS="2088" />
+                        <String WC="0.80000001192092896" CONTENT="the" HEIGHT="56" WIDTH="108"
+                            VPOS="3613" HPOS="2109" />
+                        <SP HEIGHT="56" WIDTH="22" VPOS="3613" HPOS="2218" />
+                        <String WC="0.95571428537368774" CONTENT="future." HEIGHT="56" WIDTH="226"
+                            VPOS="3613" HPOS="2241" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block14" HEIGHT="192" WIDTH="1650" VPOS="2922" HPOS="716"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="2996" HEIGHT="58" WIDTH="1624" VPOS="2939" HPOS="731">
+                        <String WC="1." CONTENT="THE" HEIGHT="58" WIDTH="174" VPOS="2939" HPOS="731" />
+                        <SP HEIGHT="58" WIDTH="32" VPOS="2939" HPOS="906" />
+                        <String WC="0.95749998092651367" CONTENT="PEOPLE&apos;S" HEIGHT="58"
+                            WIDTH="416" VPOS="2939" HPOS="939" />
+                        <SP HEIGHT="58" WIDTH="28" VPOS="2939" HPOS="1356" />
+                        <String WC="0.83125001192092896" CONTENT="COMPUTER" HEIGHT="58" WIDTH="488"
+                            VPOS="2939" HPOS="1385" />
+                        <SP HEIGHT="58" WIDTH="34" VPOS="2939" HPOS="1874" />
+                        <String WC="1." CONTENT="COMPANY" HEIGHT="58" WIDTH="446" VPOS="2939"
+                            HPOS="1909" />
+                    </TextLine>
+                    <TextLine BASELINE="3086" HEIGHT="70" WIDTH="580" VPOS="3031" HPOS="735">
+                        <String WC="0.93999999761581421" CONTENT="is" HEIGHT="56" WIDTH="42"
+                            VPOS="3031" HPOS="735" />
+                        <SP HEIGHT="42" WIDTH="20" VPOS="3045" HPOS="778" />
+                        <String WC="1." CONTENT="a" HEIGHT="38" WIDTH="32" VPOS="3049" HPOS="799" />
+                        <SP HEIGHT="40" WIDTH="28" VPOS="3047" HPOS="832" />
+                        <String WC="0.9191666841506958" CONTENT="newspaper..." HEIGHT="54"
+                            WIDTH="454" VPOS="3047" HPOS="861" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block15" HEIGHT="96" WIDTH="1650" VPOS="3140" HPOS="716"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3209" HEIGHT="72" WIDTH="1110" VPOS="3153" HPOS="729">
+                        <String WC="1." CONTENT="about" HEIGHT="58" WIDTH="190" VPOS="3155"
+                            HPOS="729" />
+                        <SP HEIGHT="56" WIDTH="26" VPOS="3155" HPOS="920" />
+                        <String WC="0.97500002384185791" CONTENT="having" HEIGHT="72" WIDTH="210"
+                            VPOS="3153" HPOS="947" />
+                        <SP HEIGHT="72" WIDTH="24" VPOS="3153" HPOS="1158" />
+                        <String WC="1." CONTENT="fun" HEIGHT="56" WIDTH="108" VPOS="3153"
+                            HPOS="1183" />
+                        <SP HEIGHT="40" WIDTH="24" VPOS="3169" HPOS="1292" />
+                        <String WC="1." CONTENT="with" HEIGHT="56" WIDTH="144" VPOS="3153"
+                            HPOS="1317" />
+                        <SP HEIGHT="58" WIDTH="26" VPOS="3153" HPOS="1462" />
+                        <String WC="0.97222220897674561" CONTENT="computers" HEIGHT="62" WIDTH="350"
+                            VPOS="3161" HPOS="1489" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block16" HEIGHT="1208" WIDTH="2896" VPOS="4766" HPOS="340"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <Shape>
+                        <Polygon
+                            POINTS="340,4766 2632,4766 2632,5042 3172,5042 3172,5318 3232,5318 3232,5600 3236,5600 3236,5974 340,5974 340,4766" />
+                    </Shape>
+                    <TextLine BASELINE="4852" HEIGHT="98" WIDTH="2270" VPOS="4779" HPOS="353">
+                        <String WC="1." CONTENT="does" HEIGHT="68" WIDTH="178" VPOS="4795"
+                            HPOS="353" />
+                        <SP HEIGHT="58" WIDTH="22" VPOS="4817" HPOS="532" />
+                        <String WC="0.76499998569488525" CONTENT="your" HEIGHT="60" WIDTH="182"
+                            VPOS="4815" HPOS="555" />
+                        <SP HEIGHT="46" WIDTH="22" VPOS="4813" HPOS="738" />
+                        <String WC="0.9100000262260437" CONTENT="school," HEIGHT="84" WIDTH="272"
+                            VPOS="4789" HPOS="761" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="4813" HPOS="1034" />
+                        <String WC="1." CONTENT="group" HEIGHT="66" WIDTH="226" VPOS="4811"
+                            HPOS="1063" />
+                        <SP HEIGHT="64" WIDTH="24" VPOS="4809" HPOS="1290" />
+                        <String WC="0.99000000953674316" CONTENT="or" HEIGHT="48" WIDTH="82"
+                            VPOS="4809" HPOS="1315" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="4809" HPOS="1398" />
+                        <String WC="0.94083333015441895" CONTENT="organization" HEIGHT="84"
+                            WIDTH="478" VPOS="4787" HPOS="1423" />
+                        <SP HEIGHT="66" WIDTH="30" VPOS="4783" HPOS="1902" />
+                        <String WC="0.91250002384185791" CONTENT="have" HEIGHT="68" WIDTH="172"
+                            VPOS="4783" HPOS="1933" />
+                        <SP HEIGHT="48" WIDTH="24" VPOS="4803" HPOS="2106" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="36" VPOS="4803" HPOS="2131" />
+                        <SP HEIGHT="46" WIDTH="32" VPOS="4803" HPOS="2168" />
+                        <String WC="1." CONTENT="computer?" HEIGHT="84" WIDTH="422" VPOS="4779"
+                            HPOS="2201" />
+                    </TextLine>
+                    <TextLine BASELINE="4999" HEIGHT="86" WIDTH="986" VPOS="4931" HPOS="355">
+                        <String WC="1." CONTENT="do" HEIGHT="68" WIDTH="94" VPOS="4937" HPOS="355" />
+                        <SP HEIGHT="60" WIDTH="22" VPOS="4957" HPOS="450" />
+                        <String WC="0.56999999284744263" CONTENT="you" HEIGHT="60" WIDTH="150"
+                            VPOS="4957" HPOS="473" />
+                        <SP HEIGHT="68" WIDTH="30" VPOS="4935" HPOS="624" />
+                        <String WC="0.99250000715255737" CONTENT="have" HEIGHT="66" WIDTH="172"
+                            VPOS="4935" HPOS="655" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="4955" HPOS="828" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="38" VPOS="4955" HPOS="853" />
+                        <SP HEIGHT="46" WIDTH="32" VPOS="4955" HPOS="892" />
+                        <String WC="0.96666663885116577" CONTENT="computer?" HEIGHT="84" WIDTH="416"
+                            VPOS="4931" HPOS="925" />
+                    </TextLine>
+                    <TextLine BASELINE="5132" HEIGHT="96" WIDTH="2804" VPOS="5059" HPOS="355">
+                        <String WC="1." CONTENT="do" HEIGHT="66" WIDTH="94" VPOS="5079" HPOS="355" />
+                        <SP HEIGHT="54" WIDTH="26" VPOS="5101" HPOS="450" />
+                        <String WC="0.64666664600372314" CONTENT="you" HEIGHT="56" WIDTH="148"
+                            VPOS="5099" HPOS="477" />
+                        <SP HEIGHT="64" WIDTH="26" VPOS="5077" HPOS="626" />
+                        <String WC="0.90750002861022949" CONTENT="like" HEIGHT="64" WIDTH="140"
+                            VPOS="5077" HPOS="653" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="5097" HPOS="794" />
+                        <String WC="0.9024999737739563" CONTENT="your" HEIGHT="58" WIDTH="184"
+                            VPOS="5095" HPOS="823" />
+                        <SP HEIGHT="44" WIDTH="26" VPOS="5095" HPOS="1008" />
+                        <String WC="0.88111108541488647" CONTENT="computer?" HEIGHT="78" WIDTH="416"
+                            VPOS="5073" HPOS="1035" />
+                        <SP HEIGHT="80" WIDTH="52" VPOS="5069" HPOS="1452" />
+                        <String WC="0.74000000953674316" CONTENT="(do" HEIGHT="80" WIDTH="128"
+                            VPOS="5069" HPOS="1505" />
+                        <SP HEIGHT="56" WIDTH="24" VPOS="5091" HPOS="1634" />
+                        <String WC="1." CONTENT="you" HEIGHT="58" WIDTH="148" VPOS="5089"
+                            HPOS="1659" />
+                        <SP HEIGHT="66" WIDTH="24" VPOS="5067" HPOS="1808" />
+                        <String WC="0.91250002384185791" CONTENT="like" HEIGHT="66" WIDTH="144"
+                            VPOS="5067" HPOS="1833" />
+                        <SP HEIGHT="54" WIDTH="28" VPOS="5079" HPOS="1978" />
+                        <String WC="1." CONTENT="the" HEIGHT="66" WIDTH="118" VPOS="5065"
+                            HPOS="2007" />
+                        <SP HEIGHT="44" WIDTH="28" VPOS="5087" HPOS="2126" />
+                        <String WC="0.96875" CONTENT="computer" HEIGHT="70" WIDTH="374" VPOS="5075"
+                            HPOS="2155" />
+                        <SP HEIGHT="44" WIDTH="22" VPOS="5083" HPOS="2530" />
+                        <String WC="0.93642854690551758" CONTENT="manufacturer?)" HEIGHT="80"
+                            WIDTH="606" VPOS="5059" HPOS="2553" />
+                    </TextLine>
+                    <TextLine BASELINE="5274" HEIGHT="88" WIDTH="1536" VPOS="5205" HPOS="359">
+                        <String WC="0.80666667222976685" CONTENT="how" HEIGHT="66" WIDTH="162"
+                            VPOS="5215" HPOS="359" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="5215" HPOS="522" />
+                        <String WC="0.85000002384185791" CONTENT="do" HEIGHT="66" WIDTH="98"
+                            VPOS="5215" HPOS="545" />
+                        <SP HEIGHT="58" WIDTH="24" VPOS="5235" HPOS="644" />
+                        <String WC="1." CONTENT="you" HEIGHT="58" WIDTH="148" VPOS="5235" HPOS="669" />
+                        <SP HEIGHT="66" WIDTH="36" VPOS="5213" HPOS="818" />
+                        <String WC="0.87199997901916504" CONTENT="build" HEIGHT="66" WIDTH="190"
+                            VPOS="5211" HPOS="855" />
+                        <SP HEIGHT="66" WIDTH="28" VPOS="5211" HPOS="1046" />
+                        <String WC="0.94999998807907104" CONTENT="a" HEIGHT="42" WIDTH="36"
+                            VPOS="5233" HPOS="1075" />
+                        <SP HEIGHT="44" WIDTH="32" VPOS="5231" HPOS="1112" />
+                        <String WC="1." CONTENT="cheap" HEIGHT="78" WIDTH="222" VPOS="5211"
+                            HPOS="1145" />
+                        <SP HEIGHT="68" WIDTH="32" VPOS="5221" HPOS="1368" />
+                        <String WC="1." CONTENT="tape" HEIGHT="68" WIDTH="158" VPOS="5221"
+                            HPOS="1401" />
+                        <SP HEIGHT="42" WIDTH="28" VPOS="5229" HPOS="1560" />
+                        <String WC="0.92142856121063232" CONTENT="winder?" HEIGHT="66" WIDTH="306"
+                            VPOS="5205" HPOS="1589" />
+                    </TextLine>
+                    <TextLine BASELINE="5408" HEIGHT="104" WIDTH="2857" VPOS="5331" HPOS="359">
+                        <String WC="1." CONTENT="do" HEIGHT="70" WIDTH="92" VPOS="5353" HPOS="359" />
+                        <SP HEIGHT="60" WIDTH="26" VPOS="5375" HPOS="452" />
+                        <String WC="1." CONTENT="you" HEIGHT="60" WIDTH="148" VPOS="5375" HPOS="479" />
+                        <SP HEIGHT="70" WIDTH="28" VPOS="5351" HPOS="628" />
+                        <String WC="0.93000000715255737" CONTENT="have" HEIGHT="68" WIDTH="172"
+                            VPOS="5351" HPOS="657" />
+                        <SP HEIGHT="48" WIDTH="26" VPOS="5371" HPOS="830" />
+                        <String WC="1." CONTENT="any" HEIGHT="60" WIDTH="146" VPOS="5371" HPOS="857" />
+                        <SP HEIGHT="62" WIDTH="20" VPOS="5373" HPOS="1004" />
+                        <String WC="0.93500000238418579" CONTENT="good" HEIGHT="86" WIDTH="190"
+                            VPOS="5349" HPOS="1025" />
+                        <SP HEIGHT="84" WIDTH="26" VPOS="5349" HPOS="1216" />
+                        <String WC="1." CONTENT="game" HEIGHT="66" WIDTH="200" VPOS="5367"
+                            HPOS="1243" />
+                        <SP HEIGHT="60" WIDTH="22" VPOS="5369" HPOS="1444" />
+                        <String WC="0.87285715341567993" CONTENT="playing" HEIGHT="84" WIDTH="286"
+                            VPOS="5345" HPOS="1467" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="5365" HPOS="1754" />
+                        <String WC="0.99500000476837158" CONTENT="programs" HEIGHT="68" WIDTH="362"
+                            VPOS="5359" HPOS="1777" />
+                        <SP HEIGHT="48" WIDTH="22" VPOS="5359" HPOS="2140" />
+                        <String WC="1." CONTENT="or" HEIGHT="48" WIDTH="80" VPOS="5359" HPOS="2163" />
+                        <SP HEIGHT="44" WIDTH="24" VPOS="5359" HPOS="2244" />
+                        <String WC="0.79000002145767212" CONTENT="simulations" HEIGHT="66"
+                            WIDTH="450" VPOS="5337" HPOS="2269" />
+                        <SP HEIGHT="80" WIDTH="26" VPOS="5333" HPOS="2720" />
+                        <String WC="0.74000000953674316" CONTENT="(in" HEIGHT="80" WIDTH="102"
+                            VPOS="5333" HPOS="2747" />
+                        <SP HEIGHT="64" WIDTH="26" VPOS="5335" HPOS="2850" />
+                        <String WC="0.84285712242126465" CONTENT="BASIC)?" HEIGHT="80" WIDTH="339"
+                            VPOS="5331" HPOS="2877" />
+                    </TextLine>
+                    <TextLine BASELINE="5556" HEIGHT="80" WIDTH="750" VPOS="5491" HPOS="361">
+                        <String WC="0.85500001907348633" CONTENT="what" HEIGHT="66" WIDTH="184"
+                            VPOS="5493" HPOS="361" />
+                        <SP HEIGHT="66" WIDTH="24" VPOS="5493" HPOS="546" />
+                        <String WC="1." CONTENT="do" HEIGHT="66" WIDTH="98" VPOS="5493" HPOS="571" />
+                        <SP HEIGHT="58" WIDTH="26" VPOS="5513" HPOS="670" />
+                        <String WC="1." CONTENT="you" HEIGHT="58" WIDTH="150" VPOS="5513" HPOS="697" />
+                        <SP HEIGHT="44" WIDTH="30" VPOS="5513" HPOS="848" />
+                        <String WC="0.80199998617172241" CONTENT="want?" HEIGHT="66" WIDTH="232"
+                            VPOS="5491" HPOS="879" />
+                    </TextLine>
+                    <TextLine BASELINE="5689" HEIGHT="100" WIDTH="2862" VPOS="5613" HPOS="363">
+                        <String WC="0.88999998569488525" CONTENT="would" HEIGHT="70" WIDTH="230"
+                            VPOS="5631" HPOS="363" />
+                        <SP HEIGHT="80" WIDTH="28" VPOS="5633" HPOS="594" />
+                        <String WC="1." CONTENT="you" HEIGHT="60" WIDTH="148" VPOS="5653" HPOS="623" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="5631" HPOS="772" />
+                        <String WC="0.74250000715255737" CONTENT="like" HEIGHT="66" WIDTH="144"
+                            VPOS="5631" HPOS="799" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="5641" HPOS="944" />
+                        <String WC="1." CONTENT="to" HEIGHT="58" WIDTH="78" VPOS="5641" HPOS="973" />
+                        <SP HEIGHT="70" WIDTH="26" VPOS="5629" HPOS="1052" />
+                        <String WC="1." CONTENT="do" HEIGHT="68" WIDTH="98" VPOS="5629" HPOS="1079" />
+                        <SP HEIGHT="48" WIDTH="26" VPOS="5649" HPOS="1178" />
+                        <String WC="1." CONTENT="one" HEIGHT="46" WIDTH="140" VPOS="5649"
+                            HPOS="1205" />
+                        <SP HEIGHT="48" WIDTH="24" VPOS="5647" HPOS="1346" />
+                        <String WC="0.8399999737739563" CONTENT="or" HEIGHT="48" WIDTH="82"
+                            VPOS="5647" HPOS="1371" />
+                        <SP HEIGHT="48" WIDTH="26" VPOS="5645" HPOS="1454" />
+                        <String WC="1." CONTENT="more" HEIGHT="48" WIDTH="196" VPOS="5645"
+                            HPOS="1481" />
+                        <SP HEIGHT="62" WIDTH="24" VPOS="5645" HPOS="1678" />
+                        <String WC="0.99800002574920654" CONTENT="pages" HEIGHT="66" WIDTH="212"
+                            VPOS="5643" HPOS="1703" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="5643" HPOS="1916" />
+                        <String WC="0.72000002861022949" CONTENT="of" HEIGHT="68" WIDTH="90"
+                            VPOS="5621" HPOS="1941" />
+                        <SP HEIGHT="84" WIDTH="14" VPOS="5621" HPOS="2032" />
+                        <String WC="0.96727269887924194" CONTENT="photo-ready" HEIGHT="88"
+                            WIDTH="480" VPOS="5617" HPOS="2047" />
+                        <SP HEIGHT="60" WIDTH="24" VPOS="5637" HPOS="2528" />
+                        <String WC="1." CONTENT="copy" HEIGHT="62" WIDTH="196" VPOS="5637"
+                            HPOS="2553" />
+                        <SP HEIGHT="82" WIDTH="22" VPOS="5615" HPOS="2750" />
+                        <String WC="1." CONTENT="for" HEIGHT="68" WIDTH="118" VPOS="5615"
+                            HPOS="2773" />
+                        <SP HEIGHT="46" WIDTH="20" VPOS="5635" HPOS="2892" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="38" VPOS="5635" HPOS="2913" />
+                        <SP HEIGHT="68" WIDTH="30" VPOS="5613" HPOS="2952" />
+                        <String WC="1." CONTENT="future" HEIGHT="68" WIDTH="242" VPOS="5613"
+                            HPOS="2983" />
+                    </TextLine>
+                    <TextLine BASELINE="5806" HEIGHT="68" WIDTH="226" VPOS="5741" HPOS="359">
+                        <String WC="0.95499998331069946" CONTENT="issue?" HEIGHT="68" WIDTH="226"
+                            VPOS="5741" HPOS="359" />
+                    </TextLine>
+                    <TextLine BASELINE="5940" HEIGHT="98" WIDTH="2656" VPOS="5865" HPOS="365">
+                        <String WC="0.95800000429153442" CONTENT="would" HEIGHT="70" WIDTH="232"
+                            VPOS="5881" HPOS="365" />
+                        <SP HEIGHT="82" WIDTH="28" VPOS="5881" HPOS="598" />
+                        <String WC="1." CONTENT="you" HEIGHT="60" WIDTH="146" VPOS="5903" HPOS="627" />
+                        <SP HEIGHT="48" WIDTH="28" VPOS="5901" HPOS="774" />
+                        <String WC="0.79500001668930054" CONTENT="or" HEIGHT="48" WIDTH="84"
+                            VPOS="5901" HPOS="803" />
+                        <SP HEIGHT="60" WIDTH="24" VPOS="5901" HPOS="888" />
+                        <String WC="0.91250002384185791" CONTENT="your" HEIGHT="62" WIDTH="184"
+                            VPOS="5899" HPOS="913" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="5899" HPOS="1098" />
+                        <String WC="0.93999999761581421" CONTENT="group" HEIGHT="66" WIDTH="226"
+                            VPOS="5897" HPOS="1121" />
+                        <SP HEIGHT="86" WIDTH="24" VPOS="5875" HPOS="1348" />
+                        <String WC="0.81999999284744263" CONTENT="like" HEIGHT="68" WIDTH="142"
+                            VPOS="5875" HPOS="1373" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="5887" HPOS="1516" />
+                        <String WC="1." CONTENT="to" HEIGHT="56" WIDTH="74" VPOS="5887" HPOS="1545" />
+                        <SP HEIGHT="48" WIDTH="30" VPOS="5895" HPOS="1620" />
+                        <String WC="1." CONTENT="edit" HEIGHT="68" WIDTH="148" VPOS="5873"
+                            HPOS="1651" />
+                        <SP HEIGHT="54" WIDTH="22" VPOS="5885" HPOS="1800" />
+                        <String WC="1." CONTENT="and" HEIGHT="68" WIDTH="138" VPOS="5871"
+                            HPOS="1823" />
+                        <SP HEIGHT="84" WIDTH="26" VPOS="5871" HPOS="1962" />
+                        <String WC="0.96857142448425293" CONTENT="produce" HEIGHT="86" WIDTH="320"
+                            VPOS="5869" HPOS="1989" />
+                        <SP HEIGHT="48" WIDTH="20" VPOS="5889" HPOS="2310" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="38" VPOS="5889" HPOS="2331" />
+                        <SP HEIGHT="46" WIDTH="32" VPOS="5889" HPOS="2370" />
+                        <String WC="0.95749998092651367" CONTENT="complete" HEIGHT="84" WIDTH="362"
+                            VPOS="5865" HPOS="2403" />
+                        <SP HEIGHT="66" WIDTH="28" VPOS="5867" HPOS="2766" />
+                        <String WC="0.90499997138977051" CONTENT="issue?" HEIGHT="66" WIDTH="226"
+                            VPOS="5865" HPOS="2795" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block17" HEIGHT="236" WIDTH="1546" VPOS="6382" HPOS="848"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="6600" HEIGHT="204" WIDTH="1516" VPOS="6398" HPOS="862">
+                        <String WC="0.75999999046325684" CONTENT="€№€№" HEIGHT="204" WIDTH="1516"
+                            VPOS="6398" HPOS="862" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page2_Block18" HEIGHT="1982" WIDTH="2270" VPOS="6416" HPOS="490">
+                    <Shape>
+                        <Polygon
+                            POINTS="2378,6416 2760,6416 2760,8392 646,8392 646,8398 546,8398 546,8392 490,8392 490,6602 2378,6602 2378,6416" />
+                    </Shape>
+                </Illustration>
+                <TextBlock ID="Page2_Block19" HEIGHT="300" WIDTH="2226" VPOS="8376" HPOS="630"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="8620" HEIGHT="264" WIDTH="2192" VPOS="8396" HPOS="644">
+                        <String WC="0.34000000357627869" CONTENT="SERIOUS" HEIGHT="248" WIDTH="1280"
+                            VPOS="8412" HPOS="644" />
+                        <SP HEIGHT="232" WIDTH="102" VPOS="8404" HPOS="1925" />
+                        <String WC="0.38999998569488525" CONTENT="STUFF" HEIGHT="224" WIDTH="808"
+                            VPOS="8396" HPOS="2028" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block20" HEIGHT="120" WIDTH="688" VPOS="9014" HPOS="4134"
+                    LANG="fr" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="9122" HEIGHT="96" WIDTH="662" VPOS="9027" HPOS="4149">
+                        <String WC="0.57909089326858521" CONTENT="a.naxôsa.d." HEIGHT="96"
+                            WIDTH="610" VPOS="9027" HPOS="4149" />
+                        <String WC="0.74000000953674316" LANG="en-US" CONTENT="." HEIGHT="20"
+                            WIDTH="22" VPOS="9101" HPOS="4789" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block21" HEIGHT="88" WIDTH="77" VPOS="9234" HPOS="6850"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="9310" HEIGHT="86" WIDTH="20" VPOS="9235" HPOS="6863">
+                        <String WC="0.18000000715255737" CONTENT="(" HEIGHT="86" WIDTH="20"
+                            VPOS="9235" HPOS="6863" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block22" HEIGHT="70" WIDTH="79" VPOS="9414" HPOS="6848"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="9472" HEIGHT="62" WIDTH="16" VPOS="9414" HPOS="6861">
+                        <String WC="0.27000001072883606" CONTENT="1" HEIGHT="62" WIDTH="16"
+                            VPOS="9414" HPOS="6861" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block23" HEIGHT="174" WIDTH="1312" VPOS="10050" HPOS="4976"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="10185" HEIGHT="145" WIDTH="1282" VPOS="10063" HPOS="4993">
+                        <String WC="1." CONTENT="This" HEIGHT="124" WIDTH="336" VPOS="10065"
+                            HPOS="4993" />
+                        <SP HEIGHT="126" WIDTH="60" VPOS="10063" HPOS="5330" />
+                        <String WC="1." CONTENT="is" HEIGHT="122" WIDTH="116" VPOS="10063"
+                            HPOS="5391" />
+                        <SP HEIGHT="109" WIDTH="52" VPOS="10099" HPOS="5508" />
+                        <String WC="1." CONTENT="page" HEIGHT="111" WIDTH="382" VPOS="10097"
+                            HPOS="5561" />
+                        <SP HEIGHT="90" WIDTH="66" VPOS="10095" HPOS="5944" />
+                        <String WC="1." CONTENT="one" HEIGHT="88" WIDTH="264" VPOS="10093"
+                            HPOS="6011" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block24" HEIGHT="202" WIDTH="71" VPOS="9768" HPOS="6856"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="9904" HEIGHT="134" WIDTH="20" VPOS="9771" HPOS="6865">
+                        <String WC="1." CONTENT="i" HEIGHT="134" WIDTH="20" VPOS="9771" HPOS="6865" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page2_Block25" HEIGHT="1902" WIDTH="6589" VPOS="8796" HPOS="338">
+                    <Shape>
+                        <Polygon
+                            POINTS="338,8796 4148,8796 4148,9478 4992,9478 4992,9956 6927,9956 6927,10698 338,10698 338,8796" />
+                    </Shape>
+                </Illustration>
+                <TextBlock ID="Page2_Block26" HEIGHT="222" WIDTH="2426" VPOS="586" HPOS="3956"
+                    STYLEREFS="StyleId-3AE23056-D223-4C13-8810-C00D458ECDD5-">
+                    <TextLine BASELINE="756" HEIGHT="196" WIDTH="2404" VPOS="598" HPOS="3970">
+                        <String WC="0.33000001311302185" LANG="de" CONTENT="Volume" HEIGHT="156"
+                            WIDTH="412" VPOS="598" HPOS="3970" />
+                        <SP HEIGHT="152" WIDTH="70" VPOS="598" HPOS="4383" />
+                        <String WC="0.73250001668930054" LANG="en-US" CONTENT="One," HEIGHT="180"
+                            WIDTH="224" VPOS="598" HPOS="4454" />
+                        <SP HEIGHT="172" WIDTH="66" VPOS="606" HPOS="4679" />
+                        <String WC="0.32666665315628052" LANG="de" CONTENT="Number" HEIGHT="152"
+                            WIDTH="440" VPOS="606" HPOS="4746" />
+                        <SP HEIGHT="152" WIDTH="70" VPOS="606" HPOS="5187" />
+                        <String WC="0.58499997854232788" LANG="en-US" CONTENT="One;" HEIGHT="180"
+                            WIDTH="236" VPOS="606" HPOS="5258" />
+                        <SP HEIGHT="176" WIDTH="74" VPOS="610" HPOS="5495" />
+                        <String WC="0.46500000357627869" LANG="en-US" CONTENT="October,"
+                            HEIGHT="184" WIDTH="456" VPOS="610" HPOS="5570" />
+                        <SP HEIGHT="176" WIDTH="50" VPOS="618" HPOS="6027" />
+                        <String WC="0.51399999856948853" LANG="en-US" CONTENT="1972." HEIGHT="156"
+                            WIDTH="296" VPOS="614" HPOS="6078" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block27" HEIGHT="116" WIDTH="922" VPOS="886" HPOS="5428"
+                    STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="968" HEIGHT="92" WIDTH="896" VPOS="899" HPOS="5443">
+                        <String WC="0.65222221612930298" LANG="fr" CONTENT="Copyright" HEIGHT="86"
+                            WIDTH="328" VPOS="899" HPOS="5443" />
+                        <SP HEIGHT="56" WIDTH="30" VPOS="911" HPOS="5772" />
+                        <String WC="0.76749998331069946" LANG="en-US" CONTENT="1972" HEIGHT="60"
+                            WIDTH="164" VPOS="911" HPOS="5803" />
+                        <SP HEIGHT="58" WIDTH="24" VPOS="913" HPOS="5968" />
+                        <String WC="0.43500000238418579" LANG="en-US" CONTENT="by" HEIGHT="76"
+                            WIDTH="84" VPOS="913" HPOS="5993" />
+                        <SP HEIGHT="78" WIDTH="20" VPOS="911" HPOS="6078" />
+                        <String WC="1." LANG="en-US" CONTENT="Dymax" HEIGHT="80" WIDTH="240"
+                            VPOS="911" HPOS="6099" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page2_Block28" HEIGHT="1620" WIDTH="576" VPOS="1192" HPOS="5766" />
+                <TextBlock ID="Page2_Block29" HEIGHT="98" WIDTH="1356" VPOS="3546" HPOS="3904"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <TextLine BASELINE="3627" HEIGHT="74" WIDTH="1330" VPOS="3559" HPOS="3919">
+                        <String WC="0.94499999284744263" CONTENT="PEOPLE" HEIGHT="70" WIDTH="340"
+                            VPOS="3563" HPOS="3919" />
+                        <SP HEIGHT="66" WIDTH="8" VPOS="3563" HPOS="4260" />
+                        <String WC="0.89999997615814209" LANG="de" CONTENT="’S" HEIGHT="66"
+                            WIDTH="64" VPOS="3563" HPOS="4269" />
+                        <SP HEIGHT="66" WIDTH="24" VPOS="3563" HPOS="4334" />
+                        <String WC="0.83375000953674316" CONTENT="COMPUTER" HEIGHT="70" WIDTH="496"
+                            VPOS="3561" HPOS="4359" />
+                        <SP HEIGHT="70" WIDTH="32" VPOS="3559" HPOS="4856" />
+                        <String WC="0.81666666269302368" CONTENT="CENTER" HEIGHT="70" WIDTH="360"
+                            VPOS="3559" HPOS="4889" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block30" HEIGHT="1590" WIDTH="2406" VPOS="3734" HPOS="3902"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <Shape>
+                        <Polygon
+                            POINTS="3902,3734 6308,3734 6308,5324 4404,5324 4404,4856 3902,4856 3902,3734" />
+                    </Shape>
+                    <TextLine BASELINE="3813" HEIGHT="84" WIDTH="364" VPOS="3747" HPOS="3919">
+                        <String WC="0.56000000238418579" CONTENT="is" HEIGHT="64" WIDTH="52"
+                            VPOS="3751" HPOS="3919" />
+                        <SP HEIGHT="44" WIDTH="24" VPOS="3769" HPOS="3972" />
+                        <String WC="0.74000000953674316" CONTENT="a" HEIGHT="44" WIDTH="36"
+                            VPOS="3769" HPOS="3997" />
+                        <SP HEIGHT="62" WIDTH="28" VPOS="3769" HPOS="4034" />
+                        <String WC="0.8216666579246521" CONTENT="place." HEIGHT="84" WIDTH="220"
+                            VPOS="3747" HPOS="4063" />
+                    </TextLine>
+                    <TextLine BASELINE="3949" HEIGHT="92" WIDTH="2374" VPOS="3879" HPOS="3923">
+                        <String WC="0.9649999737739563" CONTENT=".." HEIGHT="12" WIDTH="58"
+                            VPOS="3943" HPOS="3923" />
+                        <SP HEIGHT="12" WIDTH="36" VPOS="3943" HPOS="3982" />
+                        <String WC="1." CONTENT=".a" HEIGHT="46" WIDTH="80" VPOS="3909" HPOS="4019" />
+                        <SP HEIGHT="62" WIDTH="30" VPOS="3909" HPOS="4100" />
+                        <String WC="0.91200000047683716" CONTENT="place" HEIGHT="84" WIDTH="200"
+                            VPOS="3887" HPOS="4131" />
+                        <SP HEIGHT="56" WIDTH="26" VPOS="3897" HPOS="4332" />
+                        <String WC="0.88999998569488525" CONTENT="to" HEIGHT="58" WIDTH="78"
+                            VPOS="3897" HPOS="4359" />
+                        <SP HEIGHT="70" WIDTH="26" VPOS="3885" HPOS="4438" />
+                        <String WC="1." CONTENT="do" HEIGHT="70" WIDTH="100" VPOS="3885" HPOS="4465" />
+                        <SP HEIGHT="58" WIDTH="30" VPOS="3897" HPOS="4566" />
+                        <String WC="1." CONTENT="the" HEIGHT="68" WIDTH="118" VPOS="3885"
+                            HPOS="4597" />
+                        <SP HEIGHT="56" WIDTH="32" VPOS="3897" HPOS="4716" />
+                        <String WC="0.9649999737739563" CONTENT="things" HEIGHT="84" WIDTH="232"
+                            VPOS="3885" HPOS="4749" />
+                        <SP HEIGHT="54" WIDTH="26" VPOS="3897" HPOS="4982" />
+                        <String WC="0.97333335876464844" CONTENT="the" HEIGHT="68" WIDTH="120"
+                            VPOS="3883" HPOS="5009" />
+                        <SP HEIGHT="66" WIDTH="26" VPOS="3883" HPOS="5130" />
+                        <String WC="0.83625000715255737" CONTENT="People’s" HEIGHT="84" WIDTH="318"
+                            VPOS="3881" HPOS="5157" />
+                        <SP HEIGHT="70" WIDTH="26" VPOS="3879" HPOS="5476" />
+                        <String WC="0.94625002145767212" CONTENT="Computer" HEIGHT="84" WIDTH="392"
+                            VPOS="3879" HPOS="5503" />
+                        <SP HEIGHT="68" WIDTH="28" VPOS="3879" HPOS="5896" />
+                        <String WC="0.86000001430511475" CONTENT="Company" HEIGHT="84" WIDTH="372"
+                            VPOS="3879" HPOS="5925" />
+                    </TextLine>
+                    <TextLine BASELINE="4060" HEIGHT="70" WIDTH="446" VPOS="3993" HPOS="4063">
+                        <String WC="0.85799998044967651" CONTENT="talks" HEIGHT="68" WIDTH="180"
+                            VPOS="3993" HPOS="4063" />
+                        <SP HEIGHT="46" WIDTH="18" VPOS="4015" HPOS="4244" />
+                        <String WC="0.9466666579246521" CONTENT="about." HEIGHT="68" WIDTH="246"
+                            VPOS="3995" HPOS="4263" />
+                    </TextLine>
+                    <TextLine BASELINE="4165" HEIGHT="88" WIDTH="2136" VPOS="4097" HPOS="3921">
+                        <String WC="0.92500001192092896" CONTENT=".." HEIGHT="14" WIDTH="60"
+                            VPOS="4157" HPOS="3921" />
+                        <SP HEIGHT="14" WIDTH="36" VPOS="4157" HPOS="3982" />
+                        <String WC="1." CONTENT="." HEIGHT="12" WIDTH="14" VPOS="4157" HPOS="4019" />
+                        <SP HEIGHT="46" WIDTH="28" VPOS="4123" HPOS="4034" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="38" VPOS="4123" HPOS="4063" />
+                        <SP HEIGHT="62" WIDTH="28" VPOS="4123" HPOS="4102" />
+                        <String WC="0.94599997997283936" CONTENT="place" HEIGHT="84" WIDTH="198"
+                            VPOS="4101" HPOS="4131" />
+                        <SP HEIGHT="56" WIDTH="30" VPOS="4113" HPOS="4330" />
+                        <String WC="0.9100000262260437" CONTENT="to" HEIGHT="56" WIDTH="78"
+                            VPOS="4113" HPOS="4361" />
+                        <SP HEIGHT="62" WIDTH="26" VPOS="4123" HPOS="4440" />
+                        <String WC="1." CONTENT="play" HEIGHT="84" WIDTH="172" VPOS="4101"
+                            HPOS="4467" />
+                        <SP HEIGHT="58" WIDTH="22" VPOS="4123" HPOS="4640" />
+                        <String WC="1." CONTENT="with" HEIGHT="68" WIDTH="170" VPOS="4099"
+                            HPOS="4663" />
+                        <SP HEIGHT="68" WIDTH="30" VPOS="4099" HPOS="4834" />
+                        <String WC="0.93777775764465332" CONTENT="computers" HEIGHT="70" WIDTH="410"
+                            VPOS="4111" HPOS="4865" />
+                        <SP HEIGHT="46" WIDTH="28" VPOS="4119" HPOS="5276" />
+                        <String WC="1." CONTENT="—" HEIGHT="8" WIDTH="56" VPOS="4137" HPOS="5305" />
+                        <SP HEIGHT="46" WIDTH="26" VPOS="4119" HPOS="5362" />
+                        <String WC="1." CONTENT="at" HEIGHT="56" WIDTH="72" VPOS="4109" HPOS="5389" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="4109" HPOS="5462" />
+                        <String WC="1." CONTENT="modest" HEIGHT="68" WIDTH="282" VPOS="4097"
+                            HPOS="5491" />
+                        <SP HEIGHT="72" WIDTH="24" VPOS="4107" HPOS="5774" />
+                        <String WC="0.92857140302658081" CONTENT="prices." HEIGHT="80" WIDTH="258"
+                            VPOS="4099" HPOS="5799" />
+                    </TextLine>
+                    <TextLine BASELINE="4273" HEIGHT="86" WIDTH="1646" VPOS="4207" HPOS="3921">
+                        <String WC="1." CONTENT="..." HEIGHT="12" WIDTH="112" VPOS="4265"
+                            HPOS="3921" />
+                        <SP HEIGHT="48" WIDTH="26" VPOS="4229" HPOS="4034" />
+                        <String WC="0.56000000238418579" CONTENT="a" HEIGHT="48" WIDTH="38"
+                            VPOS="4229" HPOS="4061" />
+                        <SP HEIGHT="64" WIDTH="30" VPOS="4229" HPOS="4100" />
+                        <String WC="0.88400000333786011" CONTENT="place" HEIGHT="84" WIDTH="198"
+                            VPOS="4209" HPOS="4131" />
+                        <SP HEIGHT="56" WIDTH="30" VPOS="4221" HPOS="4330" />
+                        <String WC="1." CONTENT="to" HEIGHT="56" WIDTH="78" VPOS="4221" HPOS="4361" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="4209" HPOS="4440" />
+                        <String WC="0.87199997901916504" CONTENT="learn" HEIGHT="68" WIDTH="188"
+                            VPOS="4209" HPOS="4467" />
+                        <SP HEIGHT="68" WIDTH="32" VPOS="4207" HPOS="4656" />
+                        <String WC="1." CONTENT="how" HEIGHT="70" WIDTH="164" VPOS="4207"
+                            HPOS="4689" />
+                        <SP HEIGHT="56" WIDTH="30" VPOS="4219" HPOS="4854" />
+                        <String WC="1." CONTENT="to" HEIGHT="56" WIDTH="76" VPOS="4219" HPOS="4885" />
+                        <SP HEIGHT="46" WIDTH="32" VPOS="4229" HPOS="4962" />
+                        <String WC="1." CONTENT="use" HEIGHT="46" WIDTH="114" VPOS="4227"
+                            HPOS="4995" />
+                        <SP HEIGHT="46" WIDTH="30" VPOS="4227" HPOS="5110" />
+                        <String WC="0.96299999952316284" CONTENT="computers." HEIGHT="72"
+                            WIDTH="426" VPOS="4217" HPOS="5141" />
+                    </TextLine>
+                    <TextLine BASELINE="4413" HEIGHT="88" WIDTH="2234" VPOS="4343" HPOS="3921">
+                        <String WC="0.5" CONTENT="We" HEIGHT="68" WIDTH="108" VPOS="4349"
+                            HPOS="3921" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="4349" HPOS="4030" />
+                        <String WC="1." CONTENT="have" HEIGHT="68" WIDTH="174" VPOS="4349"
+                            HPOS="4057" />
+                        <SP HEIGHT="46" WIDTH="22" VPOS="4371" HPOS="4232" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="36" VPOS="4371" HPOS="4255" />
+                        <SP HEIGHT="48" WIDTH="30" VPOS="4369" HPOS="4292" />
+                        <String WC="0.87333333492279053" CONTENT="small," HEIGHT="84" WIDTH="222"
+                            VPOS="4347" HPOS="4323" />
+                        <SP HEIGHT="84" WIDTH="28" VPOS="4347" HPOS="4546" />
+                        <String WC="0.94749999046325684" CONTENT="friendly" HEIGHT="82" WIDTH="312"
+                            VPOS="4347" HPOS="4575" />
+                        <SP HEIGHT="60" WIDTH="26" VPOS="4369" HPOS="4888" />
+                        <String WC="0.99250000715255737" CONTENT="computer" HEIGHT="74" WIDTH="374"
+                            VPOS="4357" HPOS="4915" />
+                        <SP HEIGHT="46" WIDTH="30" VPOS="4367" HPOS="5290" />
+                        <String WC="1." CONTENT="..." HEIGHT="12" WIDTH="112" VPOS="4401"
+                            HPOS="5321" />
+                        <SP HEIGHT="46" WIDTH="28" VPOS="4367" HPOS="5434" />
+                        <String WC="1." CONTENT="an" HEIGHT="46" WIDTH="90" VPOS="4367" HPOS="5463" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="4347" HPOS="5554" />
+                        <String WC="0.99888890981674194" CONTENT="EduSystem" HEIGHT="82" WIDTH="442"
+                            VPOS="4343" HPOS="5583" />
+                        <SP HEIGHT="68" WIDTH="30" VPOS="4343" HPOS="6026" />
+                        <String WC="0.7149999737739563" CONTENT="20" HEIGHT="68" WIDTH="98"
+                            VPOS="4343" HPOS="6057" />
+                    </TextLine>
+                    <TextLine BASELINE="4519" HEIGHT="90" WIDTH="2200" VPOS="4451" HPOS="3919">
+                        <String WC="1." CONTENT="(see" HEIGHT="82" WIDTH="142" VPOS="4455"
+                            HPOS="3919" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="4455" HPOS="4062" />
+                        <String WC="0.89999997615814209" CONTENT="Page" HEIGHT="86" WIDTH="176"
+                            VPOS="4455" HPOS="4089" />
+                        <SP HEIGHT="68" WIDTH="28" VPOS="4455" HPOS="4266" />
+                        <String WC="0.79750001430511475" CONTENT="14)," HEIGHT="84" WIDTH="148"
+                            VPOS="4453" HPOS="4295" />
+                        <SP HEIGHT="62" WIDTH="28" VPOS="4475" HPOS="4444" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="36" VPOS="4475" HPOS="4473" />
+                        <SP HEIGHT="54" WIDTH="36" VPOS="4467" HPOS="4510" />
+                        <String WC="0.92454546689987183" CONTENT="timesharing" HEIGHT="86"
+                            WIDTH="448" VPOS="4453" HPOS="4547" />
+                        <SP HEIGHT="74" WIDTH="32" VPOS="4465" HPOS="4996" />
+                        <String WC="0.83249998092651367" CONTENT="terminal" HEIGHT="70" WIDTH="320"
+                            VPOS="4451" HPOS="5029" />
+                        <SP HEIGHT="68" WIDTH="30" VPOS="4451" HPOS="5350" />
+                        <String WC="0.94499999284744263" CONTENT="that" HEIGHT="68" WIDTH="148"
+                            VPOS="4451" HPOS="5381" />
+                        <SP HEIGHT="56" WIDTH="30" VPOS="4463" HPOS="5530" />
+                        <String WC="1." CONTENT="connects" HEIGHT="56" WIDTH="346" VPOS="4463"
+                            HPOS="5561" />
+                        <SP HEIGHT="46" WIDTH="28" VPOS="4473" HPOS="5908" />
+                        <String WC="1." CONTENT="us" HEIGHT="46" WIDTH="78" VPOS="4473" HPOS="5937" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="4461" HPOS="6016" />
+                        <String WC="1." CONTENT="to" HEIGHT="58" WIDTH="74" VPOS="4461" HPOS="6045" />
+                    </TextLine>
+                    <TextLine BASELINE="4626" HEIGHT="88" WIDTH="2210" VPOS="4557" HPOS="3923">
+                        <String WC="1." CONTENT="the" HEIGHT="68" WIDTH="114" VPOS="4561"
+                            HPOS="3923" />
+                        <SP HEIGHT="46" WIDTH="30" VPOS="4583" HPOS="4038" />
+                        <String WC="0.84399998188018799" CONTENT="world" HEIGHT="70" WIDTH="218"
+                            VPOS="4561" HPOS="4069" />
+                        <SP HEIGHT="68" WIDTH="28" VPOS="4563" HPOS="4288" />
+                        <String WC="0.74333333969116211" CONTENT="and" HEIGHT="68" WIDTH="136"
+                            VPOS="4561" HPOS="4317" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="4561" HPOS="4454" />
+                        <String WC="1." CONTENT="a" HEIGHT="44" WIDTH="36" VPOS="4583" HPOS="4481" />
+                        <SP HEIGHT="66" WIDTH="38" VPOS="4563" HPOS="4518" />
+                        <String WC="0.81999999284744263" CONTENT="Textronix" HEIGHT="66" WIDTH="390"
+                            VPOS="4563" HPOS="4557" />
+                        <SP HEIGHT="62" WIDTH="22" VPOS="4583" HPOS="4948" />
+                        <String WC="0.95833331346511841" CONTENT="programmable" HEIGHT="88"
+                            WIDTH="558" VPOS="4557" HPOS="4971" />
+                        <SP HEIGHT="46" WIDTH="30" VPOS="4581" HPOS="5530" />
+                        <String WC="0.94090908765792847" CONTENT="calculator," HEIGHT="82"
+                            WIDTH="404" VPOS="4557" HPOS="5561" />
+                        <SP HEIGHT="60" WIDTH="26" VPOS="4579" HPOS="5966" />
+                        <String WC="1." CONTENT="and" HEIGHT="68" WIDTH="140" VPOS="4557"
+                            HPOS="5993" />
+                    </TextLine>
+                    <TextLine BASELINE="4733" HEIGHT="90" WIDTH="2264" VPOS="4663" HPOS="3919">
+                        <String WC="0.79750001430511475" CONTENT="some" HEIGHT="48" WIDTH="194"
+                            VPOS="4689" HPOS="3919" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="4691" HPOS="4114" />
+                        <String WC="0.83799999952316284" CONTENT="small" HEIGHT="66" WIDTH="202"
+                            VPOS="4669" HPOS="4139" />
+                        <SP HEIGHT="66" WIDTH="24" VPOS="4669" HPOS="4342" />
+                        <String WC="0.8399999737739563" CONTENT="simple" HEIGHT="84" WIDTH="250"
+                            VPOS="4669" HPOS="4367" />
+                        <SP HEIGHT="46" WIDTH="28" VPOS="4691" HPOS="4618" />
+                        <String WC="0.84727275371551514" CONTENT="calculators" HEIGHT="70"
+                            WIDTH="420" VPOS="4667" HPOS="4647" />
+                        <SP HEIGHT="48" WIDTH="18" VPOS="4687" HPOS="5068" />
+                        <String WC="1." CONTENT="and" HEIGHT="68" WIDTH="140" VPOS="4667"
+                            HPOS="5087" />
+                        <SP HEIGHT="68" WIDTH="32" VPOS="4667" HPOS="5228" />
+                        <String WC="1." CONTENT="books" HEIGHT="68" WIDTH="232" VPOS="4667"
+                            HPOS="5261" />
+                        <SP HEIGHT="56" WIDTH="28" VPOS="4677" HPOS="5494" />
+                        <String WC="1." CONTENT="to" HEIGHT="58" WIDTH="72" VPOS="4677" HPOS="5523" />
+                        <SP HEIGHT="70" WIDTH="30" VPOS="4665" HPOS="5596" />
+                        <String WC="0.83499997854232788" CONTENT="help" HEIGHT="84" WIDTH="164"
+                            VPOS="4665" HPOS="5627" />
+                        <SP HEIGHT="62" WIDTH="28" VPOS="4687" HPOS="5792" />
+                        <String WC="1." CONTENT="you" HEIGHT="60" WIDTH="148" VPOS="4687"
+                            HPOS="5821" />
+                        <SP HEIGHT="68" WIDTH="24" VPOS="4663" HPOS="5970" />
+                        <String WC="0.80800002813339233" CONTENT="learn" HEIGHT="68" WIDTH="188"
+                            VPOS="4663" HPOS="5995" />
+                    </TextLine>
+                    <TextLine BASELINE="4840" HEIGHT="65" WIDTH="282" VPOS="4775" HPOS="3919">
+                        <String WC="0.88666665554046631" CONTENT="and..." HEIGHT="65" WIDTH="282"
+                            VPOS="4775" HPOS="3919" />
+                    </TextLine>
+                    <TextLine BASELINE="4980" HEIGHT="72" WIDTH="1336" VPOS="4911" HPOS="4421">
+                        <String WC="0.9962499737739563" CONTENT="PEOPLE’S" HEIGHT="68" WIDTH="420"
+                            VPOS="4915" HPOS="4421" />
+                        <SP HEIGHT="70" WIDTH="24" VPOS="4913" HPOS="4842" />
+                        <String WC="0.6600000262260437" CONTENT="COMPUTER" HEIGHT="70" WIDTH="494"
+                            VPOS="4913" HPOS="4867" />
+                        <SP HEIGHT="70" WIDTH="32" VPOS="4911" HPOS="5362" />
+                        <String WC="1." CONTENT="CENTER" HEIGHT="70" WIDTH="362" VPOS="4911"
+                            HPOS="5395" />
+                    </TextLine>
+                    <TextLine BASELINE="5087" HEIGHT="70" WIDTH="856" VPOS="5021" HPOS="4425">
+                        <String WC="0.82749998569488525" CONTENT="1921" HEIGHT="70" WIDTH="180"
+                            VPOS="5021" HPOS="4425" />
+                        <SP HEIGHT="66" WIDTH="36" VPOS="5023" HPOS="4606" />
+                        <String WC="0.93714284896850586" CONTENT="Menalto" HEIGHT="68" WIDTH="318"
+                            VPOS="5021" HPOS="4643" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="5021" HPOS="4962" />
+                        <String WC="0.98666667938232422" CONTENT="Avenue" HEIGHT="66" WIDTH="292"
+                            VPOS="5021" HPOS="4989" />
+                    </TextLine>
+                    <TextLine BASELINE="5194" HEIGHT="88" WIDTH="1176" VPOS="5123" HPOS="4419">
+                        <String WC="0.92400002479553223" CONTENT="Menlo" HEIGHT="70" WIDTH="238"
+                            VPOS="5127" HPOS="4419" />
+                        <SP HEIGHT="68" WIDTH="28" VPOS="5129" HPOS="4658" />
+                        <String WC="0.99800002574920654" CONTENT="Park," HEIGHT="82" WIDTH="196"
+                            VPOS="5129" HPOS="4687" />
+                        <SP HEIGHT="84" WIDTH="32" VPOS="5127" HPOS="4884" />
+                        <String WC="0.88499999046325684" CONTENT="California" HEIGHT="68"
+                            WIDTH="376" VPOS="5127" HPOS="4917" />
+                        <SP HEIGHT="70" WIDTH="60" VPOS="5125" HPOS="5294" />
+                        <String WC="0.94199997186660767" CONTENT="94025" HEIGHT="72" WIDTH="240"
+                            VPOS="5123" HPOS="5355" />
+                    </TextLine>
+                    <TextLine BASELINE="5296" HEIGHT="80" WIDTH="620" VPOS="5233" HPOS="4425">
+                        <String WC="1." CONTENT="(415)" HEIGHT="80" WIDTH="210" VPOS="5233"
+                            HPOS="4425" />
+                        <SP HEIGHT="76" WIDTH="30" VPOS="5235" HPOS="4636" />
+                        <String WC="0.72374999523162842" CONTENT="323-6117" HEIGHT="66" WIDTH="378"
+                            VPOS="5233" HPOS="4667" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block31" HEIGHT="128" WIDTH="1626" VPOS="7756" HPOS="4092"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="7861" HEIGHT="104" WIDTH="1604" VPOS="7769" HPOS="4105">
+                        <String WC="0.2824999988079071" CONTENT="TAKE" HEIGHT="98" WIDTH="356"
+                            VPOS="7769" HPOS="4105" />
+                        <SP HEIGHT="82" WIDTH="56" VPOS="7777" HPOS="4462" />
+                        <String WC="0.51999998092651367" CONTENT="A" HEIGHT="80" WIDTH="106"
+                            VPOS="7777" HPOS="4519" />
+                        <SP HEIGHT="80" WIDTH="52" VPOS="7777" HPOS="4626" />
+                        <String WC="0.28999999165534973" CONTENT="PEEK" HEIGHT="88" WIDTH="374"
+                            VPOS="7779" HPOS="4679" />
+                        <SP HEIGHT="84" WIDTH="40" VPOS="7783" HPOS="5054" />
+                        <String WC="0.22571428120136261" CONTENT="TNSTDE." HEIGHT="90" WIDTH="614"
+                            VPOS="7783" HPOS="5095" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block32" HEIGHT="164" WIDTH="2230" VPOS="7984" HPOS="4096"
+                    STYLEREFS="StyleId-579500E1-308F-4B83-B9ED-DE8E7E9C7282-">
+                    <TextLine BASELINE="8106" HEIGHT="140" WIDTH="2206" VPOS="7997" HPOS="4109">
+                        <String WC="0.57999998331069946" LANG="fr" CONTENT="^Ctrà." HEIGHT="106"
+                            WIDTH="358" VPOS="7997" HPOS="4109" />
+                        <SP HEIGHT="64" WIDTH="48" VPOS="8035" HPOS="4468" />
+                        <String WC="0.26857143640518188" LANG="de" CONTENT="ttmövä." HEIGHT="74"
+                            WIDTH="330" VPOS="8029" HPOS="4517" />
+                        <SP HEIGHT="80" WIDTH="52" VPOS="8023" HPOS="4848" />
+                        <String WC="0.42500001192092896" LANG="en-US" CONTENT="Copies" HEIGHT="114"
+                            WIDTH="418" VPOS="8023" HPOS="4901" />
+                        <SP HEIGHT="70" WIDTH="78" VPOS="8045" HPOS="5320" />
+                        <String WC="0.62000000476837158" LANG="en-US" CONTENT="oS" HEIGHT="104"
+                            WIDTH="124" VPOS="8003" HPOS="5399" />
+                        <SP HEIGHT="104" WIDTH="48" VPOS="8003" HPOS="5524" />
+                        <String WC="0.98500001430511475" LANG="en-US" CONTENT="this" HEIGHT="100"
+                            WIDTH="262" VPOS="8015" HPOS="5573" />
+                        <SP HEIGHT="96" WIDTH="36" VPOS="8019" HPOS="5836" />
+                        <String WC="0.41999998688697815" LANG="de" CONTENT="XSSUUÄ" HEIGHT="100"
+                            WIDTH="344" VPOS="8019" HPOS="5873" />
+                        <SP HEIGHT="116" WIDTH="42" VPOS="7999" HPOS="6218" />
+                        <String WC="1." LANG="en-US" CONTENT="?" HEIGHT="106" WIDTH="54" VPOS="7999"
+                            HPOS="6261" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block33" HEIGHT="128" WIDTH="648" VPOS="8222" HPOS="4440"
+                    STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="8329" HEIGHT="104" WIDTH="624" VPOS="8235" HPOS="4453">
+                        <String WC="0.26399999856948853" LANG="fr" CONTENT="QUANT" HEIGHT="100"
+                            WIDTH="404" VPOS="8235" HPOS="4453" />
+                        <SP HEIGHT="82" WIDTH="16" VPOS="8251" HPOS="4858" />
+                        <String WC="0.42333334684371948" LANG="en-US" CONTENT="XT^" HEIGHT="96"
+                            WIDTH="202" VPOS="8243" HPOS="4875" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block34" HEIGHT="116" WIDTH="420" VPOS="8220" HPOS="5502"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="8322" HEIGHT="92" WIDTH="396" VPOS="8233" HPOS="5515">
+                        <String WC="0.63599997758865356" CONTENT="PRICE" HEIGHT="92" WIDTH="396"
+                            VPOS="8233" HPOS="5515" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block35" HEIGHT="250" WIDTH="640" VPOS="8452" HPOS="5506"
+                    STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="8563" HEIGHT="102" WIDTH="530" VPOS="8465" HPOS="5527">
+                        <String WC="1." LANG="fr" CONTENT="à" HEIGHT="102" WIDTH="60" VPOS="8465"
+                            HPOS="5527" />
+                        <String WC="0.57249999046325684" LANG="en-US" CONTENT="0.50" HEIGHT="88"
+                            WIDTH="250" VPOS="8479" HPOS="5603" />
+                        <SP HEIGHT="80" WIDTH="38" VPOS="8487" HPOS="5854" />
+                        <String WC="0.57333332300186157" LANG="ru" CONTENT="4а." HEIGHT="72"
+                            WIDTH="164" VPOS="8487" HPOS="5893" />
+                    </TextLine>
+                    <TextLine BASELINE="8682" HEIGHT="92" WIDTH="544" VPOS="8599" HPOS="5519">
+                        <String WC="0.43999999761581421" LANG="en-US" CONTENT="$0.^0" HEIGHT="92"
+                            WIDTH="334" VPOS="8599" HPOS="5519" />
+                        <SP HEIGHT="76" WIDTH="36" VPOS="8609" HPOS="5854" />
+                        <String WC="0.43000000715255737" LANG="fr" CONTENT="CA." HEIGHT="72"
+                            WIDTH="172" VPOS="8613" HPOS="5891" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block36" HEIGHT="410" WIDTH="2186" VPOS="8608" HPOS="4134"
+                    LANG="en-US" STYLEREFS="StyleId-579500E1-308F-4B83-B9ED-DE8E7E9C7282-">
+                    <Shape>
+                        <Polygon
+                            POINTS="4134,8608 5182,8608 5182,8734 6320,8734 6320,9018 4134,9018 4134,8608" />
+                    </Shape>
+                    <TextLine BASELINE="8694" HEIGHT="74" WIDTH="706" VPOS="8623" HPOS="4465"
+                        STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                        <String WC="0.3033333420753479" CONTENT="VOO" HEIGHT="72" WIDTH="190"
+                            VPOS="8623" HPOS="4465" />
+                        <SP HEIGHT="66" WIDTH="40" VPOS="8629" HPOS="4656" />
+                        <String WC="0.27500000596046448" LANG="ru" CONTENT="от" HEIGHT="64"
+                            WIDTH="112" VPOS="8629" HPOS="4697" />
+                        <SP HEIGHT="60" WIDTH="46" VPOS="8631" HPOS="4810" />
+                        <String WC="0.46500000357627869" CONTENT="TV\0r£" HEIGHT="72" WIDTH="314"
+                            VPOS="8625" HPOS="4857" />
+                    </TextLine>
+                    <TextLine BASELINE="8874" HEIGHT="152" WIDTH="2152" VPOS="8749" HPOS="4157">
+                        <String WC="0.54714286327362061" CONTENT="V\gjol^" HEIGHT="118" WIDTH="448"
+                            VPOS="8769" HPOS="4157" />
+                        <SP HEIGHT="86" WIDTH="76" VPOS="8801" HPOS="4606" />
+                        <String WC="0.51999998092651367" CONTENT="se.^" HEIGHT="98" WIDTH="328"
+                            VPOS="8779" HPOS="4683" />
+                        <SP HEIGHT="28" WIDTH="296" VPOS="8851" HPOS="5041" />
+                        <String WC="0.30166667699813843" CONTENT="copies" HEIGHT="124" WIDTH="404"
+                            VPOS="8777" HPOS="5359" />
+                        <SP HEIGHT="74" WIDTH="84" VPOS="8795" HPOS="5764" />
+                        <String WC="0.56999999284744263" LANG="fr" CONTENT="oÇ" HEIGHT="122"
+                            WIDTH="140" VPOS="8749" HPOS="5849" />
+                        <SP HEIGHT="122" WIDTH="64" VPOS="8749" HPOS="5990" />
+                        <String WC="0.50749999284744263" CONTENT="^he." HEIGHT="112" WIDTH="254"
+                            VPOS="8763" HPOS="6055" />
+                    </TextLine>
+                    <TextLine BASELINE="8994" HEIGHT="118" WIDTH="2144" VPOS="8889" HPOS="4149">
+                        <String WC="0.37999999523162842" LANG="fr" CONTENT="ÔCX" HEIGHT="82"
+                            WIDTH="200" VPOS="8925" HPOS="4149" />
+                        <SP HEIGHT="86" WIDTH="84" VPOS="8917" HPOS="4350" />
+                        <String WC="0.2199999988079071" CONTENT="WZ" HEIGHT="86" WIDTH="250"
+                            VPOS="8917" HPOS="4435" />
+                        <SP HEIGHT="100" WIDTH="70" VPOS="8895" HPOS="4686" />
+                        <String WC="0.14399999380111694" CONTENT="\ssux" HEIGHT="96" WIDTH="378"
+                            VPOS="8895" HPOS="4757" />
+                        <SP HEIGHT="76" WIDTH="76" VPOS="8915" HPOS="5136" />
+                        <String WC="0.64499998092651367" CONTENT="O^" HEIGHT="104" WIDTH="134"
+                            VPOS="8891" HPOS="5213" />
+                        <SP HEIGHT="104" WIDTH="84" VPOS="8891" HPOS="5348" />
+                        <String WC="0.32499998807907104" CONTENT="VCC." HEIGHT="94" WIDTH="286"
+                            VPOS="8903" HPOS="5433" />
+                        <SP HEIGHT="98" WIDTH="46" VPOS="8889" HPOS="5720" />
+                        <String WC="1." CONTENT="^" HEIGHT="96" WIDTH="82" VPOS="8889" HPOS="5767" />
+                        <SP HEIGHT="28" WIDTH="424" VPOS="8963" HPOS="5869" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page2_Block37" HEIGHT="248" WIDTH="566" VPOS="9246" HPOS="4132"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="9358" HEIGHT="114" WIDTH="543" VPOS="9261" HPOS="4155">
+                        <String WC="0.64999997615814209" CONTENT="Najr\&amp;" HEIGHT="106"
+                            WIDTH="344" VPOS="9261" HPOS="4155" />
+                        <SP HEIGHT="90" WIDTH="50" VPOS="9285" HPOS="4500" />
+                        <String WC="0.63999998569488525" CONTENT="," HEIGHT="22" WIDTH="14"
+                            VPOS="9353" HPOS="4551" />
+                        <SP HEIGHT="18" WIDTH="133" VPOS="9357" HPOS="4565" />
+                    </TextLine>
+                    <TextLine BASELINE="9478" HEIGHT="87" WIDTH="538" VPOS="9391" HPOS="4149">
+                        <String WC="0.3271428644657135" CONTENT="AAdrass" HEIGHT="87" WIDTH="538"
+                            VPOS="9391" HPOS="4149" />
+                    </TextLine>
+                </TextBlock>
+                <GraphicalElement ID="Page2_Block38" HEIGHT="42" WIDTH="590" VPOS="6392" HPOS="4242" />
+                <GraphicalElement ID="Page2_Block39" HEIGHT="26" WIDTH="328" VPOS="6836" HPOS="856" />
+                <GraphicalElement ID="Page2_Block40" HEIGHT="24" WIDTH="422" VPOS="8962" HPOS="5868" />
+                <GraphicalElement ID="Page2_Block41" HEIGHT="18" WIDTH="1754" VPOS="9356"
+                    HPOS="4550" />
+                <GraphicalElement ID="Page2_Block42" HEIGHT="16" WIDTH="1588" VPOS="9478"
+                    HPOS="4712" />
+                <GraphicalElement ID="Page2_Block43" HEIGHT="18" WIDTH="1578" VPOS="9596"
+                    HPOS="4720" />
+                <GraphicalElement ID="Page2_Block44" HEIGHT="34" WIDTH="1186" VPOS="10554"
+                    HPOS="3718" />
+                <GraphicalElement ID="Page2_Block45" HEIGHT="46" WIDTH="2722" VPOS="10568"
+                    HPOS="614" />
+                <GraphicalElement ID="Page2_Block46" HEIGHT="10" WIDTH="382" VPOS="10572"
+                    HPOS="3336" />
+                <GraphicalElement ID="Page2_Block47" HEIGHT="36" WIDTH="276" VPOS="10588" HPOS="338" />
+                <GraphicalElement ID="Page2_Block48" HEIGHT="240" WIDTH="10" VPOS="844" HPOS="760" />
+                <GraphicalElement ID="Page2_Block49" HEIGHT="240" WIDTH="12" VPOS="840" HPOS="914" />
+                <GraphicalElement ID="Page2_Block50" HEIGHT="428" WIDTH="28" VPOS="7672" HPOS="1568" />
+                <GraphicalElement ID="Page2_Block51" HEIGHT="310" WIDTH="12" VPOS="834" HPOS="1570" />
+                <GraphicalElement ID="Page2_Block52" HEIGHT="374" WIDTH="30" VPOS="7136" HPOS="1674" />
+                <GraphicalElement ID="Page2_Block53" HEIGHT="270" WIDTH="16" VPOS="856" HPOS="1702" />
+                <GraphicalElement ID="Page2_Block54" HEIGHT="194" WIDTH="12" VPOS="1368" HPOS="1954" />
+                <GraphicalElement ID="Page2_Block55" HEIGHT="338" WIDTH="26" VPOS="6160" HPOS="4772" />
+                <GraphicalElement ID="Page2_Block56" HEIGHT="7912" WIDTH="85" VPOS="538" HPOS="6842" />
+            </PrintSpace>
+        </Page>
+        <Page ID="Page3" PHYSICAL_IMG_NR="3" HEIGHT="10703" WIDTH="6948">
+            <TopMargin HEIGHT="602" WIDTH="6948" VPOS="0" HPOS="0">
+</TopMargin>
+            <LeftMargin HEIGHT="10018" WIDTH="74" VPOS="602" HPOS="0">
+</LeftMargin>
+            <BottomMargin HEIGHT="83" WIDTH="6948" VPOS="10620" HPOS="0">
+</BottomMargin>
+            <PrintSpace HEIGHT="10018" WIDTH="6874" VPOS="602" HPOS="74">
+                <TextBlock ID="Page3_Block1" HEIGHT="726" WIDTH="1936" VPOS="672" HPOS="718"
+                    STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="1000" HEIGHT="312" WIDTH="1904" VPOS="692" HPOS="732"
+                        LANG="en-US">
+                        <String WC="0.45142856240272522" CONTENT="LOOKING" HEIGHT="312" WIDTH="1904"
+                            VPOS="692" HPOS="732" />
+                    </TextLine>
+                    <TextLine BASELINE="1376" HEIGHT="304" WIDTH="1744" VPOS="1076" HPOS="740">
+                        <String WC="0.70800000429153442" LANG="es" CONTENT="ATURE" HEIGHT="304"
+                            WIDTH="1400" VPOS="1076" HPOS="740" />
+                        <String WC="0.69999998807907104" LANG="en-US" CONTENT="." HEIGHT="72"
+                            WIDTH="72" VPOS="1308" HPOS="2204" />
+                        <SP HEIGHT="216" WIDTH="78" VPOS="1164" HPOS="2277" />
+                        <String WC="0.60500001907348633" LANG="en-US" CONTENT="¡»" HEIGHT="184"
+                            WIDTH="128" VPOS="1164" HPOS="2356" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block2" HEIGHT="614" WIDTH="1620" VPOS="1524" HPOS="744"
+                    LANG="en-US" STYLEREFS="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-">
+                    <TextLine BASELINE="1594" HEIGHT="60" WIDTH="826" VPOS="1536" HPOS="761">
+                        <String WC="0.9053846001625061" CONTENT="COMPUTERWORLD" HEIGHT="60"
+                            WIDTH="826" VPOS="1536" HPOS="761" />
+                    </TextLine>
+                    <TextLine BASELINE="1697" HEIGHT="80" WIDTH="1587" VPOS="1637" HPOS="764">
+                        <String WC="0.95999997854232788" CONTENT="“The" HEIGHT="59" WIDTH="158"
+                            VPOS="1637" HPOS="764" />
+                        <SP HEIGHT="36" WIDTH="27" VPOS="1661" HPOS="923" />
+                        <String WC="0.64899998903274536" CONTENT="newsweekly" HEIGHT="75"
+                            WIDTH="396" VPOS="1642" HPOS="951" />
+                        <SP HEIGHT="76" WIDTH="15" VPOS="1641" HPOS="1348" />
+                        <String WC="1." CONTENT="for" HEIGHT="75" WIDTH="106" VPOS="1641"
+                            HPOS="1364" />
+                        <SP HEIGHT="47" WIDTH="25" VPOS="1652" HPOS="1471" />
+                        <String WC="0.62333333492279053" CONTENT="the" HEIGHT="56" WIDTH="99"
+                            VPOS="1643" HPOS="1497" />
+                        <SP HEIGHT="36" WIDTH="26" VPOS="1662" HPOS="1597" />
+                        <String WC="0.77249997854232788" CONTENT="computer" HEIGHT="66" WIDTH="317"
+                            VPOS="1650" HPOS="1624" />
+                        <SP HEIGHT="35" WIDTH="24" VPOS="1660" HPOS="1942" />
+                        <String WC="0.77444446086883545" CONTENT="community" HEIGHT="72" WIDTH="384"
+                            VPOS="1641" HPOS="1967" />
+                    </TextLine>
+                    <TextLine BASELINE="1863" HEIGHT="82" WIDTH="890" VPOS="1800" HPOS="761">
+                        <String WC="0.82875001430511475" CONTENT="$9/year," HEIGHT="80" WIDTH="267"
+                            VPOS="1800" HPOS="761" />
+                        <SP HEIGHT="55" WIDTH="22" VPOS="1827" HPOS="1029" />
+                        <String WC="0.66666668653488159" CONTENT="published" HEIGHT="76" WIDTH="323"
+                            VPOS="1806" HPOS="1052" />
+                        <SP HEIGHT="58" WIDTH="24" VPOS="1806" HPOS="1376" />
+                        <String WC="0.79428571462631226" CONTENT="weekly." HEIGHT="74" WIDTH="250"
+                            VPOS="1807" HPOS="1401" />
+                    </TextLine>
+                    <TextLine BASELINE="1945" HEIGHT="80" WIDTH="789" VPOS="1885" HPOS="759">
+                        <String WC="0.75454545021057129" CONTENT="Circulation" HEIGHT="61"
+                            WIDTH="364" VPOS="1885" HPOS="759" />
+                        <SP HEIGHT="58" WIDTH="25" VPOS="1887" HPOS="1124" />
+                        <String WC="0.7839999794960022" CONTENT="Department" HEIGHT="78" WIDTH="398"
+                            VPOS="1887" HPOS="1150" />
+                    </TextLine>
+                    <TextLine BASELINE="2028" HEIGHT="81" WIDTH="751" VPOS="1968" HPOS="761">
+                        <String WC="1." CONTENT="797" HEIGHT="59" WIDTH="120" VPOS="1970" HPOS="761" />
+                        <SP HEIGHT="61" WIDTH="28" VPOS="1968" HPOS="882" />
+                        <String WC="0.65700000524520874" CONTENT="Washington" HEIGHT="81"
+                            WIDTH="376" VPOS="1968" HPOS="911" />
+                        <SP HEIGHT="61" WIDTH="26" VPOS="1969" HPOS="1288" />
+                        <String WC="0.9100000262260437" CONTENT="Street" HEIGHT="61" WIDTH="197"
+                            VPOS="1969" HPOS="1315" />
+                    </TextLine>
+                    <TextLine BASELINE="2111" HEIGHT="75" WIDTH="742" VPOS="2050" HPOS="756">
+                        <String WC="0.77142858505249023" CONTENT="Newton," HEIGHT="75" WIDTH="278"
+                            VPOS="2050" HPOS="756" />
+                        <SP HEIGHT="72" WIDTH="26" VPOS="2053" HPOS="1035" />
+                        <String WC="0.70800000429153442" CONTENT="Mass." HEIGHT="61" WIDTH="173"
+                            VPOS="2053" HPOS="1062" />
+                        <SP HEIGHT="58" WIDTH="50" VPOS="2056" HPOS="1236" />
+                        <String WC="1." CONTENT="02160" HEIGHT="58" WIDTH="211" VPOS="2055"
+                            HPOS="1287" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block3" HEIGHT="850" WIDTH="1780" VPOS="2230" HPOS="744"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <TextLine BASELINE="2310" HEIGHT="86" WIDTH="1753" VPOS="2243" HPOS="760">
+                        <String WC="1." CONTENT="How" HEIGHT="66" WIDTH="173" VPOS="2243" HPOS="760" />
+                        <SP HEIGHT="63" WIDTH="31" VPOS="2246" HPOS="934" />
+                        <String WC="1." CONTENT="do" HEIGHT="64" WIDTH="94" VPOS="2246" HPOS="966" />
+                        <SP HEIGHT="61" WIDTH="31" VPOS="2266" HPOS="1061" />
+                        <String WC="0.9100000262260437" CONTENT="you" HEIGHT="60" WIDTH="146"
+                            VPOS="2267" HPOS="1093" />
+                        <SP HEIGHT="64" WIDTH="26" VPOS="2249" HPOS="1240" />
+                        <String WC="1." CONTENT="keep" HEIGHT="80" WIDTH="180" VPOS="2249"
+                            HPOS="1267" />
+                        <SP HEIGHT="61" WIDTH="29" VPOS="2268" HPOS="1448" />
+                        <String WC="1." CONTENT="up" HEIGHT="60" WIDTH="95" VPOS="2268" HPOS="1478" />
+                        <SP HEIGHT="61" WIDTH="26" VPOS="2267" HPOS="1574" />
+                        <String WC="1." CONTENT="with" HEIGHT="64" WIDTH="172" VPOS="2248"
+                            HPOS="1601" />
+                        <SP HEIGHT="62" WIDTH="31" VPOS="2249" HPOS="1774" />
+                        <String WC="0.95749998092651367" CONTENT="computer" HEIGHT="74" WIDTH="368"
+                            VPOS="2252" HPOS="1806" />
+                        <SP HEIGHT="44" WIDTH="28" VPOS="2265" HPOS="2175" />
+                        <String WC="0.99500000476837158" CONTENT="science?" HEIGHT="66" WIDTH="309"
+                            VPOS="2244" HPOS="2204" />
+                    </TextLine>
+                    <TextLine BASELINE="2409" HEIGHT="84" WIDTH="1661" VPOS="2343" HPOS="762">
+                        <String WC="1." CONTENT="Read" HEIGHT="66" WIDTH="187" VPOS="2343"
+                            HPOS="762" />
+                        <SP HEIGHT="65" WIDTH="33" VPOS="2344" HPOS="950" />
+                        <String WC="0.91714286804199219" CONTENT="Computerworld." HEIGHT="83"
+                            WIDTH="624" VPOS="2344" HPOS="984" />
+                        <SP HEIGHT="65" WIDTH="67" VPOS="2347" HPOS="1609" />
+                        <String WC="1." CONTENT="New" HEIGHT="63" WIDTH="168" VPOS="2347"
+                            HPOS="1677" />
+                        <SP HEIGHT="60" WIDTH="31" VPOS="2365" HPOS="1846" />
+                        <String WC="0.86000001430511475" CONTENT="products," HEIGHT="80" WIDTH="361"
+                            VPOS="2345" HPOS="1878" />
+                        <SP HEIGHT="57" WIDTH="30" VPOS="2365" HPOS="2240" />
+                        <String WC="0.98333334922790527" CONTENT="new" HEIGHT="45" WIDTH="152"
+                            VPOS="2364" HPOS="2271" />
+                    </TextLine>
+                    <TextLine BASELINE="2509" HEIGHT="82" WIDTH="1659" VPOS="2444" HPOS="759">
+                        <String WC="0.96230769157409668" CONTENT="applications," HEIGHT="81"
+                            WIDTH="487" VPOS="2444" HPOS="759" />
+                        <SP HEIGHT="58" WIDTH="29" VPOS="2466" HPOS="1247" />
+                        <String WC="0.98666667938232422" CONTENT="new" HEIGHT="44" WIDTH="150"
+                            VPOS="2466" HPOS="1277" />
+                        <SP HEIGHT="44" WIDTH="34" VPOS="2466" HPOS="1428" />
+                        <String WC="0.93900001049041748" CONTENT="companies," HEIGHT="79"
+                            WIDTH="425" VPOS="2447" HPOS="1463" />
+                        <SP HEIGHT="58" WIDTH="28" VPOS="2465" HPOS="1889" />
+                        <String WC="0.89249998331069946" CONTENT="mergers," HEIGHT="61" WIDTH="321"
+                            VPOS="2463" HPOS="1918" />
+                        <SP HEIGHT="78" WIDTH="29" VPOS="2444" HPOS="2240" />
+                        <String WC="1." CONTENT="fail" HEIGHT="65" WIDTH="122" VPOS="2444"
+                            HPOS="2270" SUBS_TYPE="HypPart1" SUBS_CONTENT="failures." />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="2621" HEIGHT="80" WIDTH="1674" VPOS="2554" HPOS="761">
+                        <String WC="0.83799999952316284" CONTENT="ures." HEIGHT="45" WIDTH="171"
+                            VPOS="2579" HPOS="761" SUBS_TYPE="HypPart2" SUBS_CONTENT="failures." />
+                        <SP HEIGHT="65" WIDTH="54" VPOS="2558" HPOS="933" />
+                        <String WC="1." CONTENT="The" HEIGHT="64" WIDTH="149" VPOS="2558" HPOS="988" />
+                        <SP HEIGHT="66" WIDTH="32" VPOS="2556" HPOS="1138" />
+                        <String WC="0.76999998092651367" CONTENT="Wall" HEIGHT="67" WIDTH="160"
+                            VPOS="2556" HPOS="1171" />
+                        <SP HEIGHT="65" WIDTH="23" VPOS="2557" HPOS="1332" />
+                        <String WC="0.77999997138977051" CONTENT="Street" HEIGHT="65" WIDTH="230"
+                            VPOS="2557" HPOS="1356" />
+                        <SP HEIGHT="65" WIDTH="20" VPOS="2557" HPOS="1587" />
+                        <String WC="0.95571428537368774" CONTENT="Journal" HEIGHT="66" WIDTH="298"
+                            VPOS="2555" HPOS="1608" />
+                        <SP HEIGHT="65" WIDTH="26" VPOS="2555" HPOS="1907" />
+                        <String WC="1." CONTENT="of" HEIGHT="66" WIDTH="85" VPOS="2554" HPOS="1934" />
+                        <SP HEIGHT="64" WIDTH="21" VPOS="2554" HPOS="2020" />
+                        <String WC="1." CONTENT="the" HEIGHT="64" WIDTH="120" VPOS="2554"
+                            HPOS="2042" />
+                        <SP HEIGHT="45" WIDTH="34" VPOS="2573" HPOS="2163" />
+                        <String WC="1." CONTENT="comp" HEIGHT="62" WIDTH="211" VPOS="2572"
+                            HPOS="2198" SUBS_TYPE="HypPart1" SUBS_CONTENT="computer" />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="2728" HEIGHT="85" WIDTH="1657" VPOS="2661" HPOS="761">
+                        <String WC="0.87000000476837158" CONTENT="uter" HEIGHT="59" WIDTH="150"
+                            VPOS="2673" HPOS="761" SUBS_TYPE="HypPart2" SUBS_CONTENT="computer" />
+                        <SP HEIGHT="63" WIDTH="29" VPOS="2667" HPOS="912" />
+                        <String WC="0.87555557489395142" CONTENT="industry." HEIGHT="80" WIDTH="342"
+                            VPOS="2666" HPOS="942" />
+                        <SP HEIGHT="66" WIDTH="59" VPOS="2664" HPOS="1285" />
+                        <String WC="0.95999997854232788" CONTENT="Standard" HEIGHT="66" WIDTH="339"
+                            VPOS="2664" HPOS="1345" />
+                        <SP HEIGHT="64" WIDTH="32" VPOS="2665" HPOS="1685" />
+                        <String WC="0.99777776002883911" CONTENT="newspaper" HEIGHT="62" WIDTH="406"
+                            VPOS="2681" HPOS="1718" />
+                        <SP HEIGHT="46" WIDTH="28" VPOS="2680" HPOS="2125" />
+                        <String WC="1." CONTENT="mosaic" HEIGHT="65" WIDTH="264" VPOS="2661"
+                            HPOS="2154" />
+                    </TextLine>
+                    <TextLine BASELINE="2836" HEIGHT="85" WIDTH="1674" VPOS="2769" HPOS="760">
+                        <String WC="1." CONTENT="format" HEIGHT="65" WIDTH="257" VPOS="2774"
+                            HPOS="760" />
+                        <SP HEIGHT="58" WIDTH="30" VPOS="2780" HPOS="1018" />
+                        <String WC="1." CONTENT="and" HEIGHT="65" WIDTH="134" VPOS="2773"
+                            HPOS="1049" />
+                        <SP HEIGHT="65" WIDTH="32" VPOS="2773" HPOS="1184" />
+                        <String WC="0.92699998617172241" CONTENT="reporting," HEIGHT="81"
+                            WIDTH="379" VPOS="2773" HPOS="1217" />
+                        <SP HEIGHT="58" WIDTH="25" VPOS="2792" HPOS="1597" />
+                        <String WC="1." CONTENT="with" HEIGHT="64" WIDTH="175" VPOS="2772"
+                            HPOS="1623" />
+                        <SP HEIGHT="64" WIDTH="30" VPOS="2772" HPOS="1799" />
+                        <String WC="0.93000000715255737" CONTENT="columnists," HEIGHT="77"
+                            WIDTH="434" VPOS="2770" HPOS="1830" />
+                        <SP HEIGHT="58" WIDTH="30" VPOS="2789" HPOS="2265" />
+                        <String WC="1." CONTENT="edi" HEIGHT="65" WIDTH="111" VPOS="2769"
+                            HPOS="2296" SUBS_TYPE="HypPart1" SUBS_CONTENT="editorial" />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="2943" HEIGHT="84" WIDTH="1687" VPOS="2877" HPOS="759">
+                        <String WC="1." CONTENT="torial" HEIGHT="65" WIDTH="202" VPOS="2881"
+                            HPOS="759" SUBS_TYPE="HypPart2" SUBS_CONTENT="editorial" />
+                        <SP HEIGHT="80" WIDTH="28" VPOS="2881" HPOS="962" />
+                        <String WC="0.90799999237060547" CONTENT="page," HEIGHT="61" WIDTH="195"
+                            VPOS="2900" HPOS="991" />
+                        <SP HEIGHT="76" WIDTH="31" VPOS="2882" HPOS="1187" />
+                        <String WC="1." CONTENT="in" HEIGHT="62" WIDTH="66" VPOS="2882" HPOS="1219" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="2880" HPOS="1286" />
+                        <String WC="0.9179999828338623" CONTENT="depth" HEIGHT="80" WIDTH="223"
+                            VPOS="2880" HPOS="1315" />
+                        <SP HEIGHT="64" WIDTH="29" VPOS="2880" HPOS="1539" />
+                        <String WC="0.98100000619888306" CONTENT="serialized" HEIGHT="65"
+                            WIDTH="348" VPOS="2879" HPOS="1569" />
+                        <SP HEIGHT="65" WIDTH="34" VPOS="2878" HPOS="1918" />
+                        <String WC="0.86888891458511353" CONTENT="features," HEIGHT="76" WIDTH="328"
+                            VPOS="2878" HPOS="1953" />
+                        <SP HEIGHT="57" WIDTH="28" VPOS="2897" HPOS="2282" />
+                        <String WC="1." CONTENT="and" HEIGHT="64" WIDTH="135" VPOS="2877"
+                            HPOS="2311" />
+                    </TextLine>
+                    <TextLine BASELINE="3051" HEIGHT="81" WIDTH="1018" VPOS="2986" HPOS="757">
+                        <String WC="1." CONTENT="articles" HEIGHT="66" WIDTH="272" VPOS="2987"
+                            HPOS="757" />
+                        <SP HEIGHT="45" WIDTH="26" VPOS="3007" HPOS="1030" />
+                        <String WC="1." CONTENT="of" HEIGHT="66" WIDTH="84" VPOS="2986" HPOS="1057" />
+                        <SP HEIGHT="81" WIDTH="19" VPOS="2986" HPOS="1142" />
+                        <String WC="1." CONTENT="general" HEIGHT="80" WIDTH="274" VPOS="2987"
+                            HPOS="1162" />
+                        <SP HEIGHT="64" WIDTH="30" VPOS="2987" HPOS="1437" />
+                        <String WC="0.9677777886390686" CONTENT="interest." HEIGHT="63" WIDTH="307"
+                            VPOS="2988" HPOS="1468" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block4" HEIGHT="185" WIDTH="1702" VPOS="4092" HPOS="2770"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="4166" HEIGHT="82" WIDTH="1644" VPOS="4105" HPOS="2816">
+                        <String WC="0.88666665554046631" CONTENT="One" HEIGHT="60" WIDTH="128"
+                            VPOS="4105" HPOS="2816" />
+                        <SP HEIGHT="56" WIDTH="20" VPOS="4128" HPOS="2945" />
+                        <String WC="0.66500002145767212" CONTENT="year" HEIGHT="55" WIDTH="146"
+                            VPOS="4129" HPOS="2966" />
+                        <SP HEIGHT="68" WIDTH="23" VPOS="4108" HPOS="3113" />
+                        <String WC="0.64300000667572021" CONTENT="(excluding" HEIGHT="78"
+                            WIDTH="346" VPOS="4108" HPOS="3137" />
+                        <SP HEIGHT="66" WIDTH="24" VPOS="4120" HPOS="3484" />
+                        <String WC="0.76333332061767578" CONTENT="the" HEIGHT="56" WIDTH="99"
+                            VPOS="4111" HPOS="3509" />
+                        <SP HEIGHT="60" WIDTH="27" VPOS="4107" HPOS="3609" />
+                        <String WC="0.67750000953674316" CONTENT="Computer" HEIGHT="80" WIDTH="333"
+                            VPOS="4107" HPOS="3637" />
+                        <SP HEIGHT="58" WIDTH="21" VPOS="4108" HPOS="3971" />
+                        <String WC="0.84777778387069702" CONTENT="Directory" HEIGHT="77" WIDTH="324"
+                            VPOS="4108" HPOS="3993" />
+                        <SP HEIGHT="54" WIDTH="19" VPOS="4131" HPOS="4318" />
+                        <String WC="0.95333331823348999" CONTENT="and" HEIGHT="57" WIDTH="122"
+                            VPOS="4111" HPOS="4338" />
+                    </TextLine>
+                    <TextLine BASELINE="4249" HEIGHT="81" WIDTH="1416" VPOS="4188" HPOS="2809">
+                        <String WC="0.71833330392837524" CONTENT="Buyers" HEIGHT="77" WIDTH="231"
+                            VPOS="4189" HPOS="2809" />
+                        <SP HEIGHT="61" WIDTH="23" VPOS="4188" HPOS="3041" />
+                        <String WC="0.58333331346511841" CONTENT="Guide)" HEIGHT="71" WIDTH="224"
+                            VPOS="4188" HPOS="3065" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="4191" HPOS="3290" />
+                        <String WC="1." CONTENT="12" HEIGHT="55" WIDTH="78" VPOS="4194" HPOS="3317" />
+                        <SP HEIGHT="56" WIDTH="24" VPOS="4194" HPOS="3396" />
+                        <String WC="0.87714284658432007" CONTENT="issues," HEIGHT="69" WIDTH="200"
+                            VPOS="4195" HPOS="3421" />
+                        <SP HEIGHT="74" WIDTH="33" VPOS="4190" HPOS="3622" />
+                        <String WC="0.79500001668930054" CONTENT="U.S." HEIGHT="62" WIDTH="129"
+                            VPOS="4190" HPOS="3656" />
+                        <SP HEIGHT="38" WIDTH="28" VPOS="4213" HPOS="3786" />
+                        <String WC="0.78600001335144043" CONTENT="only:" HEIGHT="75" WIDTH="171"
+                            VPOS="4194" HPOS="3815" />
+                        <SP HEIGHT="65" WIDTH="31" VPOS="4192" HPOS="3987" />
+                        <String WC="0.59333330392837524" CONTENT="$9.50." HEIGHT="65" WIDTH="206"
+                            VPOS="4192" HPOS="4019" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block5" HEIGHT="186" WIDTH="1702" VPOS="4294" HPOS="2770"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="4365" HEIGHT="83" WIDTH="1628" VPOS="4303" HPOS="2816">
+                        <String WC="0.81666666269302368" CONTENT="One" HEIGHT="62" WIDTH="126"
+                            VPOS="4303" HPOS="2816" />
+                        <SP HEIGHT="56" WIDTH="19" VPOS="4327" HPOS="2943" />
+                        <String WC="0.85500001907348633" CONTENT="year" HEIGHT="54" WIDTH="150"
+                            VPOS="4329" HPOS="2963" />
+                        <SP HEIGHT="68" WIDTH="20" VPOS="4308" HPOS="3114" />
+                        <String WC="0.63999998569488525" CONTENT="(including" HEIGHT="77"
+                            WIDTH="333" VPOS="4308" HPOS="3135" />
+                        <SP HEIGHT="65" WIDTH="23" VPOS="4320" HPOS="3469" />
+                        <String WC="0.75666666030883789" CONTENT="the" HEIGHT="56" WIDTH="100"
+                            VPOS="4310" HPOS="3493" />
+                        <SP HEIGHT="59" WIDTH="27" VPOS="4307" HPOS="3594" />
+                        <String WC="0.63375002145767212" CONTENT="Computer" HEIGHT="79" WIDTH="333"
+                            VPOS="4307" HPOS="3622" />
+                        <SP HEIGHT="58" WIDTH="22" VPOS="4307" HPOS="3956" />
+                        <String WC="0.85333335399627686" CONTENT="Directory" HEIGHT="78" WIDTH="322"
+                            VPOS="4307" HPOS="3979" />
+                        <SP HEIGHT="55" WIDTH="20" VPOS="4330" HPOS="4302" />
+                        <String WC="0.88333332538604736" CONTENT="and" HEIGHT="58" WIDTH="121"
+                            VPOS="4309" HPOS="4323" />
+                    </TextLine>
+                    <TextLine BASELINE="4449" HEIGHT="80" WIDTH="1460" VPOS="4388" HPOS="2807">
+                        <String WC="0.81333333253860474" CONTENT="Buyers" HEIGHT="77" WIDTH="231"
+                            VPOS="4388" HPOS="2807" />
+                        <SP HEIGHT="60" WIDTH="25" VPOS="4388" HPOS="3039" />
+                        <String WC="0.62833333015441895" CONTENT="Guide)" HEIGHT="70" WIDTH="222"
+                            VPOS="4388" HPOS="3065" />
+                        <SP HEIGHT="68" WIDTH="27" VPOS="4390" HPOS="3288" />
+                        <String WC="0.69499999284744263" CONTENT="13" HEIGHT="57" WIDTH="78"
+                            VPOS="4392" HPOS="3316" />
+                        <SP HEIGHT="57" WIDTH="24" VPOS="4392" HPOS="3395" />
+                        <String WC="0.48142856359481812" CONTENT="issues," HEIGHT="68" WIDTH="199"
+                            VPOS="4395" HPOS="3420" />
+                        <SP HEIGHT="74" WIDTH="33" VPOS="4389" HPOS="3620" />
+                        <String WC="0.77999997138977051" CONTENT="U.S." HEIGHT="62" WIDTH="130"
+                            VPOS="4389" HPOS="3654" />
+                        <SP HEIGHT="38" WIDTH="27" VPOS="4413" HPOS="3785" />
+                        <String WC="0.78200000524520874" CONTENT="only:" HEIGHT="75" WIDTH="171"
+                            VPOS="4393" HPOS="3813" />
+                        <SP HEIGHT="64" WIDTH="31" VPOS="4392" HPOS="3985" />
+                        <String WC="0.61142855882644653" CONTENT="$18.50." HEIGHT="64" WIDTH="250"
+                            VPOS="4392" HPOS="4017" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block6" HEIGHT="303" WIDTH="1824" VPOS="3672" HPOS="4864"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3740" HEIGHT="66" WIDTH="1790" VPOS="3684" HPOS="4886">
+                        <String WC="0.95999997854232788" CONTENT="Note:" HEIGHT="49" WIDTH="149"
+                            VPOS="3684" HPOS="4886" />
+                        <SP HEIGHT="46" WIDTH="45" VPOS="3686" HPOS="5036" />
+                        <String WC="0.68500000238418579" CONTENT="We" HEIGHT="48" WIDTH="86"
+                            VPOS="3686" HPOS="5082" />
+                        <SP HEIGHT="47" WIDTH="21" VPOS="3689" HPOS="5169" />
+                        <String WC="0.87285715341567993" CONTENT="believe" HEIGHT="48" WIDTH="196"
+                            VPOS="3689" HPOS="5191" />
+                        <SP HEIGHT="46" WIDTH="20" VPOS="3691" HPOS="5388" />
+                        <String WC="0.95800000429153442" CONTENT="books" HEIGHT="47" WIDTH="174"
+                            VPOS="3691" HPOS="5409" />
+                        <SP HEIGHT="33" WIDTH="18" VPOS="3705" HPOS="5584" />
+                        <String WC="0.92400002479553223" CONTENT="about" HEIGHT="47" WIDTH="165"
+                            VPOS="3693" HPOS="5603" />
+                        <SP HEIGHT="39" WIDTH="23" VPOS="3701" HPOS="5769" />
+                        <String WC="1." CONTENT="computers" HEIGHT="49" WIDTH="303" VPOS="3701"
+                            HPOS="5793" />
+                        <SP HEIGHT="35" WIDTH="19" VPOS="3707" HPOS="6097" />
+                        <String WC="0.96666663885116577" CONTENT="are" HEIGHT="34" WIDTH="83"
+                            VPOS="3708" HPOS="6117" />
+                        <SP HEIGHT="45" WIDTH="22" VPOS="3698" HPOS="6201" />
+                        <String WC="1." CONTENT="best" HEIGHT="45" WIDTH="119" VPOS="3698"
+                            HPOS="6224" />
+                        <SP HEIGHT="44" WIDTH="23" VPOS="3699" HPOS="6344" />
+                        <String WC="0.99900001287460327" CONTENT="introduced" HEIGHT="47"
+                            WIDTH="308" VPOS="3699" HPOS="6368" />
+                    </TextLine>
+                    <TextLine BASELINE="3813" HEIGHT="66" WIDTH="1730" VPOS="3762" HPOS="4881">
+                        <String WC="1." CONTENT="to" HEIGHT="40" WIDTH="54" VPOS="3766" HPOS="4881" />
+                        <SP HEIGHT="34" WIDTH="23" VPOS="3772" HPOS="4936" />
+                        <String WC="1." CONTENT="students" HEIGHT="47" WIDTH="241" VPOS="3762"
+                            HPOS="4960" />
+                        <SP HEIGHT="35" WIDTH="18" VPOS="3775" HPOS="5202" />
+                        <String WC="1." CONTENT="or" HEIGHT="34" WIDTH="58" VPOS="3776" HPOS="5221" />
+                        <SP HEIGHT="45" WIDTH="21" VPOS="3766" HPOS="5280" />
+                        <String WC="0.97428572177886963" CONTENT="budding" HEIGHT="58" WIDTH="233"
+                            VPOS="3765" HPOS="5302" />
+                        <SP HEIGHT="44" WIDTH="23" VPOS="3779" HPOS="5536" />
+                        <String WC="0.99124997854232788" CONTENT="computer" HEIGHT="48" WIDTH="277"
+                            VPOS="3775" HPOS="5560" />
+                        <SP HEIGHT="45" WIDTH="21" VPOS="3769" HPOS="5838" />
+                        <String WC="1." CONTENT="freaks" HEIGHT="47" WIDTH="172" VPOS="3769"
+                            HPOS="5860" />
+                        <SP HEIGHT="33" WIDTH="21" VPOS="3783" HPOS="6033" />
+                        <String WC="0.95200002193450928" CONTENT="after" HEIGHT="46" WIDTH="133"
+                            VPOS="3770" HPOS="6055" />
+                        <SP HEIGHT="39" WIDTH="21" VPOS="3778" HPOS="6189" />
+                        <String WC="1." CONTENT="they" HEIGHT="57" WIDTH="127" VPOS="3771"
+                            HPOS="6211" />
+                        <SP HEIGHT="55" WIDTH="25" VPOS="3773" HPOS="6339" />
+                        <String WC="1." CONTENT="have" HEIGHT="45" WIDTH="124" VPOS="3773"
+                            HPOS="6365" />
+                        <SP HEIGHT="45" WIDTH="24" VPOS="3773" HPOS="6490" />
+                        <String WC="1." CONTENT="had" HEIGHT="47" WIDTH="96" VPOS="3773" HPOS="6515" />
+                    </TextLine>
+                    <TextLine BASELINE="3887" HEIGHT="68" WIDTH="1594" VPOS="3835" HPOS="4881">
+                        <String WC="0.98250001668930054" CONTENT="some" HEIGHT="35" WIDTH="142"
+                            VPOS="3846" HPOS="4881" />
+                        <SP HEIGHT="46" WIDTH="22" VPOS="3835" HPOS="5024" />
+                        <String WC="0.72500002384185791" CONTENT="hands-on" HEIGHT="48" WIDTH="252"
+                            VPOS="3835" HPOS="5047" />
+                        <SP HEIGHT="34" WIDTH="26" VPOS="3850" HPOS="5300" />
+                        <String WC="0.97428572177886963" CONTENT="contact" HEIGHT="39" WIDTH="214"
+                            VPOS="3847" HPOS="5327" />
+                        <SP HEIGHT="38" WIDTH="20" VPOS="3848" HPOS="5542" />
+                        <String WC="0.79500001668930054" CONTENT="with" HEIGHT="46" WIDTH="127"
+                            VPOS="3841" HPOS="5563" />
+                        <SP HEIGHT="47" WIDTH="22" VPOS="3841" HPOS="5691" />
+                        <String WC="1." CONTENT="the" HEIGHT="47" WIDTH="90" VPOS="3842" HPOS="5714" />
+                        <SP HEIGHT="47" WIDTH="24" VPOS="3842" HPOS="5805" />
+                        <String WC="0.92333334684371948" CONTENT="Modern" HEIGHT="48" WIDTH="215"
+                            VPOS="3842" HPOS="5830" />
+                        <SP HEIGHT="46" WIDTH="22" VPOS="3843" HPOS="6046" />
+                        <String WC="0.93384617567062378" CONTENT="Technological" HEIGHT="60"
+                            WIDTH="406" VPOS="3843" HPOS="6069" />
+                    </TextLine>
+                    <TextLine BASELINE="3956" HEIGHT="53" WIDTH="364" VPOS="3906" HPOS="4882">
+                        <String WC="0.84333330392837524" CONTENT="Marvel" HEIGHT="49" WIDTH="180"
+                            VPOS="3906" HPOS="4882" />
+                        <SP HEIGHT="44" WIDTH="28" VPOS="3910" HPOS="5063" />
+                        <String WC="0.78714287281036377" CONTENT="itself." HEIGHT="49" WIDTH="154"
+                            VPOS="3910" HPOS="5092" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block7" HEIGHT="275" WIDTH="1824" VPOS="4007" HPOS="4864"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="4084" HEIGHT="83" WIDTH="1196" VPOS="4023" HPOS="4876">
+                        <String WC="0.99800002574920654" CONTENT="From:" HEIGHT="61" WIDTH="206"
+                            VPOS="4023" HPOS="4876" />
+                        <SP HEIGHT="59" WIDTH="98" VPOS="4024" HPOS="5083" />
+                        <String WC="0.68250000476837158" CONTENT="W.H." HEIGHT="62" WIDTH="149"
+                            VPOS="4024" HPOS="5182" />
+                        <SP HEIGHT="61" WIDTH="27" VPOS="4025" HPOS="5332" />
+                        <String WC="0.90714287757873535" CONTENT="Freeman" HEIGHT="61" WIDTH="289"
+                            VPOS="4025" HPOS="5360" />
+                        <SP HEIGHT="60" WIDTH="21" VPOS="4026" HPOS="5650" />
+                        <String WC="1." CONTENT="&amp;" HEIGHT="60" WIDTH="57" VPOS="4026"
+                            HPOS="5672" />
+                        <SP HEIGHT="61" WIDTH="25" VPOS="4026" HPOS="5730" />
+                        <String WC="0.96428573131561279" CONTENT="Company" HEIGHT="80" WIDTH="316"
+                            VPOS="4026" HPOS="5756" />
+                    </TextLine>
+                    <TextLine BASELINE="4169" HEIGHT="62" WIDTH="601" VPOS="4108" HPOS="5178">
+                        <String WC="0.92666667699813843" CONTENT="660" HEIGHT="59" WIDTH="120"
+                            VPOS="4110" HPOS="5178" />
+                        <SP HEIGHT="60" WIDTH="22" VPOS="4108" HPOS="5299" />
+                        <String WC="0.98666667938232422" CONTENT="Market" HEIGHT="61" WIDTH="237"
+                            VPOS="4108" HPOS="5322" />
+                        <SP HEIGHT="60" WIDTH="21" VPOS="4109" HPOS="5560" />
+                        <String WC="0.86000001430511475" CONTENT="Street" HEIGHT="61" WIDTH="197"
+                            VPOS="4109" HPOS="5582" />
+                    </TextLine>
+                    <TextLine BASELINE="4252" HEIGHT="78" WIDTH="918" VPOS="4191" HPOS="5175">
+                        <String WC="0.9466666579246521" LANG="fr" CONTENT="San" HEIGHT="60"
+                            WIDTH="114" VPOS="4191" HPOS="5175" />
+                        <SP HEIGHT="59" WIDTH="25" VPOS="4191" HPOS="5290" />
+                        <String WC="0.79000002145767212" CONTENT="Francisco," HEIGHT="74"
+                            WIDTH="338" VPOS="4191" HPOS="5316" />
+                        <SP HEIGHT="73" WIDTH="28" VPOS="4192" HPOS="5655" />
+                        <String WC="0.91333335638046265" CONTENT="Calif." HEIGHT="77" WIDTH="167"
+                            VPOS="4192" HPOS="5684" />
+                        <SP HEIGHT="59" WIDTH="32" VPOS="4196" HPOS="5852" />
+                        <String WC="0.63200002908706665" CONTENT="94104" HEIGHT="59" WIDTH="208"
+                            VPOS="4196" HPOS="5885" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block8" HEIGHT="266" WIDTH="1276" VPOS="3762" HPOS="2804"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="3835" HEIGHT="81" WIDTH="1251" VPOS="3774" HPOS="2817">
+                        <String WC="0.91600000858306885" CONTENT="From:" HEIGHT="60" WIDTH="206"
+                            VPOS="3774" HPOS="2817" />
+                        <SP HEIGHT="59" WIDTH="188" VPOS="3776" HPOS="3024" />
+                        <String WC="0.87749999761581421" CONTENT="Berkeley" HEIGHT="77" WIDTH="292"
+                            VPOS="3776" HPOS="3213" />
+                        <SP HEIGHT="77" WIDTH="22" VPOS="3776" HPOS="3506" />
+                        <String WC="0.74333333969116211" CONTENT="Enterprises," HEIGHT="79"
+                            WIDTH="389" VPOS="3776" HPOS="3529" />
+                        <SP HEIGHT="72" WIDTH="24" VPOS="3777" HPOS="3919" />
+                        <String WC="0.81999999284744263" CONTENT="Inc." HEIGHT="60" WIDTH="124"
+                            VPOS="3777" HPOS="3944" />
+                    </TextLine>
+                    <TextLine BASELINE="3919" HEIGHT="79" WIDTH="756" VPOS="3859" HPOS="3215">
+                        <String WC="1." CONTENT="815" HEIGHT="58" WIDTH="124" VPOS="3863"
+                            HPOS="3215" />
+                        <SP HEIGHT="61" WIDTH="31" VPOS="3859" HPOS="3340" />
+                        <String WC="0.70999997854232788" CONTENT="Washington" HEIGHT="79"
+                            WIDTH="373" VPOS="3859" HPOS="3372" />
+                        <SP HEIGHT="60" WIDTH="27" VPOS="3859" HPOS="3746" />
+                        <String WC="0.86833333969116211" CONTENT="Street" HEIGHT="60" WIDTH="197"
+                            VPOS="3859" HPOS="3774" />
+                    </TextLine>
+                    <TextLine BASELINE="4001" HEIGHT="74" WIDTH="870" VPOS="3941" HPOS="3116">
+                        <String WC="1." CONTENT="Newtonville," HEIGHT="73" WIDTH="415" VPOS="3942"
+                            HPOS="3116" />
+                        <SP HEIGHT="74" WIDTH="22" VPOS="3941" HPOS="3532" />
+                        <String WC="0.76800000667572021" CONTENT="Mass." HEIGHT="61" WIDTH="174"
+                            VPOS="3941" HPOS="3555" />
+                        <SP HEIGHT="57" WIDTH="51" VPOS="3945" HPOS="3730" />
+                        <String WC="1." CONTENT="02161" HEIGHT="58" WIDTH="204" VPOS="3944"
+                            HPOS="3782" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page3_Block9" HEIGHT="7478" WIDTH="6874" VPOS="3142" HPOS="74">
+                    <Shape>
+                        <Polygon
+                            POINTS="506,3142 2786,3142 2786,4568 4972,4568 4972,4980 6948,4980 6948,10620 3040,10620 3040,10204 84,10204 84,5872 506,5872 506,5368 74,5368 74,4656 506,4656 506,3142" />
+                    </Shape>
+                </Illustration>
+                <TextBlock ID="Page3_Block10" HEIGHT="290" WIDTH="2512" VPOS="10048" HPOS="544"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="10259" HEIGHT="248" WIDTH="2342" VPOS="10066" HPOS="698">
+                        <String WC="0.29666665196418762" CONTENT="2nd" HEIGHT="216" WIDTH="260"
+                            VPOS="10066" HPOS="698" />
+                        <SP HEIGHT="180" WIDTH="38" VPOS="10114" HPOS="959" />
+                        <String WC="0.60600000619888306" CONTENT="page," HEIGHT="172" WIDTH="252"
+                            VPOS="10134" HPOS="998" />
+                        <SP HEIGHT="184" WIDTH="22" VPOS="10118" HPOS="1251" />
+                        <String WC="0.51999998092651367" CONTENT="just" HEIGHT="184" WIDTH="196"
+                            VPOS="10118" HPOS="1274" />
+                        <SP HEIGHT="140" WIDTH="50" VPOS="10122" HPOS="1471" />
+                        <String WC="0.39500001072883606" CONTENT="in" HEIGHT="136" WIDTH="100"
+                            VPOS="10126" HPOS="1522" />
+                        <SP HEIGHT="116" WIDTH="46" VPOS="10150" HPOS="1623" />
+                        <String WC="0.38499999046325684" CONTENT="ease" HEIGHT="116" WIDTH="220"
+                            VPOS="10150" HPOS="1670" />
+                        <SP HEIGHT="164" WIDTH="46" VPOS="10150" HPOS="1891" />
+                        <String WC="0.29666665196418762" CONTENT="you" HEIGHT="160" WIDTH="180"
+                            VPOS="10154" HPOS="1938" />
+                        <SP HEIGHT="112" WIDTH="58" VPOS="10150" HPOS="2119" />
+                        <String WC="0.44249999523162842" CONTENT="were" HEIGHT="108" WIDTH="256"
+                            VPOS="10150" HPOS="2178" />
+                        <SP HEIGHT="108" WIDTH="58" VPOS="10150" HPOS="2435" />
+                        <String WC="0.42555555701255798" CONTENT="wondering" HEIGHT="192"
+                            WIDTH="546" VPOS="10114" HPOS="2494" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block11" HEIGHT="158" WIDTH="728" VPOS="5730" HPOS="3098"
+                    LANG="ru" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <Shape>
+                        <Polygon
+                            POINTS="3636,5730 3826,5730 3826,5888 3098,5888 3098,5770 3636,5770 3636,5730" />
+                    </Shape>
+                    <TextLine BASELINE="5862" HEIGHT="83" WIDTH="610" VPOS="5789" HPOS="3111">
+                        <String WC="0.8399999737739563" CONTENT="ад»" HEIGHT="72" WIDTH="232"
+                            VPOS="5789" HPOS="3111" />
+                        <SP HEIGHT="82" WIDTH="4" VPOS="5789" HPOS="3344" />
+                        <String WC="0.7850000262260437" CONTENT="м^" HEIGHT="83" WIDTH="372"
+                            VPOS="5789" HPOS="3349" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block12" HEIGHT="360" WIDTH="3890" VPOS="658" HPOS="2910"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="984" HEIGHT="328" WIDTH="3872" VPOS="676" HPOS="2924">
+                        <String WC="0.4699999988079071" CONTENT="OVER" HEIGHT="304" WIDTH="1128"
+                            VPOS="700" HPOS="2924" />
+                        <SP HEIGHT="304" WIDTH="270" VPOS="692" HPOS="4053" />
+                        <String WC="0.75333333015441895" CONTENT="THE" HEIGHT="304" WIDTH="800"
+                            VPOS="684" HPOS="4324" />
+                        <SP HEIGHT="304" WIDTH="254" VPOS="684" HPOS="5125" />
+                        <String WC="0.62400001287460327" CONTENT="LITER" HEIGHT="312" WIDTH="1416"
+                            VPOS="676" HPOS="5380" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block13" HEIGHT="1346" WIDTH="1834" VPOS="1146" HPOS="2816"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <TextLine BASELINE="1217" HEIGHT="61" WIDTH="1415" VPOS="1158" HPOS="2833"
+                        STYLEREFS="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-">
+                        <String WC="0.89222222566604614" CONTENT="COMPUTERS" HEIGHT="61" WIDTH="544"
+                            VPOS="1158" HPOS="2833" />
+                        <SP HEIGHT="58" WIDTH="26" VPOS="1160" HPOS="3378" />
+                        <String WC="0.99000000953674316" CONTENT="AND" HEIGHT="57" WIDTH="192"
+                            VPOS="1161" HPOS="3405" />
+                        <SP HEIGHT="57" WIDTH="33" VPOS="1161" HPOS="3598" />
+                        <String WC="0.87099999189376831" CONTENT="AUTOMATION" HEIGHT="61"
+                            WIDTH="616" VPOS="1158" HPOS="3632" />
+                    </TextLine>
+                    <TextLine BASELINE="1318" HEIGHT="83" WIDTH="1550" VPOS="1258" HPOS="2850"
+                        STYLEREFS="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-">
+                        <String WC="0.70249998569488525" CONTENT="“The" HEIGHT="59" WIDTH="158"
+                            VPOS="1258" HPOS="2850" />
+                        <SP HEIGHT="36" WIDTH="29" VPOS="1281" HPOS="3009" />
+                        <String WC="0.72624999284744263" CONTENT="magazine" HEIGHT="73" WIDTH="297"
+                            VPOS="1264" HPOS="3039" />
+                        <SP HEIGHT="36" WIDTH="26" VPOS="1284" HPOS="3337" />
+                        <String WC="1." CONTENT="of" HEIGHT="75" WIDTH="77" VPOS="1262" HPOS="3364" />
+                        <SP HEIGHT="75" WIDTH="16" VPOS="1262" HPOS="3442" />
+                        <String WC="0.49666666984558105" CONTENT="the" HEIGHT="55" WIDTH="100"
+                            VPOS="1265" HPOS="3459" />
+                        <SP HEIGHT="58" WIDTH="24" VPOS="1262" HPOS="3560" />
+                        <String WC="0.77428573369979858" CONTENT="design," HEIGHT="79" WIDTH="222"
+                            VPOS="1262" HPOS="3585" />
+                        <SP HEIGHT="49" WIDTH="22" VPOS="1285" HPOS="3808" />
+                        <String WC="0.77999997138977051" CONTENT="applications," HEIGHT="77"
+                            WIDTH="422" VPOS="1262" HPOS="3831" />
+                        <SP HEIGHT="47" WIDTH="24" VPOS="1284" HPOS="4254" />
+                        <String WC="0.79000002145767212" CONTENT="and" HEIGHT="57" WIDTH="121"
+                            VPOS="1261" HPOS="4279" />
+                    </TextLine>
+                    <TextLine BASELINE="1402" HEIGHT="79" WIDTH="1633" VPOS="1344" HPOS="2833"
+                        STYLEREFS="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-">
+                        <String WC="0.7316666841506958" CONTENT="implications" HEIGHT="75"
+                            WIDTH="398" VPOS="1344" HPOS="2833" />
+                        <SP HEIGHT="36" WIDTH="24" VPOS="1366" HPOS="3232" />
+                        <String WC="0.64499998092651367" CONTENT="of" HEIGHT="73" WIDTH="78"
+                            VPOS="1346" HPOS="3257" />
+                        <SP HEIGHT="73" WIDTH="13" VPOS="1346" HPOS="3336" />
+                        <String WC="0.7881818413734436" CONTENT="information" HEIGHT="74"
+                            WIDTH="392" VPOS="1346" HPOS="3350" />
+                        <SP HEIGHT="56" WIDTH="21" VPOS="1367" HPOS="3743" />
+                        <String WC="0.83099997043609619" CONTENT="processing" HEIGHT="75"
+                            WIDTH="350" VPOS="1348" HPOS="3765" />
+                        <SP HEIGHT="55" WIDTH="20" VPOS="1367" HPOS="4116" />
+                        <String WC="0.93124997615814209" CONTENT="systems." HEIGHT="63" WIDTH="272"
+                            VPOS="1357" HPOS="4137" />
+                        <SP HEIGHT="60" WIDTH="18" VPOS="1344" HPOS="4410" />
+                        <String WC="1." CONTENT="”" HEIGHT="26" WIDTH="37" VPOS="1344" HPOS="4429" />
+                    </TextLine>
+                    <TextLine BASELINE="1567" HEIGHT="81" WIDTH="1806" VPOS="1502" HPOS="2832">
+                        <String WC="1." CONTENT="This" HEIGHT="64" WIDTH="163" VPOS="1502"
+                            HPOS="2832" />
+                        <SP HEIGHT="61" WIDTH="28" VPOS="1522" HPOS="2996" />
+                        <String WC="1." CONTENT="periodical" HEIGHT="79" WIDTH="376" VPOS="1504"
+                            HPOS="3025" />
+                        <SP HEIGHT="62" WIDTH="29" VPOS="1504" HPOS="3402" />
+                        <String WC="1." CONTENT="is" HEIGHT="62" WIDTH="54" VPOS="1505" HPOS="3432" />
+                        <SP HEIGHT="56" WIDTH="26" VPOS="1511" HPOS="3487" />
+                        <String WC="1." CONTENT="the" HEIGHT="62" WIDTH="118" VPOS="1505"
+                            HPOS="3514" />
+                        <SP HEIGHT="43" WIDTH="33" VPOS="1524" HPOS="3633" />
+                        <String WC="1." CONTENT="closest" HEIGHT="63" WIDTH="249" VPOS="1505"
+                            HPOS="3667" />
+                        <SP HEIGHT="57" WIDTH="32" VPOS="1511" HPOS="3917" />
+                        <String WC="1." CONTENT="thing" HEIGHT="77" WIDTH="195" VPOS="1505"
+                            HPOS="3950" />
+                        <SP HEIGHT="71" WIDTH="29" VPOS="1511" HPOS="4146" />
+                        <String WC="1." CONTENT="to" HEIGHT="56" WIDTH="75" VPOS="1511" HPOS="4176" />
+                        <SP HEIGHT="62" WIDTH="32" VPOS="1505" HPOS="4252" />
+                        <String WC="1." CONTENT="being" HEIGHT="77" WIDTH="205" VPOS="1505"
+                            HPOS="4285" />
+                        <SP HEIGHT="70" WIDTH="28" VPOS="1512" HPOS="4491" />
+                        <String WC="0.97666668891906738" CONTENT="the" HEIGHT="63" WIDTH="118"
+                            VPOS="1505" HPOS="4520" />
+                    </TextLine>
+                    <TextLine BASELINE="1666" HEIGHT="81" WIDTH="1771" VPOS="1601" HPOS="2830">
+                        <String WC="0.7279999852180481" CONTENT="Scientific" HEIGHT="80" WIDTH="361"
+                            VPOS="1601" HPOS="2830" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="1602" HPOS="3192" />
+                        <String WC="0.76375001668930054" CONTENT="American" HEIGHT="64" WIDTH="370"
+                            VPOS="1602" HPOS="3215" />
+                        <SP HEIGHT="43" WIDTH="35" VPOS="1622" HPOS="3586" />
+                        <String WC="1." CONTENT="of" HEIGHT="63" WIDTH="84" VPOS="1602" HPOS="3622" />
+                        <SP HEIGHT="64" WIDTH="23" VPOS="1602" HPOS="3707" />
+                        <String WC="0.8566666841506958" CONTENT="the" HEIGHT="63" WIDTH="119"
+                            VPOS="1603" HPOS="3731" />
+                        <SP HEIGHT="45" WIDTH="33" VPOS="1622" HPOS="3851" />
+                        <String WC="0.92000001668930054" CONTENT="computer-oriented" HEIGHT="79"
+                            WIDTH="716" VPOS="1603" HPOS="3885" />
+                    </TextLine>
+                    <TextLine BASELINE="1765" HEIGHT="81" WIDTH="1644" VPOS="1701" HPOS="2835">
+                        <String WC="0.89833331108093262" CONTENT="press." HEIGHT="61" WIDTH="203"
+                            VPOS="1720" HPOS="2835" />
+                        <SP HEIGHT="64" WIDTH="56" VPOS="1702" HPOS="3039" />
+                        <String WC="0.93699997663497925" CONTENT="Apparently" HEIGHT="81"
+                            WIDTH="436" VPOS="1701" HPOS="3096" />
+                        <SP HEIGHT="61" WIDTH="29" VPOS="1720" HPOS="3533" />
+                        <String WC="0.94749999046325684" CONTENT="well" HEIGHT="63" WIDTH="154"
+                            VPOS="1701" HPOS="3563" />
+                        <SP HEIGHT="63" WIDTH="27" VPOS="1701" HPOS="3718" />
+                        <String WC="0.93599998950958252" CONTENT="researched" HEIGHT="64"
+                            WIDTH="402" VPOS="1702" HPOS="3746" />
+                        <SP HEIGHT="64" WIDTH="32" VPOS="1702" HPOS="4149" />
+                        <String WC="0.93111109733581543" CONTENT="articles," HEIGHT="78" WIDTH="297"
+                            VPOS="1701" HPOS="4182" />
+                    </TextLine>
+                    <TextLine BASELINE="1864" HEIGHT="81" WIDTH="1692" VPOS="1800" HPOS="2832">
+                        <String WC="1." CONTENT="broad" HEIGHT="64" WIDTH="214" VPOS="1801"
+                            HPOS="2832" />
+                        <SP HEIGHT="63" WIDTH="32" VPOS="1802" HPOS="3047" />
+                        <String WC="0.91250002384185791" CONTENT="spectrum" HEIGHT="74" WIDTH="353"
+                            VPOS="1807" HPOS="3080" />
+                        <SP HEIGHT="45" WIDTH="28" VPOS="1820" HPOS="3434" />
+                        <String WC="1." CONTENT="of" HEIGHT="65" WIDTH="86" VPOS="1800" HPOS="3463" />
+                        <SP HEIGHT="65" WIDTH="20" VPOS="1800" HPOS="3550" />
+                        <String WC="0.93999999761581421" CONTENT="topics:" HEIGHT="79" WIDTH="255"
+                            VPOS="1801" HPOS="3571" />
+                        <SP HEIGHT="63" WIDTH="59" VPOS="1800" HPOS="3827" />
+                        <String WC="0.95666664838790894" CONTENT="Technical" HEIGHT="65" WIDTH="378"
+                            VPOS="1800" HPOS="3887" />
+                        <SP HEIGHT="76" WIDTH="27" VPOS="1801" HPOS="4266" />
+                        <String WC="0.9660000205039978" CONTENT="(hard" HEIGHT="76" WIDTH="199"
+                            VPOS="1801" HPOS="4294" SUBS_TYPE="HypPart1" SUBS_CONTENT="(hardware" />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="1964" HEIGHT="87" WIDTH="1710" VPOS="1896" HPOS="2832">
+                        <String WC="1." CONTENT="ware" HEIGHT="47" WIDTH="176" VPOS="1911"
+                            HPOS="2832" SUBS_TYPE="HypPart2" SUBS_CONTENT="(hardware" />
+                        <SP HEIGHT="46" WIDTH="29" VPOS="1913" HPOS="3009" />
+                        <String WC="1." CONTENT="and" HEIGHT="64" WIDTH="134" VPOS="1896"
+                            HPOS="3039" />
+                        <SP HEIGHT="65" WIDTH="33" VPOS="1896" HPOS="3174" />
+                        <String WC="0.93300002813339233" CONTENT="software)," HEIGHT="81"
+                            WIDTH="385" VPOS="1897" HPOS="3208" />
+                        <SP HEIGHT="59" WIDTH="30" VPOS="1919" HPOS="3594" />
+                        <String WC="0.93428570032119751" CONTENT="social," HEIGHT="79" WIDTH="235"
+                            VPOS="1900" HPOS="3625" />
+                        <SP HEIGHT="59" WIDTH="30" VPOS="1920" HPOS="3861" />
+                        <String WC="0.96166664361953735" CONTENT="educational," HEIGHT="80"
+                            WIDTH="473" VPOS="1901" HPOS="3892" />
+                        <SP HEIGHT="60" WIDTH="28" VPOS="1923" HPOS="4366" />
+                        <String WC="1." CONTENT="pol" HEIGHT="80" WIDTH="120" VPOS="1903"
+                            HPOS="4395" SUBS_TYPE="HypPart1" SUBS_CONTENT="political." />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="2064" HEIGHT="83" WIDTH="1570" VPOS="1997" HPOS="2831">
+                        <String WC="0.93428570032119751" CONTENT="itical." HEIGHT="67" WIDTH="207"
+                            VPOS="1997" HPOS="2831" SUBS_TYPE="HypPart2" SUBS_CONTENT="political." />
+                        <SP HEIGHT="64" WIDTH="58" VPOS="2000" HPOS="3039" />
+                        <String WC="0.95499998331069946" CONTENT="It’s" HEIGHT="67" WIDTH="120"
+                            VPOS="1999" HPOS="3098" />
+                        <SP HEIGHT="45" WIDTH="25" VPOS="2021" HPOS="3219" />
+                        <String WC="1." CONTENT="a" HEIGHT="44" WIDTH="37" VPOS="2021" HPOS="3245" />
+                        <SP HEIGHT="45" WIDTH="31" VPOS="2020" HPOS="3283" />
+                        <String WC="0.88499999046325684" CONTENT="magazine" HEIGHT="79" WIDTH="350"
+                            VPOS="2001" HPOS="3315" />
+                        <SP HEIGHT="44" WIDTH="28" VPOS="2020" HPOS="3666" />
+                        <String WC="0.9375" CONTENT="with" HEIGHT="64" WIDTH="172" VPOS="2000"
+                            HPOS="3695" />
+                        <SP HEIGHT="63" WIDTH="28" VPOS="2001" HPOS="3868" />
+                        <String WC="1." CONTENT="a" HEIGHT="44" WIDTH="36" VPOS="2020" HPOS="3897" />
+                        <SP HEIGHT="45" WIDTH="33" VPOS="2019" HPOS="3934" />
+                        <String WC="0.95909088850021362" CONTENT="conscience." HEIGHT="65"
+                            WIDTH="433" VPOS="2000" HPOS="3968" />
+                    </TextLine>
+                    <TextLine BASELINE="2169" HEIGHT="85" WIDTH="1790" VPOS="2099" HPOS="2828">
+                        <String WC="1." CONTENT="Computers" HEIGHT="85" WIDTH="417" VPOS="2099"
+                            HPOS="2828" />
+                        <SP HEIGHT="46" WIDTH="23" VPOS="2127" HPOS="3246" />
+                        <String WC="0.95333331823348999" CONTENT="and" HEIGHT="65" WIDTH="142"
+                            VPOS="2108" HPOS="3270" />
+                        <SP HEIGHT="65" WIDTH="22" VPOS="2108" HPOS="3413" />
+                        <String WC="0.93800002336502075" CONTENT="Automation" HEIGHT="64"
+                            WIDTH="473" VPOS="2108" HPOS="3436" />
+                        <SP HEIGHT="63" WIDTH="35" VPOS="2105" HPOS="3910" />
+                        <String WC="1." CONTENT="is" HEIGHT="63" WIDTH="54" VPOS="2105" HPOS="3946" />
+                        <SP HEIGHT="64" WIDTH="27" VPOS="2104" HPOS="4001" />
+                        <String WC="0.99400001764297485" CONTENT="heavy" HEIGHT="78" WIDTH="219"
+                            VPOS="2104" HPOS="4029" />
+                        <SP HEIGHT="59" WIDTH="30" VPOS="2123" HPOS="4249" />
+                        <String WC="1." CONTENT="on" HEIGHT="44" WIDTH="94" VPOS="2123" HPOS="4280" />
+                        <SP HEIGHT="44" WIDTH="30" VPOS="2123" HPOS="4375" />
+                        <String WC="0.87166666984558105" CONTENT="social" HEIGHT="63" WIDTH="212"
+                            VPOS="2105" HPOS="4406" />
+                    </TextLine>
+                    <TextLine BASELINE="2264" HEIGHT="79" WIDTH="1724" VPOS="2199" HPOS="2834">
+                        <String WC="0.96857142448425293" CONTENT="comment" HEIGHT="58" WIDTH="355"
+                            VPOS="2206" HPOS="2834" />
+                        <SP HEIGHT="59" WIDTH="29" VPOS="2206" HPOS="3190" />
+                        <String WC="0.95333331823348999" CONTENT="and" HEIGHT="64" WIDTH="134"
+                            VPOS="2201" HPOS="3220" />
+                        <SP HEIGHT="63" WIDTH="33" VPOS="2201" HPOS="3355" />
+                        <String WC="0.91399997472763062" CONTENT="humanistic" HEIGHT="64"
+                            WIDTH="421" VPOS="2201" HPOS="3389" />
+                        <SP HEIGHT="45" WIDTH="27" VPOS="2219" HPOS="3811" />
+                        <String WC="0.99500000476837158" CONTENT="uses" HEIGHT="46" WIDTH="154"
+                            VPOS="2218" HPOS="3839" />
+                        <SP HEIGHT="45" WIDTH="27" VPOS="2218" HPOS="3994" />
+                        <String WC="1." CONTENT="of" HEIGHT="64" WIDTH="86" VPOS="2199" HPOS="4022" />
+                        <SP HEIGHT="64" WIDTH="25" VPOS="2199" HPOS="4109" />
+                        <String WC="0.90299999713897705" CONTENT="computers." HEIGHT="74"
+                            WIDTH="423" VPOS="2204" HPOS="4135" />
+                    </TextLine>
+                    <TextLine BASELINE="2362" HEIGHT="84" WIDTH="1764" VPOS="2294" HPOS="2831">
+                        <String WC="1." CONTENT="Every" HEIGHT="82" WIDTH="217" VPOS="2294"
+                            HPOS="2831" />
+                        <SP HEIGHT="78" WIDTH="26" VPOS="2298" HPOS="3049" />
+                        <String WC="0.86666667461395264" CONTENT="August" HEIGHT="80" WIDTH="271"
+                            VPOS="2298" HPOS="3076" />
+                        <SP HEIGHT="63" WIDTH="29" VPOS="2301" HPOS="3348" />
+                        <String WC="0.88400000333786011" CONTENT="issue" HEIGHT="64" WIDTH="178"
+                            VPOS="2301" HPOS="3378" />
+                        <SP HEIGHT="64" WIDTH="29" VPOS="2300" HPOS="3557" />
+                        <String WC="0.904285728931427" CONTENT="focuses" HEIGHT="65" WIDTH="281"
+                            VPOS="2300" HPOS="3587" />
+                        <SP HEIGHT="45" WIDTH="26" VPOS="2319" HPOS="3869" />
+                        <String WC="1." CONTENT="on" HEIGHT="45" WIDTH="95" VPOS="2319" HPOS="3896" />
+                        <SP HEIGHT="65" WIDTH="28" VPOS="2298" HPOS="3992" />
+                        <String WC="1." CONTENT="Computer" HEIGHT="80" WIDTH="392" VPOS="2298"
+                            HPOS="4021" />
+                        <SP HEIGHT="63" WIDTH="26" VPOS="2298" HPOS="4414" />
+                        <String WC="1." CONTENT="Art;" HEIGHT="76" WIDTH="154" VPOS="2298"
+                            HPOS="4441" />
+                    </TextLine>
+                    <TextLine BASELINE="2461" HEIGHT="83" WIDTH="1770" VPOS="2396" HPOS="2829">
+                        <String WC="1." CONTENT="every" HEIGHT="62" WIDTH="201" VPOS="2413"
+                            HPOS="2829" />
+                        <SP HEIGHT="79" WIDTH="27" VPOS="2396" HPOS="3031" />
+                        <String WC="0.9440000057220459" CONTENT="March" HEIGHT="66" WIDTH="240"
+                            VPOS="2396" HPOS="3059" />
+                        <SP HEIGHT="63" WIDTH="30" VPOS="2399" HPOS="3300" />
+                        <String WC="0.93199998140335083" CONTENT="issue" HEIGHT="64" WIDTH="174"
+                            VPOS="2399" HPOS="3331" />
+                        <SP HEIGHT="44" WIDTH="28" VPOS="2418" HPOS="3506" />
+                        <String WC="0.99000000953674316" CONTENT="on" HEIGHT="43" WIDTH="95"
+                            VPOS="2419" HPOS="3535" />
+                        <SP HEIGHT="64" WIDTH="30" VPOS="2399" HPOS="3631" />
+                        <String WC="0.9725000262260437" CONTENT="Computer" HEIGHT="80" WIDTH="389"
+                            VPOS="2399" HPOS="3662" />
+                        <SP HEIGHT="63" WIDTH="26" VPOS="2400" HPOS="4052" />
+                        <String WC="1." CONTENT="in" HEIGHT="63" WIDTH="71" VPOS="2400" HPOS="4079" />
+                        <SP HEIGHT="65" WIDTH="30" VPOS="2398" HPOS="4151" />
+                        <String WC="0.94199997186660767" CONTENT="Education." HEIGHT="65"
+                            WIDTH="417" VPOS="2397" HPOS="4182" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block14" HEIGHT="1122" WIDTH="1880" VPOS="2578" HPOS="2796"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <TextLine BASELINE="2659" HEIGHT="83" WIDTH="1811" VPOS="2591" HPOS="2827">
+                        <String WC="0.98222219944000244" CONTENT="Computers" HEIGHT="83" WIDTH="421"
+                            VPOS="2591" HPOS="2827" />
+                        <SP HEIGHT="45" WIDTH="26" VPOS="2614" HPOS="3249" />
+                        <String WC="0.98000001907348633" CONTENT="and" HEIGHT="64" WIDTH="132"
+                            VPOS="2595" HPOS="3276" />
+                        <SP HEIGHT="64" WIDTH="32" VPOS="2595" HPOS="3409" />
+                        <String WC="0.97100001573562622" CONTENT="Automation" HEIGHT="64"
+                            WIDTH="471" VPOS="2595" HPOS="3442" />
+                        <SP HEIGHT="57" WIDTH="30" VPOS="2602" HPOS="3914" />
+                        <String WC="0.95428574085235596" CONTENT="thrives" HEIGHT="64" WIDTH="256"
+                            VPOS="2596" HPOS="3945" />
+                        <SP HEIGHT="45" WIDTH="28" VPOS="2614" HPOS="4202" />
+                        <String WC="0.85500001907348633" CONTENT="on" HEIGHT="44" WIDTH="95"
+                            VPOS="2615" HPOS="4231" />
+                        <SP HEIGHT="45" WIDTH="33" VPOS="2615" HPOS="4327" />
+                        <String WC="0.87999999523162842" CONTENT="contro" HEIGHT="59" WIDTH="248"
+                            VPOS="2601" HPOS="4361" SUBS_TYPE="HypPart1" SUBS_CONTENT="controversy" />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="2757" HEIGHT="81" WIDTH="1602" VPOS="2692" HPOS="2827">
+                        <String WC="0.96200001239776611" CONTENT="versy" HEIGHT="63" WIDTH="193"
+                            VPOS="2709" HPOS="2827" SUBS_TYPE="HypPart2" SUBS_CONTENT="controversy" />
+                        <SP HEIGHT="60" WIDTH="32" VPOS="2712" HPOS="3021" />
+                        <String WC="1." CONTENT="—" HEIGHT="6" WIDTH="57" VPOS="2732" HPOS="3054" />
+                        <SP HEIGHT="59" WIDTH="30" VPOS="2699" HPOS="3112" />
+                        <String WC="0.8933333158493042" CONTENT="try" HEIGHT="74" WIDTH="111"
+                            VPOS="2699" HPOS="3143" />
+                        <SP HEIGHT="74" WIDTH="28" VPOS="2699" HPOS="3255" />
+                        <String WC="0.8566666841506958" CONTENT="these:" HEIGHT="64" WIDTH="219"
+                            VPOS="2694" HPOS="3284" />
+                        <SP HEIGHT="64" WIDTH="75" VPOS="2693" HPOS="3504" />
+                        <String WC="0.47499999403953552" CONTENT="“The" HEIGHT="65" WIDTH="181"
+                            VPOS="2692" HPOS="3580" />
+                        <SP HEIGHT="63" WIDTH="24" VPOS="2694" HPOS="3762" />
+                        <String WC="0.62769228219985962" CONTENT="Assassination" HEIGHT="64"
+                            WIDTH="516" VPOS="2694" HPOS="3787" />
+                        <SP HEIGHT="44" WIDTH="30" VPOS="2713" HPOS="4304" />
+                        <String WC="0.62999999523162842" CONTENT="of" HEIGHT="79" WIDTH="94"
+                            VPOS="2693" HPOS="4335" />
+                    </TextLine>
+                    <TextLine BASELINE="2855" HEIGHT="84" WIDTH="1749" VPOS="2788" HPOS="2821">
+                        <String WC="0.80111110210418701" CONTENT="President" HEIGHT="68" WIDTH="355"
+                            VPOS="2788" HPOS="2821" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="2792" HPOS="3177" />
+                        <String WC="0.83249998092651367" CONTENT="John" HEIGHT="66" WIDTH="190"
+                            VPOS="2791" HPOS="3200" />
+                        <SP HEIGHT="65" WIDTH="30" VPOS="2790" HPOS="3391" />
+                        <String WC="0.79000002145767212" CONTENT="F." HEIGHT="68" WIDTH="68"
+                            VPOS="2790" HPOS="3422" />
+                        <SP HEIGHT="67" WIDTH="38" VPOS="2791" HPOS="3491" />
+                        <String WC="0.77499997615814209" CONTENT="Kennedy:" HEIGHT="79" WIDTH="376"
+                            VPOS="2791" HPOS="3530" />
+                        <SP HEIGHT="65" WIDTH="38" VPOS="2791" HPOS="3907" />
+                        <String WC="0.78333336114883423" CONTENT="The" HEIGHT="65" WIDTH="140"
+                            VPOS="2791" HPOS="3946" />
+                        <SP HEIGHT="63" WIDTH="27" VPOS="2792" HPOS="4087" />
+                        <String WC="0.93090909719467163" CONTENT="Application" HEIGHT="81"
+                            WIDTH="455" VPOS="2791" HPOS="4115" />
+                    </TextLine>
+                    <TextLine BASELINE="2954" HEIGHT="85" WIDTH="1792" VPOS="2887" HPOS="2822">
+                        <String WC="0.63999998569488525" CONTENT="of" HEIGHT="79" WIDTH="93"
+                            VPOS="2887" HPOS="2822" />
+                        <SP HEIGHT="79" WIDTH="17" VPOS="2887" HPOS="2916" />
+                        <String WC="0.76222223043441772" CONTENT="Computers" HEIGHT="84" WIDTH="420"
+                            VPOS="2887" HPOS="2934" />
+                        <SP HEIGHT="55" WIDTH="28" VPOS="2901" HPOS="3355" />
+                        <String WC="0.88499999046325684" CONTENT="to" HEIGHT="55" WIDTH="72"
+                            VPOS="2901" HPOS="3384" />
+                        <SP HEIGHT="55" WIDTH="33" VPOS="2901" HPOS="3457" />
+                        <String WC="0.93333333730697632" CONTENT="the" HEIGHT="65" WIDTH="118"
+                            VPOS="2891" HPOS="3491" />
+                        <SP HEIGHT="65" WIDTH="25" VPOS="2890" HPOS="3610" />
+                        <String WC="0.88833332061767578" CONTENT="Photographic" HEIGHT="82"
+                            WIDTH="519" VPOS="2890" HPOS="3636" />
+                        <SP HEIGHT="66" WIDTH="24" VPOS="2889" HPOS="4156" />
+                        <String WC="0.74777776002883911" CONTENT="Evidence." HEIGHT="66" WIDTH="363"
+                            VPOS="2889" HPOS="4181" />
+                        <SP HEIGHT="65" WIDTH="28" VPOS="2890" HPOS="4545" />
+                        <String WC="1." CONTENT="”" HEIGHT="21" WIDTH="40" VPOS="2890" HPOS="4574" />
+                    </TextLine>
+                    <TextLine BASELINE="3052" HEIGHT="83" WIDTH="1836" VPOS="2984" HPOS="2827">
+                        <String WC="0.91600000858306885" CONTENT="(May," HEIGHT="82" WIDTH="219"
+                            VPOS="2984" HPOS="2827" />
+                        <SP HEIGHT="78" WIDTH="36" VPOS="2987" HPOS="3047" />
+                        <String WC="0.90600001811981201" CONTENT="1970," HEIGHT="81" WIDTH="211"
+                            VPOS="2985" HPOS="3084" />
+                        <SP HEIGHT="58" WIDTH="28" VPOS="3008" HPOS="3296" />
+                        <String WC="1." CONTENT="a" HEIGHT="44" WIDTH="36" VPOS="3008" HPOS="3325" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="2989" HPOS="3362" />
+                        <String WC="1." CONTENT="dynamite" HEIGHT="78" WIDTH="360" VPOS="2989"
+                            HPOS="3391" />
+                        <SP HEIGHT="44" WIDTH="30" VPOS="3008" HPOS="3752" />
+                        <String WC="0.98555552959442139" CONTENT="article);" HEIGHT="78" WIDTH="298"
+                            VPOS="2989" HPOS="3783" />
+                        <SP HEIGHT="69" WIDTH="32" VPOS="2998" HPOS="4082" />
+                        <String WC="0.66750001907348633" CONTENT="&quot;The" HEIGHT="65" WIDTH="192"
+                            VPOS="2988" HPOS="4115" />
+                        <SP HEIGHT="66" WIDTH="42" VPOS="2987" HPOS="4308" />
+                        <String WC="0.74857145547866821" CONTENT="Vietnam" HEIGHT="67" WIDTH="312"
+                            VPOS="2987" HPOS="4351" />
+                    </TextLine>
+                    <TextLine BASELINE="3149" HEIGHT="84" WIDTH="1707" VPOS="3082" HPOS="2819">
+                        <String WC="0.73600000143051147" CONTENT="Peace" HEIGHT="66" WIDTH="215"
+                            VPOS="3082" HPOS="2819" />
+                        <SP HEIGHT="65" WIDTH="29" VPOS="3082" HPOS="3035" />
+                        <String WC="0.88599997758865356" CONTENT="Game:" HEIGHT="67" WIDTH="245"
+                            VPOS="3082" HPOS="3065" />
+                        <SP HEIGHT="65" WIDTH="39" VPOS="3084" HPOS="3311" />
+                        <String WC="0.81294119358062744" CONTENT="Computer-Assisted" HEIGHT="82"
+                            WIDTH="728" VPOS="3084" HPOS="3351" />
+                        <SP HEIGHT="64" WIDTH="27" VPOS="3086" HPOS="4080" />
+                        <String WC="0.83799999952316284" CONTENT="Simulation" HEIGHT="66"
+                            WIDTH="418" VPOS="3086" HPOS="4108" />
+                    </TextLine>
+                    <TextLine BASELINE="3247" HEIGHT="82" WIDTH="1709" VPOS="3179" HPOS="2821">
+                        <String WC="1." CONTENT="of" HEIGHT="79" WIDTH="93" VPOS="3180" HPOS="2821" />
+                        <SP HEIGHT="80" WIDTH="15" VPOS="3179" HPOS="2915" />
+                        <String WC="0.86571431159973145" CONTENT="Complex" HEIGHT="82" WIDTH="343"
+                            VPOS="3179" HPOS="2931" />
+                        <SP HEIGHT="64" WIDTH="24" VPOS="3182" HPOS="3275" />
+                        <String WC="0.89666664600372314" CONTENT="Relations" HEIGHT="66" WIDTH="368"
+                            VPOS="3182" HPOS="3300" />
+                        <SP HEIGHT="62" WIDTH="25" VPOS="3186" HPOS="3669" />
+                        <String WC="0.67500001192092896" CONTENT="in" HEIGHT="60" WIDTH="68"
+                            VPOS="3186" HPOS="3695" />
+                        <SP HEIGHT="63" WIDTH="28" VPOS="3183" HPOS="3764" />
+                        <String WC="0.92230767011642456" CONTENT="International" HEIGHT="66"
+                            WIDTH="517" VPOS="3183" HPOS="3793" />
+                        <SP HEIGHT="65" WIDTH="16" VPOS="3183" HPOS="4311" />
+                        <String WC="0.95249998569488525" CONTENT="Rela" HEIGHT="66" WIDTH="176"
+                            VPOS="3183" HPOS="4328" SUBS_TYPE="HypPart1" SUBS_CONTENT="Relations." />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="3348" HEIGHT="84" WIDTH="1757" VPOS="3281" HPOS="2817">
+                        <String WC="0.74166667461395264" CONTENT="tions." HEIGHT="62" WIDTH="197"
+                            VPOS="3287" HPOS="2817" SUBS_TYPE="HypPart2" SUBS_CONTENT="Relations." />
+                        <SP HEIGHT="66" WIDTH="27" VPOS="3283" HPOS="3015" />
+                        <String WC="1." CONTENT="”" HEIGHT="21" WIDTH="39" VPOS="3283" HPOS="3043" />
+                        <SP HEIGHT="78" WIDTH="26" VPOS="3283" HPOS="3083" />
+                        <String WC="0.92000001668930054" CONTENT="(March," HEIGHT="80" WIDTH="293"
+                            VPOS="3283" HPOS="3110" />
+                        <SP HEIGHT="79" WIDTH="37" VPOS="3284" HPOS="3404" />
+                        <String WC="0.97500002384185791" CONTENT="1970);" HEIGHT="80" WIDTH="244"
+                            VPOS="3281" HPOS="3442" />
+                        <SP HEIGHT="78" WIDTH="40" VPOS="3283" HPOS="3687" />
+                        <String WC="0.92000001668930054" CONTENT="“A" HEIGHT="64" WIDTH="90"
+                            VPOS="3283" HPOS="3728" />
+                        <SP HEIGHT="64" WIDTH="37" VPOS="3283" HPOS="3819" />
+                        <String WC="0.93250000476837158" CONTENT="Computer" HEIGHT="82" WIDTH="393"
+                            VPOS="3283" HPOS="3857" />
+                        <SP HEIGHT="63" WIDTH="24" VPOS="3285" HPOS="4251" />
+                        <String WC="1." CONTENT="Labora" HEIGHT="64" WIDTH="270" VPOS="3285"
+                            HPOS="4276" SUBS_TYPE="HypPart1" SUBS_CONTENT="Laboratory" />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="3455" HEIGHT="81" WIDTH="1708" VPOS="3389" HPOS="2816">
+                        <String WC="0.75749999284744263" CONTENT="tory" HEIGHT="68" WIDTH="155"
+                            VPOS="3401" HPOS="2816" SUBS_TYPE="HypPart2" SUBS_CONTENT="Laboratory" />
+                        <SP HEIGHT="78" WIDTH="19" VPOS="3391" HPOS="2972" />
+                        <String WC="1." CONTENT="for" HEIGHT="78" WIDTH="127" VPOS="3391"
+                            HPOS="2992" />
+                        <SP HEIGHT="65" WIDTH="21" VPOS="3390" HPOS="3120" />
+                        <String WC="0.97100001573562622" CONTENT="Elementary" HEIGHT="80"
+                            WIDTH="446" VPOS="3390" HPOS="3142" />
+                        <SP HEIGHT="80" WIDTH="30" VPOS="3390" HPOS="3589" />
+                        <String WC="0.89499998092651367" CONTENT="Schools." HEIGHT="67" WIDTH="312"
+                            VPOS="3390" HPOS="3620" />
+                        <SP HEIGHT="67" WIDTH="26" VPOS="3390" HPOS="3933" />
+                        <String WC="1." CONTENT="”" HEIGHT="22" WIDTH="42" VPOS="3390" HPOS="3960" />
+                        <SP HEIGHT="78" WIDTH="22" VPOS="3390" HPOS="4003" />
+                        <String WC="0.94999998807907104" CONTENT="(June" HEIGHT="76" WIDTH="212"
+                            VPOS="3392" HPOS="4026" />
+                        <SP HEIGHT="65" WIDTH="41" VPOS="3390" HPOS="4239" />
+                        <String WC="0.9466666579246521" CONTENT="1972);" HEIGHT="81" WIDTH="243"
+                            VPOS="3389" HPOS="4281" />
+                    </TextLine>
+                    <TextLine BASELINE="3563" HEIGHT="83" WIDTH="1677" VPOS="3497" HPOS="2827">
+                        <String WC="0.79500001668930054" CONTENT="“The" HEIGHT="65" WIDTH="180"
+                            VPOS="3497" HPOS="2827" />
+                        <SP HEIGHT="65" WIDTH="35" VPOS="3497" HPOS="3008" />
+                        <String WC="0.90750002861022949" CONTENT="Uses" HEIGHT="67" WIDTH="166"
+                            VPOS="3497" HPOS="3044" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="3517" HPOS="3211" />
+                        <String WC="1." CONTENT="of" HEIGHT="78" WIDTH="94" VPOS="3499" HPOS="3236" />
+                        <SP HEIGHT="79" WIDTH="18" VPOS="3498" HPOS="3331" />
+                        <String WC="0.89444446563720703" CONTENT="Computers" HEIGHT="82" WIDTH="418"
+                            VPOS="3498" HPOS="3350" />
+                        <SP HEIGHT="62" WIDTH="27" VPOS="3503" HPOS="3769" />
+                        <String WC="0.69999998807907104" CONTENT="in" HEIGHT="61" WIDTH="67"
+                            VPOS="3503" HPOS="3797" />
+                        <SP HEIGHT="46" WIDTH="25" VPOS="3518" HPOS="3865" />
+                        <String WC="1." CONTENT="a" HEIGHT="45" WIDTH="40" VPOS="3519" HPOS="3891" />
+                        <SP HEIGHT="67" WIDTH="28" VPOS="3497" HPOS="3932" />
+                        <String WC="0.88444441556930542" CONTENT="Political" HEIGHT="67" WIDTH="323"
+                            VPOS="3497" HPOS="3961" />
+                        <SP HEIGHT="65" WIDTH="26" VPOS="3498" HPOS="4285" />
+                        <String WC="1." CONTENT="Cam" HEIGHT="67" WIDTH="166" VPOS="3498"
+                            HPOS="4312" SUBS_TYPE="HypPart1" SUBS_CONTENT="Campaign." />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="3670" HEIGHT="83" WIDTH="923" VPOS="3604" HPOS="2809">
+                        <String WC="0.66833335161209106" CONTENT="paign." HEIGHT="78" WIDTH="219"
+                            VPOS="3609" HPOS="2809" SUBS_TYPE="HypPart2" SUBS_CONTENT="Campaign." />
+                        <SP HEIGHT="66" WIDTH="27" VPOS="3605" HPOS="3029" />
+                        <String WC="1." CONTENT="”" HEIGHT="22" WIDTH="40" VPOS="3605" HPOS="3057" />
+                        <SP HEIGHT="77" WIDTH="24" VPOS="3605" HPOS="3098" />
+                        <String WC="0.86500000953674316" CONTENT="(August," HEIGHT="80" WIDTH="328"
+                            VPOS="3606" HPOS="3123" />
+                        <SP HEIGHT="80" WIDTH="37" VPOS="3605" HPOS="3452" />
+                        <String WC="0.96166664361953735" CONTENT="1971)." HEIGHT="80" WIDTH="242"
+                            VPOS="3604" HPOS="3490" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block15" HEIGHT="138" WIDTH="324" VPOS="5710" HPOS="4304"
+                    LANG="en-US" STYLEREFS="StyleId-005B92B4-525C-4C9C-AB9D-E09BF2344A2F-">
+                    <TextLine BASELINE="5830" HEIGHT="79" WIDTH="291" VPOS="5753" HPOS="4321">
+                        <String WC="0.39599999785423279" CONTENT="ter!®" HEIGHT="79" WIDTH="291"
+                            VPOS="5753" HPOS="4321" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block16" HEIGHT="96" WIDTH="1480" VPOS="1126" HPOS="4904"
+                    LANG="en-US" STYLEREFS="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-">
+                    <TextLine BASELINE="1205" HEIGHT="72" WIDTH="1454" VPOS="1139" HPOS="4917">
+                        <String WC="0.97111111879348755" CONTENT="COMPUTERS" HEIGHT="66" WIDTH="540"
+                            VPOS="1139" HPOS="4917" />
+                        <SP HEIGHT="62" WIDTH="24" VPOS="1145" HPOS="5458" />
+                        <String WC="0.96333330869674683" CONTENT="AND" HEIGHT="58" WIDTH="196"
+                            VPOS="1149" HPOS="5483" />
+                        <SP HEIGHT="58" WIDTH="32" VPOS="1149" HPOS="5680" />
+                        <String WC="0.89818179607391357" CONTENT="COMPUTATION" HEIGHT="62"
+                            WIDTH="658" VPOS="1149" HPOS="5713" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block17" HEIGHT="698" WIDTH="1790" VPOS="1288" HPOS="4894"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <TextLine BASELINE="1372" HEIGHT="91" WIDTH="1631" VPOS="1300" HPOS="4914">
+                        <String WC="1." CONTENT="This" HEIGHT="64" WIDTH="159" VPOS="1300"
+                            HPOS="4914" />
+                        <SP HEIGHT="63" WIDTH="28" VPOS="1302" HPOS="5074" />
+                        <String WC="1." CONTENT="is" HEIGHT="63" WIDTH="53" VPOS="1302" HPOS="5103" />
+                        <SP HEIGHT="58" WIDTH="27" VPOS="1309" HPOS="5157" />
+                        <String WC="1." CONTENT="the" HEIGHT="64" WIDTH="117" VPOS="1304"
+                            HPOS="5185" />
+                        <SP HEIGHT="64" WIDTH="30" VPOS="1307" HPOS="5303" />
+                        <String WC="1." CONTENT="best" HEIGHT="65" WIDTH="151" VPOS="1307"
+                            HPOS="5334" />
+                        <SP HEIGHT="65" WIDTH="30" VPOS="1309" HPOS="5486" />
+                        <String WC="1." CONTENT="book" HEIGHT="65" WIDTH="194" VPOS="1309"
+                            HPOS="5517" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="1311" HPOS="5712" />
+                        <String WC="0.93199998140335083" CONTENT="about" HEIGHT="64" WIDTH="225"
+                            VPOS="1311" HPOS="5735" />
+                        <SP HEIGHT="54" WIDTH="36" VPOS="1322" HPOS="5961" />
+                        <String WC="0.93666666746139526" CONTENT="computers" HEIGHT="75" WIDTH="404"
+                            VPOS="1316" HPOS="5998" />
+                        <SP HEIGHT="45" WIDTH="33" VPOS="1329" HPOS="6403" />
+                        <String WC="0.62000000476837158" CONTENT="." HEIGHT="9" WIDTH="11"
+                            VPOS="1364" HPOS="6437" />
+                        <SP HEIGHT="12" WIDTH="34" VPOS="1364" HPOS="6449" />
+                        <String WC="0.73000001907348633" CONTENT="." HEIGHT="10" WIDTH="12"
+                            VPOS="1366" HPOS="6484" />
+                        <SP HEIGHT="12" WIDTH="36" VPOS="1366" HPOS="6497" />
+                        <String WC="0.68000000715255737" CONTENT="." HEIGHT="11" WIDTH="11"
+                            VPOS="1367" HPOS="6534" />
+                    </TextLine>
+                    <TextLine BASELINE="1481" HEIGHT="92" WIDTH="1760" VPOS="1411" HPOS="4912">
+                        <String WC="0.92750000953674316" CONTENT="what" HEIGHT="64" WIDTH="181"
+                            VPOS="1411" HPOS="4912" />
+                        <SP HEIGHT="59" WIDTH="31" VPOS="1417" HPOS="5094" />
+                        <String WC="1." CONTENT="they" HEIGHT="81" WIDTH="167" VPOS="1412"
+                            HPOS="5126" />
+                        <SP HEIGHT="59" WIDTH="29" VPOS="1434" HPOS="5294" />
+                        <String WC="0.84249997138977051" CONTENT="are," HEIGHT="60" WIDTH="137"
+                            VPOS="1434" HPOS="5324" />
+                        <SP HEIGHT="76" WIDTH="29" VPOS="1418" HPOS="5462" />
+                        <String WC="1." CONTENT="how" HEIGHT="62" WIDTH="159" VPOS="1418"
+                            HPOS="5492" />
+                        <SP HEIGHT="54" WIDTH="32" VPOS="1426" HPOS="5652" />
+                        <String WC="1." CONTENT="they" HEIGHT="77" WIDTH="168" VPOS="1420"
+                            HPOS="5685" />
+                        <SP HEIGHT="77" WIDTH="31" VPOS="1420" HPOS="5854" />
+                        <String WC="0.93444442749023438" CONTENT="happened," HEIGHT="79" WIDTH="395"
+                            VPOS="1420" HPOS="5886" />
+                        <SP HEIGHT="77" WIDTH="31" VPOS="1420" HPOS="6282" />
+                        <String WC="1." CONTENT="how" HEIGHT="63" WIDTH="158" VPOS="1420"
+                            HPOS="6314" />
+                        <SP HEIGHT="58" WIDTH="31" VPOS="1428" HPOS="6473" />
+                        <String WC="1." CONTENT="they" HEIGHT="80" WIDTH="167" VPOS="1423"
+                            HPOS="6505" />
+                    </TextLine>
+                    <TextLine BASELINE="1589" HEIGHT="88" WIDTH="1760" VPOS="1521" HPOS="4910">
+                        <String WC="1." CONTENT="work" HEIGHT="63" WIDTH="188" VPOS="1521"
+                            HPOS="4910" />
+                        <SP HEIGHT="64" WIDTH="34" VPOS="1521" HPOS="5099" />
+                        <String WC="1." CONTENT="and" HEIGHT="64" WIDTH="130" VPOS="1522"
+                            HPOS="5134" />
+                        <SP HEIGHT="64" WIDTH="32" VPOS="1522" HPOS="5265" />
+                        <String WC="1." CONTENT="how" HEIGHT="64" WIDTH="159" VPOS="1522"
+                            HPOS="5298" />
+                        <SP HEIGHT="56" WIDTH="34" VPOS="1530" HPOS="5458" />
+                        <String WC="1." CONTENT="they" HEIGHT="78" WIDTH="167" VPOS="1525"
+                            HPOS="5493" />
+                        <SP HEIGHT="58" WIDTH="29" VPOS="1545" HPOS="5661" />
+                        <String WC="1." CONTENT="are" HEIGHT="43" WIDTH="110" VPOS="1545"
+                            HPOS="5691" />
+                        <SP HEIGHT="43" WIDTH="29" VPOS="1545" HPOS="5802" />
+                        <String WC="0.82200002670288086" CONTENT="used." HEIGHT="63" WIDTH="192"
+                            VPOS="1527" HPOS="5832" />
+                        <SP HEIGHT="63" WIDTH="59" VPOS="1527" HPOS="6025" />
+                        <String WC="0.94333332777023315" CONTENT="Computers" HEIGHT="82" WIDTH="418"
+                            VPOS="1527" HPOS="6085" />
+                        <SP HEIGHT="45" WIDTH="22" VPOS="1551" HPOS="6504" />
+                        <String WC="0.75666666030883789" CONTENT="and" HEIGHT="66" WIDTH="143"
+                            VPOS="1530" HPOS="6527" />
+                    </TextLine>
+                    <TextLine BASELINE="1696" HEIGHT="83" WIDTH="1585" VPOS="1628" HPOS="4912">
+                        <String WC="0.95272725820541382" CONTENT="Computation" HEIGHT="83"
+                            WIDTH="500" VPOS="1628" HPOS="4912" />
+                        <SP HEIGHT="44" WIDTH="38" VPOS="1649" HPOS="5413" />
+                        <String WC="0.98374998569488525" CONTENT="consists" HEIGHT="63" WIDTH="292"
+                            VPOS="1631" HPOS="5452" />
+                        <SP HEIGHT="44" WIDTH="26" VPOS="1650" HPOS="5745" />
+                        <String WC="0.875" CONTENT="of" HEIGHT="62" WIDTH="85" VPOS="1632"
+                            HPOS="5772" />
+                        <SP HEIGHT="64" WIDTH="25" VPOS="1631" HPOS="5858" />
+                        <String WC="1." CONTENT="26" HEIGHT="65" WIDTH="93" VPOS="1631" HPOS="5884" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="1633" HPOS="5978" />
+                        <String WC="0.79000002145767212" CONTENT="articles" HEIGHT="65" WIDTH="274"
+                            VPOS="1636" HPOS="6007" />
+                        <SP HEIGHT="65" WIDTH="29" VPOS="1636" HPOS="6282" />
+                        <String WC="0.77249997854232788" CONTENT="from" HEIGHT="66" WIDTH="185"
+                            VPOS="1636" HPOS="6312" />
+                    </TextLine>
+                    <TextLine BASELINE="1803" HEIGHT="88" WIDTH="1593" VPOS="1734" HPOS="4906">
+                        <String WC="0.83099997043609619" CONTENT="Scientific" HEIGHT="82"
+                            WIDTH="359" VPOS="1734" HPOS="4906" />
+                        <SP HEIGHT="64" WIDTH="22" VPOS="1738" HPOS="5266" />
+                        <String WC="0.83111113309860229" CONTENT="American," HEIGHT="78" WIDTH="403"
+                            VPOS="1738" HPOS="5289" />
+                        <SP HEIGHT="79" WIDTH="38" VPOS="1737" HPOS="5693" />
+                        <String WC="1." CONTENT="1950" HEIGHT="66" WIDTH="184" VPOS="1736"
+                            HPOS="5732" />
+                        <SP HEIGHT="66" WIDTH="29" VPOS="1737" HPOS="5917" />
+                        <String WC="1." CONTENT="through" HEIGHT="82" WIDTH="306" VPOS="1740"
+                            HPOS="5947" />
+                        <SP HEIGHT="63" WIDTH="39" VPOS="1745" HPOS="6254" />
+                        <String WC="0.93999999761581421" CONTENT="1971." HEIGHT="65" WIDTH="205"
+                            VPOS="1743" HPOS="6294" />
+                    </TextLine>
+                    <TextLine BASELINE="1967" HEIGHT="77" WIDTH="1468" VPOS="1897" HPOS="4907">
+                        <String WC="0.94333332777023315" CONTENT="The" HEIGHT="65" WIDTH="141"
+                            VPOS="1897" HPOS="4907" />
+                        <SP HEIGHT="63" WIDTH="27" VPOS="1901" HPOS="5049" />
+                        <String WC="1." CONTENT="book" HEIGHT="64" WIDTH="193" VPOS="1901"
+                            HPOS="5077" />
+                        <SP HEIGHT="64" WIDTH="32" VPOS="1901" HPOS="5271" />
+                        <String WC="1." CONTENT="is" HEIGHT="63" WIDTH="55" VPOS="1902" HPOS="5304" />
+                        <SP HEIGHT="64" WIDTH="25" VPOS="1901" HPOS="5360" />
+                        <String WC="1." CONTENT="divided" HEIGHT="65" WIDTH="275" VPOS="1901"
+                            HPOS="5386" />
+                        <SP HEIGHT="64" WIDTH="33" VPOS="1902" HPOS="5662" />
+                        <String WC="1." CONTENT="into" HEIGHT="64" WIDTH="150" VPOS="1902"
+                            HPOS="5696" />
+                        <SP HEIGHT="64" WIDTH="31" VPOS="1903" HPOS="5847" />
+                        <String WC="0.92250001430511475" CONTENT="five" HEIGHT="64" WIDTH="137"
+                            VPOS="1903" HPOS="5879" />
+                        <SP HEIGHT="45" WIDTH="30" VPOS="1923" HPOS="6017" />
+                        <String WC="0.93222224712371826" CONTENT="sections:" HEIGHT="65" WIDTH="327"
+                            VPOS="1909" HPOS="6048" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block18" HEIGHT="330" WIDTH="116" VPOS="2174" HPOS="4982"
+                    LANG="en-US" STYLEREFS="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-">
+                    <TextLine BASELINE="2244" HEIGHT="58" WIDTH="60" VPOS="2187" HPOS="4999">
+                        <String WC="0.72500002384185791" CONTENT="II" HEIGHT="58" WIDTH="60"
+                            VPOS="2187" HPOS="4999" />
+                    </TextLine>
+                    <TextLine BASELINE="2328" HEIGHT="60" WIDTH="90" VPOS="2269" HPOS="4997">
+                        <String WC="0.97000002861022949" CONTENT="III" HEIGHT="60" WIDTH="90"
+                            VPOS="2269" HPOS="4997" />
+                    </TextLine>
+                    <TextLine BASELINE="2410" HEIGHT="60" WIDTH="88" VPOS="2351" HPOS="4995">
+                        <String WC="0.54500001668930054" CONTENT="IV" HEIGHT="60" WIDTH="88"
+                            VPOS="2351" HPOS="4995" />
+                    </TextLine>
+                    <TextLine BASELINE="2492" HEIGHT="58" WIDTH="52" VPOS="2435" HPOS="5009">
+                        <String WC="1." CONTENT="V" HEIGHT="58" WIDTH="52" VPOS="2435" HPOS="5009" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block19" HEIGHT="444" WIDTH="1410" VPOS="2092" HPOS="5182"
+                    LANG="en-US" STYLEREFS="StyleId-5FAD982E-5545-4C0E-851E-EBF3503090E4-">
+                    <TextLine BASELINE="2166" HEIGHT="61" WIDTH="469" VPOS="2105" HPOS="5197">
+                        <String WC="0.81749999523162842" CONTENT="Fundamentals" HEIGHT="61"
+                            WIDTH="469" VPOS="2105" HPOS="5197" />
+                    </TextLine>
+                    <TextLine BASELINE="2249" HEIGHT="86" WIDTH="1323" VPOS="2188" HPOS="5201">
+                        <String WC="0.86333334445953369" CONTENT="Games," HEIGHT="74" WIDTH="232"
+                            VPOS="2188" HPOS="5201" />
+                        <SP HEIGHT="74" WIDTH="23" VPOS="2188" HPOS="5434" />
+                        <String WC="0.56000000238418579" CONTENT="Music" HEIGHT="61" WIDTH="191"
+                            VPOS="2188" HPOS="5458" />
+                        <SP HEIGHT="36" WIDTH="21" VPOS="2212" HPOS="5650" />
+                        <String WC="0.87999999523162842" CONTENT="and" HEIGHT="57" WIDTH="121"
+                            VPOS="2191" HPOS="5672" />
+                        <SP HEIGHT="56" WIDTH="19" VPOS="2191" HPOS="5794" />
+                        <String WC="0.7070000171661377" CONTENT="Artificial" HEIGHT="75" WIDTH="306"
+                            VPOS="2191" HPOS="5814" />
+                        <SP HEIGHT="58" WIDTH="18" VPOS="2193" HPOS="6121" />
+                        <String WC="0.83333331346511841" CONTENT="Intelligence" HEIGHT="81"
+                            WIDTH="384" VPOS="2193" HPOS="6140" />
+                    </TextLine>
+                    <TextLine BASELINE="2332" HEIGHT="85" WIDTH="1315" VPOS="2270" HPOS="5194">
+                        <String WC="0.74909090995788574" CONTENT="Mathematics" HEIGHT="60"
+                            WIDTH="420" VPOS="2270" HPOS="5194" />
+                        <SP HEIGHT="36" WIDTH="23" VPOS="2294" HPOS="5615" />
+                        <String WC="0.60000002384185791" CONTENT="of," HEIGHT="74" WIDTH="86"
+                            VPOS="2273" HPOS="5639" />
+                        <SP HEIGHT="68" WIDTH="28" VPOS="2274" HPOS="5726" />
+                        <String WC="0.6066666841506958" CONTENT="by," HEIGHT="75" WIDTH="99"
+                            VPOS="2274" HPOS="5755" />
+                        <SP HEIGHT="49" WIDTH="21" VPOS="2297" HPOS="5855" />
+                        <String WC="0.98000001907348633" CONTENT="and" HEIGHT="57" WIDTH="123"
+                            VPOS="2275" HPOS="5877" />
+                        <SP HEIGHT="74" WIDTH="13" VPOS="2275" HPOS="6001" />
+                        <String WC="1." CONTENT="for" HEIGHT="74" WIDTH="110" VPOS="2275"
+                            HPOS="6015" />
+                        <SP HEIGHT="59" WIDTH="22" VPOS="2275" HPOS="6126" />
+                        <String WC="0.84666669368743896" CONTENT="Computers" HEIGHT="80" WIDTH="360"
+                            VPOS="2275" HPOS="6149" />
+                    </TextLine>
+                    <TextLine BASELINE="2415" HEIGHT="80" WIDTH="1203" VPOS="2352" HPOS="5199">
+                        <String WC="0.86124998331069946" CONTENT="Computer" HEIGHT="80" WIDTH="328"
+                            VPOS="2352" HPOS="5199" />
+                        <SP HEIGHT="58" WIDTH="21" VPOS="2353" HPOS="5528" />
+                        <String WC="1." CONTENT="Models" HEIGHT="61" WIDTH="234" VPOS="2353"
+                            HPOS="5550" />
+                        <SP HEIGHT="36" WIDTH="24" VPOS="2378" HPOS="5785" />
+                        <String WC="1." CONTENT="of" HEIGHT="74" WIDTH="79" VPOS="2357" HPOS="5810" />
+                        <SP HEIGHT="74" WIDTH="14" VPOS="2357" HPOS="5890" />
+                        <String WC="0.71333330869674683" CONTENT="the" HEIGHT="56" WIDTH="100"
+                            VPOS="2359" HPOS="5905" />
+                        <SP HEIGHT="59" WIDTH="22" VPOS="2356" HPOS="6006" />
+                        <String WC="0.86000001430511475" CONTENT="Real" HEIGHT="61" WIDTH="152"
+                            VPOS="2356" HPOS="6029" />
+                        <SP HEIGHT="58" WIDTH="27" VPOS="2359" HPOS="6182" />
+                        <String WC="0.80000001192092896" CONTENT="World" HEIGHT="61" WIDTH="192"
+                            VPOS="2359" HPOS="6210" />
+                    </TextLine>
+                    <TextLine BASELINE="2498" HEIGHT="89" WIDTH="1385" VPOS="2434" HPOS="5195">
+                        <String WC="0.81749999523162842" CONTENT="Four" HEIGHT="62" WIDTH="160"
+                            VPOS="2434" HPOS="5195" />
+                        <SP HEIGHT="58" WIDTH="19" VPOS="2436" HPOS="5356" />
+                        <String WC="0.74000000953674316" CONTENT="Essays" HEIGHT="78" WIDTH="215"
+                            VPOS="2436" HPOS="5376" />
+                        <SP HEIGHT="37" WIDTH="22" VPOS="2459" HPOS="5592" />
+                        <String WC="0.75499999523162842" CONTENT="on" HEIGHT="37" WIDTH="80"
+                            VPOS="2459" HPOS="5615" />
+                        <SP HEIGHT="46" WIDTH="28" VPOS="2451" HPOS="5696" />
+                        <String WC="0.58333331346511841" CONTENT="the" HEIGHT="56" WIDTH="99"
+                            VPOS="2441" HPOS="5725" />
+                        <SP HEIGHT="61" WIDTH="31" VPOS="2438" HPOS="5825" />
+                        <String WC="0.78250002861022949" CONTENT="Uses" HEIGHT="62" WIDTH="141"
+                            VPOS="2438" HPOS="5857" />
+                        <SP HEIGHT="37" WIDTH="24" VPOS="2462" HPOS="5999" />
+                        <String WC="1." CONTENT="of" HEIGHT="74" WIDTH="79" VPOS="2442" HPOS="6024" />
+                        <SP HEIGHT="74" WIDTH="13" VPOS="2442" HPOS="6104" />
+                        <String WC="0.73666667938232422" CONTENT="the" HEIGHT="56" WIDTH="100"
+                            VPOS="2445" HPOS="6118" />
+                        <SP HEIGHT="60" WIDTH="27" VPOS="2442" HPOS="6219" />
+                        <String WC="0.78374999761581421" CONTENT="Computer" HEIGHT="81" WIDTH="333"
+                            VPOS="2442" HPOS="6247" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block20" HEIGHT="1000" WIDTH="1934" VPOS="2594" HPOS="4828"
+                    LANG="en-US" STYLEREFS="StyleId-445DF913-A516-40FE-A4CE-7B1C1030E057-">
+                    <TextLine BASELINE="2680" HEIGHT="92" WIDTH="1756" VPOS="2607" HPOS="4897">
+                        <String WC="1." CONTENT="Articles" HEIGHT="68" WIDTH="294" VPOS="2607"
+                            HPOS="4897" />
+                        <SP HEIGHT="62" WIDTH="30" VPOS="2613" HPOS="5192" />
+                        <String WC="1." CONTENT="include:" HEIGHT="64" WIDTH="302" VPOS="2613"
+                            HPOS="5223" />
+                        <SP HEIGHT="62" WIDTH="40" VPOS="2615" HPOS="5526" />
+                        <String WC="1." CONTENT="“Computer" HEIGHT="84" WIDTH="436" VPOS="2613"
+                            HPOS="5567" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="2617" HPOS="6004" />
+                        <String WC="1." CONTENT="Logic" HEIGHT="82" WIDTH="212" VPOS="2617"
+                            HPOS="6033" />
+                        <SP HEIGHT="48" WIDTH="24" VPOS="2639" HPOS="6246" />
+                        <String WC="1." CONTENT="and" HEIGHT="64" WIDTH="138" VPOS="2623"
+                            HPOS="6271" />
+                        <SP HEIGHT="66" WIDTH="32" VPOS="2621" HPOS="6410" />
+                        <String WC="1." CONTENT="Mem" HEIGHT="66" WIDTH="184" VPOS="2621"
+                            HPOS="6443" SUBS_TYPE="HypPart1" SUBS_CONTENT="Memory”," />
+                        <HYP CONTENT="­" />
+                    </TextLine>
+                    <TextLine BASELINE="2779" HEIGHT="94" WIDTH="1532" VPOS="2707" HPOS="4897">
+                        <String WC="0.94999998807907104" CONTENT="ory”," HEIGHT="80" WIDTH="202"
+                            VPOS="2707" HPOS="4897" SUBS_TYPE="HypPart2" SUBS_CONTENT="Memory”," />
+                        <SP HEIGHT="78" WIDTH="30" VPOS="2709" HPOS="5100" />
+                        <String WC="0.95444446802139282" CONTENT="“Computer" HEIGHT="82" WIDTH="436"
+                            VPOS="2709" HPOS="5131" />
+                        <SP HEIGHT="64" WIDTH="30" VPOS="2713" HPOS="5568" />
+                        <String WC="0.91166669130325317" CONTENT="Inputs" HEIGHT="82" WIDTH="244"
+                            VPOS="2713" HPOS="5599" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="2735" HPOS="5844" />
+                        <String WC="1." CONTENT="and" HEIGHT="64" WIDTH="136" VPOS="2717"
+                            HPOS="5869" />
+                        <SP HEIGHT="64" WIDTH="30" VPOS="2717" HPOS="6006" />
+                        <String WC="0.96222221851348877" CONTENT="Outputs”," HEIGHT="84" WIDTH="392"
+                            VPOS="2717" HPOS="6037" />
+                    </TextLine>
+                    <TextLine BASELINE="2878" HEIGHT="96" WIDTH="1574" VPOS="2805" HPOS="4901">
+                        <String WC="1." CONTENT="“Computer" HEIGHT="84" WIDTH="430" VPOS="2805"
+                            HPOS="4901" />
+                        <SP HEIGHT="66" WIDTH="28" VPOS="2809" HPOS="5332" />
+                        <String WC="0.99699997901916504" CONTENT="Displays”," HEIGHT="84"
+                            WIDTH="396" VPOS="2809" HPOS="5361" />
+                        <SP HEIGHT="78" WIDTH="30" VPOS="2815" HPOS="5758" />
+                        <String WC="1." CONTENT="“Time" HEIGHT="68" WIDTH="242" VPOS="2813"
+                            HPOS="5789" />
+                        <SP HEIGHT="66" WIDTH="32" VPOS="2815" HPOS="6032" />
+                        <String WC="1." CONTENT="Sharing" HEIGHT="86" WIDTH="286" VPOS="2815"
+                            HPOS="6065" />
+                        <SP HEIGHT="60" WIDTH="26" VPOS="2841" HPOS="6352" />
+                        <String WC="1." CONTENT="on" HEIGHT="46" WIDTH="96" VPOS="2841" HPOS="6379" />
+                    </TextLine>
+                    <TextLine BASELINE="2976" HEIGHT="92" WIDTH="1592" VPOS="2907" HPOS="4899">
+                        <String WC="0.97272729873657227" CONTENT="computers”," HEIGHT="80"
+                            WIDTH="472" VPOS="2907" HPOS="4899" />
+                        <SP HEIGHT="78" WIDTH="30" VPOS="2909" HPOS="5372" />
+                        <String WC="1." CONTENT="“A" HEIGHT="64" WIDTH="108" VPOS="2909" HPOS="5403" />
+                        <SP HEIGHT="66" WIDTH="26" VPOS="2909" HPOS="5512" />
+                        <String WC="0.93000000715255737" CONTENT="Chess" HEIGHT="70" WIDTH="216"
+                            VPOS="2909" HPOS="5539" />
+                        <SP HEIGHT="68" WIDTH="26" VPOS="2911" HPOS="5756" />
+                        <String WC="0.98142856359481812" CONTENT="Playing" HEIGHT="84" WIDTH="282"
+                            VPOS="2911" HPOS="5783" />
+                        <SP HEIGHT="80" WIDTH="26" VPOS="2915" HPOS="6066" />
+                        <String WC="0.98333334922790527" CONTENT="Machine”," HEIGHT="84" WIDTH="398"
+                            VPOS="2915" HPOS="6093" />
+                    </TextLine>
+                    <TextLine BASELINE="3077" HEIGHT="96" WIDTH="1732" VPOS="3003" HPOS="4897">
+                        <String WC="0.97333335876464844" CONTENT="“Computer" HEIGHT="84" WIDTH="430"
+                            VPOS="3003" HPOS="4897" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="3007" HPOS="5328" />
+                        <String WC="0.96857142448425293" CONTENT="Music”," HEIGHT="82" WIDTH="298"
+                            VPOS="3007" HPOS="5357" />
+                        <SP HEIGHT="78" WIDTH="28" VPOS="3011" HPOS="5656" />
+                        <String WC="1." CONTENT="“Artificial" HEIGHT="68" WIDTH="396" VPOS="3011"
+                            HPOS="5685" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="3015" HPOS="6082" />
+                        <String WC="0.97142857313156128" CONTENT="Intelligence”," HEIGHT="84"
+                            WIDTH="518" VPOS="3015" HPOS="6111" />
+                    </TextLine>
+                    <TextLine BASELINE="3175" HEIGHT="92" WIDTH="1782" VPOS="3101" HPOS="4897">
+                        <String WC="1." CONTENT="“Games," HEIGHT="84" WIDTH="320" VPOS="3101"
+                            HPOS="4897" />
+                        <SP HEIGHT="80" WIDTH="30" VPOS="3105" HPOS="5218" />
+                        <String WC="1." CONTENT="Logic" HEIGHT="82" WIDTH="212" VPOS="3105"
+                            HPOS="5249" />
+                        <SP HEIGHT="48" WIDTH="24" VPOS="3127" HPOS="5462" />
+                        <String WC="1." CONTENT="and" HEIGHT="66" WIDTH="136" VPOS="3109"
+                            HPOS="5487" />
+                        <SP HEIGHT="66" WIDTH="30" VPOS="3109" HPOS="5624" />
+                        <String WC="1." CONTENT="Computers”," HEIGHT="84" WIDTH="500" VPOS="3109"
+                            HPOS="5655" />
+                        <SP HEIGHT="78" WIDTH="56" VPOS="3115" HPOS="6156" />
+                        <String WC="1." CONTENT="“The" HEIGHT="68" WIDTH="192" VPOS="3115"
+                            HPOS="6213" />
+                        <SP HEIGHT="66" WIDTH="30" VPOS="3117" HPOS="6406" />
+                        <String WC="1." CONTENT="Monte" HEIGHT="66" WIDTH="242" VPOS="3117"
+                            HPOS="6437" />
+                    </TextLine>
+                    <TextLine BASELINE="3275" HEIGHT="92" WIDTH="1720" VPOS="3201" HPOS="4889">
+                        <String WC="1." CONTENT="Carlo" HEIGHT="68" WIDTH="200" VPOS="3201"
+                            HPOS="4889" />
+                        <SP HEIGHT="66" WIDTH="30" VPOS="3203" HPOS="5090" />
+                        <String WC="0.97374999523162842" CONTENT="Method”," HEIGHT="84" WIDTH="372"
+                            VPOS="3203" HPOS="5121" />
+                        <SP HEIGHT="80" WIDTH="30" VPOS="3207" HPOS="5494" />
+                        <String WC="1." CONTENT="“Systems" HEIGHT="84" WIDTH="362" VPOS="3205"
+                            HPOS="5525" />
+                        <SP HEIGHT="66" WIDTH="26" VPOS="3211" HPOS="5888" />
+                        <String WC="1." CONTENT="Analysis" HEIGHT="82" WIDTH="322" VPOS="3211"
+                            HPOS="5915" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="3233" HPOS="6238" />
+                        <String WC="1." CONTENT="of" HEIGHT="64" WIDTH="90" VPOS="3215" HPOS="6263" />
+                        <SP HEIGHT="66" WIDTH="22" VPOS="3215" HPOS="6354" />
+                        <String WC="1." CONTENT="Urban" HEIGHT="66" WIDTH="232" VPOS="3215"
+                            HPOS="6377" />
+                    </TextLine>
+                    <TextLine BASELINE="3373" HEIGHT="96" WIDTH="1720" VPOS="3297" HPOS="4889">
+                        <String WC="0.97624999284744263" CONTENT="Transportation”," HEIGHT="88"
+                            WIDTH="652" VPOS="3297" HPOS="4889" />
+                        <SP HEIGHT="80" WIDTH="32" VPOS="3305" HPOS="5542" />
+                        <String WC="1." CONTENT="“Chromosome" HEIGHT="70" WIDTH="558" VPOS="3305"
+                            HPOS="5575" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="3311" HPOS="6134" />
+                        <String WC="1." CONTENT="Analysis" HEIGHT="82" WIDTH="324" VPOS="3311"
+                            HPOS="6163" />
+                        <SP HEIGHT="64" WIDTH="26" VPOS="3315" HPOS="6488" />
+                        <String WC="1." CONTENT="by" HEIGHT="78" WIDTH="94" VPOS="3315" HPOS="6515" />
+                    </TextLine>
+                    <TextLine BASELINE="3471" HEIGHT="96" WIDTH="1776" VPOS="3395" HPOS="4887">
+                        <String WC="0.94300001859664917" CONTENT="Computer”," HEIGHT="86"
+                            WIDTH="460" VPOS="3395" HPOS="4887" />
+                        <SP HEIGHT="80" WIDTH="32" VPOS="3401" HPOS="5348" />
+                        <String WC="1." CONTENT="“Man" HEIGHT="68" WIDTH="208" VPOS="3401"
+                            HPOS="5381" />
+                        <SP HEIGHT="66" WIDTH="28" VPOS="3403" HPOS="5590" />
+                        <String WC="1." CONTENT="Viewed" HEIGHT="68" WIDTH="284" VPOS="3403"
+                            HPOS="5619" />
+                        <SP HEIGHT="66" WIDTH="30" VPOS="3407" HPOS="5904" />
+                        <String WC="1." CONTENT="as" HEIGHT="46" WIDTH="74" VPOS="3427" HPOS="5935" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="3427" HPOS="6010" />
+                        <String WC="1." CONTENT="a" HEIGHT="46" WIDTH="38" VPOS="3427" HPOS="6035" />
+                        <SP HEIGHT="66" WIDTH="28" VPOS="3407" HPOS="6074" />
+                        <String WC="1." CONTENT="Machine”," HEIGHT="84" WIDTH="398" VPOS="3407"
+                            HPOS="6103" />
+                        <SP HEIGHT="60" WIDTH="26" VPOS="3431" HPOS="6502" />
+                        <String WC="1." CONTENT="and" HEIGHT="66" WIDTH="134" VPOS="3411"
+                            HPOS="6529" />
+                    </TextLine>
+                    <TextLine BASELINE="3567" HEIGHT="90" WIDTH="1518" VPOS="3493" HPOS="4891">
+                        <String WC="1." CONTENT="“The" HEIGHT="68" WIDTH="188" VPOS="3493"
+                            HPOS="4891" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="3497" HPOS="5080" />
+                        <String WC="1." CONTENT="Uses" HEIGHT="68" WIDTH="172" VPOS="3497"
+                            HPOS="5109" />
+                        <SP HEIGHT="46" WIDTH="24" VPOS="3519" HPOS="5282" />
+                        <String WC="1." CONTENT="of" HEIGHT="66" WIDTH="86" VPOS="3499" HPOS="5307" />
+                        <SP HEIGHT="66" WIDTH="20" VPOS="3499" HPOS="5394" />
+                        <String WC="1." CONTENT="Computer" HEIGHT="84" WIDTH="390" VPOS="3499"
+                            HPOS="5415" />
+                        <SP HEIGHT="64" WIDTH="28" VPOS="3505" HPOS="5806" />
+                        <String WC="1." CONTENT="in" HEIGHT="64" WIDTH="72" VPOS="3505" HPOS="5835" />
+                        <SP HEIGHT="64" WIDTH="26" VPOS="3505" HPOS="5908" />
+                        <String WC="0.97272729873657227" CONTENT="Education.”" HEIGHT="70"
+                            WIDTH="474" VPOS="3505" HPOS="5935" />
+                    </TextLine>
+                </TextBlock>
+                <TextBlock ID="Page3_Block21" HEIGHT="188" WIDTH="950" VPOS="4344" HPOS="5158"
+                    LANG="en-US" STYLEREFS="StyleId-E403BA48-2B56-4615-A114-B35CF968CB7A-">
+                    <TextLine BASELINE="4417" HEIGHT="81" WIDTH="927" VPOS="4356" HPOS="5169">
+                        <String WC="0.77999997138977051" CONTENT="Published," HEIGHT="75"
+                            WIDTH="340" VPOS="4356" HPOS="5169" />
+                        <SP HEIGHT="70" WIDTH="29" VPOS="4361" HPOS="5510" />
+                        <String WC="0.82400000095367432" CONTENT="1971," HEIGHT="70" WIDTH="183"
+                            VPOS="4360" HPOS="5540" />
+                        <SP HEIGHT="68" WIDTH="25" VPOS="4362" HPOS="5724" />
+                        <String WC="1." CONTENT="283" HEIGHT="58" WIDTH="128" VPOS="4361"
+                            HPOS="5750" />
+                        <SP HEIGHT="76" WIDTH="22" VPOS="4361" HPOS="5879" />
+                        <String WC="0.93166667222976685" CONTENT="pages." HEIGHT="56" WIDTH="194"
+                            VPOS="4381" HPOS="5902" />
+                    </TextLine>
+                    <TextLine BASELINE="4500" HEIGHT="78" WIDTH="511" VPOS="4441" HPOS="5175">
+                        <String WC="0.90799999237060547" CONTENT="$4.95" HEIGHT="64" WIDTH="183"
+                            VPOS="4441" HPOS="5175" />
+                        <SP HEIGHT="76" WIDTH="18" VPOS="4443" HPOS="5359" />
+                        <String WC="0.79777777194976807" CONTENT="postpaid." HEIGHT="77" WIDTH="308"
+                            VPOS="4442" HPOS="5378" />
+                    </TextLine>
+                </TextBlock>
+                <Illustration ID="Page3_Block22" HEIGHT="1790" WIDTH="1374" VPOS="4560" HPOS="4968" />
+                <GraphicalElement ID="Page3_Block23" HEIGHT="12" WIDTH="232" VPOS="4646" HPOS="3460" />
+                <GraphicalElement ID="Page3_Block24" HEIGHT="2" WIDTH="196" VPOS="4652" HPOS="3884" />
+                <GraphicalElement ID="Page3_Block25" HEIGHT="2" WIDTH="246" VPOS="4666" HPOS="3598" />
+                <GraphicalElement ID="Page3_Block26" HEIGHT="2" WIDTH="182" VPOS="4794" HPOS="3200" />
+                <GraphicalElement ID="Page3_Block27" HEIGHT="16" WIDTH="270" VPOS="5030" HPOS="6034" />
+                <GraphicalElement ID="Page3_Block28" HEIGHT="14" WIDTH="506" VPOS="5042" HPOS="5138" />
+                <GraphicalElement ID="Page3_Block29" HEIGHT="2" WIDTH="196" VPOS="5294" HPOS="4432" />
+                <GraphicalElement ID="Page3_Block30" HEIGHT="12" WIDTH="314" VPOS="5406" HPOS="3102" />
+                <GraphicalElement ID="Page3_Block31" HEIGHT="2" WIDTH="252" VPOS="5456" HPOS="4114" />
+                <GraphicalElement ID="Page3_Block32" HEIGHT="18" WIDTH="612" VPOS="5462" HPOS="5026" />
+                <GraphicalElement ID="Page3_Block33" HEIGHT="2" WIDTH="204" VPOS="5466" HPOS="4182" />
+                <GraphicalElement ID="Page3_Block34" HEIGHT="18" WIDTH="634" VPOS="5466" HPOS="5676" />
+                <GraphicalElement ID="Page3_Block35" HEIGHT="2" WIDTH="296" VPOS="5496" HPOS="4262" />
+                <GraphicalElement ID="Page3_Block36" HEIGHT="2" WIDTH="176" VPOS="5584" HPOS="3160" />
+                <GraphicalElement ID="Page3_Block37" HEIGHT="12" WIDTH="296" VPOS="5600" HPOS="4266" />
+                <GraphicalElement ID="Page3_Block38" HEIGHT="18" WIDTH="824" VPOS="5640" HPOS="3870" />
+                <GraphicalElement ID="Page3_Block39" HEIGHT="20" WIDTH="802" VPOS="5654" HPOS="3046" />
+                <GraphicalElement ID="Page3_Block40" HEIGHT="2" WIDTH="272" VPOS="5684" HPOS="4122" />
+                <GraphicalElement ID="Page3_Block41" HEIGHT="18" WIDTH="270" VPOS="5848" HPOS="5698" />
+                <GraphicalElement ID="Page3_Block42" HEIGHT="18" WIDTH="614" VPOS="5902" HPOS="5012" />
+                <GraphicalElement ID="Page3_Block43" HEIGHT="12" WIDTH="530" VPOS="5912" HPOS="5778" />
+                <GraphicalElement ID="Page3_Block44" HEIGHT="2" WIDTH="196" VPOS="6550" HPOS="3876" />
+                <GraphicalElement ID="Page3_Block45" HEIGHT="40" WIDTH="486" VPOS="6900" HPOS="1956" />
+                <GraphicalElement ID="Page3_Block46" HEIGHT="30" WIDTH="410" VPOS="7324" HPOS="2886" />
+                <GraphicalElement ID="Page3_Block47" HEIGHT="24" WIDTH="454" VPOS="7524" HPOS="2720" />
+                <GraphicalElement ID="Page3_Block48" HEIGHT="16" WIDTH="402" VPOS="7936" HPOS="6478" />
+                <GraphicalElement ID="Page3_Block49" HEIGHT="16" WIDTH="434" VPOS="7938" HPOS="4652" />
+                <GraphicalElement ID="Page3_Block50" HEIGHT="18" WIDTH="486" VPOS="7940" HPOS="5586" />
+                <GraphicalElement ID="Page3_Block51" HEIGHT="18" WIDTH="386" VPOS="7968" HPOS="2952" />
+                <GraphicalElement ID="Page3_Block52" HEIGHT="12" WIDTH="448" VPOS="7998" HPOS="982" />
+                <GraphicalElement ID="Page3_Block53" HEIGHT="18" WIDTH="498" VPOS="8014" HPOS="4808" />
+                <GraphicalElement ID="Page3_Block54" HEIGHT="20" WIDTH="472" VPOS="8066" HPOS="1710" />
+                <GraphicalElement ID="Page3_Block55" HEIGHT="16" WIDTH="592" VPOS="8078" HPOS="506" />
+                <GraphicalElement ID="Page3_Block56" HEIGHT="20" WIDTH="546" VPOS="8126" HPOS="6320" />
+                <GraphicalElement ID="Page3_Block57" HEIGHT="20" WIDTH="764" VPOS="8134" HPOS="5072" />
+                <GraphicalElement ID="Page3_Block58" HEIGHT="12" WIDTH="390" VPOS="8168" HPOS="1124" />
+                <GraphicalElement ID="Page3_Block59" HEIGHT="14" WIDTH="282" VPOS="8168" HPOS="2376" />
+                <GraphicalElement ID="Page3_Block60" HEIGHT="16" WIDTH="248" VPOS="8190" HPOS="6618" />
+                <GraphicalElement ID="Page3_Block61" HEIGHT="20" WIDTH="536" VPOS="8198" HPOS="5394" />
+                <GraphicalElement ID="Page3_Block62" HEIGHT="28" WIDTH="572" VPOS="8236" HPOS="3842" />
+                <GraphicalElement ID="Page3_Block63" HEIGHT="20" WIDTH="494" VPOS="8248" HPOS="2180" />
+                <GraphicalElement ID="Page3_Block64" HEIGHT="14" WIDTH="530" VPOS="8262" HPOS="684" />
+                <GraphicalElement ID="Page3_Block65" HEIGHT="18" WIDTH="320" VPOS="8536" HPOS="5614" />
+                <GraphicalElement ID="Page3_Block66" HEIGHT="22" WIDTH="446" VPOS="8556" HPOS="5894" />
+                <GraphicalElement ID="Page3_Block67" HEIGHT="18" WIDTH="274" VPOS="8578" HPOS="4812" />
+                <GraphicalElement ID="Page3_Block68" HEIGHT="16" WIDTH="384" VPOS="8620" HPOS="1800" />
+                <GraphicalElement ID="Page3_Block69" HEIGHT="12" WIDTH="372" VPOS="8790" HPOS="4674" />
+                <GraphicalElement ID="Page3_Block70" HEIGHT="14" WIDTH="230" VPOS="8946" HPOS="6662" />
+                <GraphicalElement ID="Page3_Block71" HEIGHT="10" WIDTH="402" VPOS="8966" HPOS="5198" />
+                <GraphicalElement ID="Page3_Block72" HEIGHT="12" WIDTH="392" VPOS="8974" HPOS="4032" />
+                <GraphicalElement ID="Page3_Block73" HEIGHT="10" WIDTH="672" VPOS="8994" HPOS="2172" />
+                <GraphicalElement ID="Page3_Block74" HEIGHT="14" WIDTH="566" VPOS="8998" HPOS="844" />
+                <GraphicalElement ID="Page3_Block75" HEIGHT="18" WIDTH="274" VPOS="9072" HPOS="4044" />
+                <GraphicalElement ID="Page3_Block76" HEIGHT="14" WIDTH="470" VPOS="9076" HPOS="4824" />
+                <GraphicalElement ID="Page3_Block77" HEIGHT="22" WIDTH="518" VPOS="9084" HPOS="2774" />
+                <GraphicalElement ID="Page3_Block78" HEIGHT="12" WIDTH="544" VPOS="9098" HPOS="1690" />
+                <GraphicalElement ID="Page3_Block79" HEIGHT="14" WIDTH="598" VPOS="9104" HPOS="500" />
+                <GraphicalElement ID="Page3_Block80" HEIGHT="22" WIDTH="638" VPOS="9344" HPOS="6232" />
+                <GraphicalElement ID="Page3_Block81" HEIGHT="20" WIDTH="648" VPOS="9368" HPOS="4998" />
+                <GraphicalElement ID="Page3_Block82" HEIGHT="12" WIDTH="228" VPOS="9396" HPOS="3770" />
+                <GraphicalElement ID="Page3_Block83" HEIGHT="20" WIDTH="616" VPOS="9412" HPOS="2496" />
+                <GraphicalElement ID="Page3_Block84" HEIGHT="22" WIDTH="676" VPOS="9430" HPOS="1160" />
+                <GraphicalElement ID="Page3_Block85" HEIGHT="10" WIDTH="406" VPOS="9570" HPOS="5816" />
+                <GraphicalElement ID="Page3_Block86" HEIGHT="18" WIDTH="362" VPOS="9622" HPOS="516" />
+                <GraphicalElement ID="Page3_Block87" HEIGHT="12" WIDTH="414" VPOS="9622" HPOS="1820" />
+                <GraphicalElement ID="Page3_Block88" HEIGHT="12" WIDTH="226" VPOS="9688" HPOS="6676" />
+                <GraphicalElement ID="Page3_Block89" HEIGHT="18" WIDTH="748" VPOS="9700" HPOS="5202" />
+                <GraphicalElement ID="Page3_Block90" HEIGHT="14" WIDTH="424" VPOS="9720" HPOS="4038" />
+                <GraphicalElement ID="Page3_Block91" HEIGHT="10" WIDTH="248" VPOS="9726" HPOS="3716" />
+                <GraphicalElement ID="Page3_Block92" HEIGHT="12" WIDTH="752" VPOS="9736" HPOS="2204" />
+                <GraphicalElement ID="Page3_Block93" HEIGHT="12" WIDTH="764" VPOS="9740" HPOS="684" />
+                <GraphicalElement ID="Page3_Block94" HEIGHT="22" WIDTH="360" VPOS="9818" HPOS="4098" />
+                <GraphicalElement ID="Page3_Block95" HEIGHT="6" WIDTH="572" VPOS="10268" HPOS="3146" />
+                <GraphicalElement ID="Page3_Block96" HEIGHT="24" WIDTH="508" VPOS="10594"
+                    HPOS="6328" />
+                <GraphicalElement ID="Page3_Block97" HEIGHT="2" WIDTH="854" VPOS="10618" HPOS="3264" />
+                <GraphicalElement ID="Page3_Block98" HEIGHT="12" WIDTH="158" VPOS="8612" HPOS="3110" />
+                <GraphicalElement ID="Page3_Block99" HEIGHT="8" WIDTH="184" VPOS="9616" HPOS="3106" />
+                <GraphicalElement ID="Page3_Block100" HEIGHT="534" WIDTH="28" VPOS="9100" HPOS="502" />
+                <GraphicalElement ID="Page3_Block101" HEIGHT="552" WIDTH="28" VPOS="8086" HPOS="506" />
+                <GraphicalElement ID="Page3_Block102" HEIGHT="272" WIDTH="12" VPOS="8268" HPOS="662" />
+                <GraphicalElement ID="Page3_Block103" HEIGHT="344" WIDTH="18" VPOS="9740" HPOS="688" />
+                <GraphicalElement ID="Page3_Block104" HEIGHT="404" WIDTH="22" VPOS="9090"
+                    HPOS="1086" />
+                <GraphicalElement ID="Page3_Block105" HEIGHT="716" WIDTH="16" VPOS="8260"
+                    HPOS="1408" />
+                <GraphicalElement ID="Page3_Block106" HEIGHT="390" WIDTH="18" VPOS="9734"
+                    HPOS="1426" />
+                <GraphicalElement ID="Page3_Block107" HEIGHT="360" WIDTH="14" VPOS="8980"
+                    HPOS="1430" />
+                <GraphicalElement ID="Page3_Block108" HEIGHT="456" WIDTH="24" VPOS="7916"
+                    HPOS="1494" />
+                <GraphicalElement ID="Page3_Block109" HEIGHT="338" WIDTH="20" VPOS="9102"
+                    HPOS="1686" />
+                <GraphicalElement ID="Page3_Block110" HEIGHT="658" WIDTH="26" VPOS="9426"
+                    HPOS="1816" />
+                <GraphicalElement ID="Page3_Block111" HEIGHT="738" WIDTH="22" VPOS="8266"
+                    HPOS="2166" />
+                <GraphicalElement ID="Page3_Block112" HEIGHT="436" WIDTH="22" VPOS="9818"
+                    HPOS="2184" />
+                <GraphicalElement ID="Page3_Block113" HEIGHT="536" WIDTH="18" VPOS="9104"
+                    HPOS="2218" />
+                <GraphicalElement ID="Page3_Block114" HEIGHT="292" WIDTH="18" VPOS="8996"
+                    HPOS="2550" />
+                <GraphicalElement ID="Page3_Block115" HEIGHT="336" WIDTH="18" VPOS="9094"
+                    HPOS="2778" />
+                <GraphicalElement ID="Page3_Block116" HEIGHT="930" WIDTH="36" VPOS="6116"
+                    HPOS="2826" />
+                <GraphicalElement ID="Page3_Block117" HEIGHT="732" WIDTH="24" VPOS="8248"
+                    HPOS="2922" />
+                <GraphicalElement ID="Page3_Block118" HEIGHT="234" WIDTH="4" VPOS="5656" HPOS="3044" />
+                <GraphicalElement ID="Page3_Block119" HEIGHT="578" WIDTH="30" VPOS="8168"
+                    HPOS="3068" />
+                <GraphicalElement ID="Page3_Block120" HEIGHT="664" WIDTH="26" VPOS="9406"
+                    HPOS="3102" />
+                <GraphicalElement ID="Page3_Block121" HEIGHT="228" WIDTH="8" VPOS="5534" HPOS="3206" />
+                <GraphicalElement ID="Page3_Block122" HEIGHT="550" WIDTH="20" VPOS="8042"
+                    HPOS="3264" />
+                <GraphicalElement ID="Page3_Block123" HEIGHT="542" WIDTH="18" VPOS="9082"
+                    HPOS="3270" />
+                <GraphicalElement ID="Page3_Block124" HEIGHT="276" WIDTH="18" VPOS="8142"
+                    HPOS="3400" />
+                <GraphicalElement ID="Page3_Block125" HEIGHT="464" WIDTH="16" VPOS="8530"
+                    HPOS="3694" />
+                <GraphicalElement ID="Page3_Block126" HEIGHT="308" WIDTH="20" VPOS="9738"
+                    HPOS="3710" />
+                <GraphicalElement ID="Page3_Block127" HEIGHT="340" WIDTH="18" VPOS="9050"
+                    HPOS="3816" />
+                <GraphicalElement ID="Page3_Block128" HEIGHT="1016" WIDTH="26" VPOS="5756"
+                    HPOS="3832" />
+                <GraphicalElement ID="Page3_Block129" HEIGHT="1074" WIDTH="22" VPOS="4566"
+                    HPOS="3846" />
+                <GraphicalElement ID="Page3_Block130" HEIGHT="330" WIDTH="14" VPOS="4582"
+                    HPOS="3904" />
+                <GraphicalElement ID="Page3_Block131" HEIGHT="326" WIDTH="26" VPOS="9052"
+                    HPOS="4300" />
+                <GraphicalElement ID="Page3_Block132" HEIGHT="774" WIDTH="26" VPOS="8210"
+                    HPOS="4410" />
+                <GraphicalElement ID="Page3_Block133" HEIGHT="582" WIDTH="22" VPOS="9678"
+                    HPOS="4446" />
+                <GraphicalElement ID="Page3_Block134" HEIGHT="266" WIDTH="8" VPOS="6376" HPOS="4630" />
+                <GraphicalElement ID="Page3_Block135" HEIGHT="454" WIDTH="18" VPOS="8808"
+                    HPOS="4664" />
+                <GraphicalElement ID="Page3_Block136" HEIGHT="316" WIDTH="8" VPOS="6172" HPOS="4676" />
+                <GraphicalElement ID="Page3_Block137" HEIGHT="212" WIDTH="2" VPOS="5734" HPOS="4682" />
+                <GraphicalElement ID="Page3_Block138" HEIGHT="274" WIDTH="16" VPOS="8314"
+                    HPOS="4804" />
+                <GraphicalElement ID="Page3_Block139" HEIGHT="358" WIDTH="22" VPOS="5936"
+                    HPOS="4994" />
+                <GraphicalElement ID="Page3_Block140" HEIGHT="696" WIDTH="34" VPOS="9376"
+                    HPOS="5002" />
+                <GraphicalElement ID="Page3_Block141" HEIGHT="350" WIDTH="18" VPOS="5496"
+                    HPOS="5010" />
+                <GraphicalElement ID="Page3_Block142" HEIGHT="336" WIDTH="22" VPOS="5952"
+                    HPOS="5014" />
+                <GraphicalElement ID="Page3_Block143" HEIGHT="340" WIDTH="16" VPOS="5076"
+                    HPOS="5022" />
+                <GraphicalElement ID="Page3_Block144" HEIGHT="334" WIDTH="18" VPOS="5510"
+                    HPOS="5026" />
+                <GraphicalElement ID="Page3_Block145" HEIGHT="324" WIDTH="20" VPOS="5094"
+                    HPOS="5036" />
+                <GraphicalElement ID="Page3_Block146" HEIGHT="402" WIDTH="18" VPOS="8460"
+                    HPOS="5072" />
+                <GraphicalElement ID="Page3_Block147" HEIGHT="748" WIDTH="20" VPOS="8206"
+                    HPOS="5188" />
+                <GraphicalElement ID="Page3_Block148" HEIGHT="524" WIDTH="18" VPOS="9730"
+                    HPOS="5206" />
+                <GraphicalElement ID="Page3_Block149" HEIGHT="290" WIDTH="18" VPOS="9074"
+                    HPOS="5308" />
+                <GraphicalElement ID="Page3_Block150" HEIGHT="290" WIDTH="18" VPOS="9026"
+                    HPOS="5566" />
+                <GraphicalElement ID="Page3_Block151" HEIGHT="382" WIDTH="18" VPOS="5920"
+                    HPOS="5656" />
+                <GraphicalElement ID="Page3_Block152" HEIGHT="350" WIDTH="22" VPOS="5962"
+                    HPOS="5672" />
+                <GraphicalElement ID="Page3_Block153" HEIGHT="774" WIDTH="18" VPOS="8200"
+                    HPOS="5920" />
+                <GraphicalElement ID="Page3_Block154" HEIGHT="552" WIDTH="14" VPOS="9680"
+                    HPOS="5928" />
+                <GraphicalElement ID="Page3_Block155" HEIGHT="664" WIDTH="20" VPOS="9358"
+                    HPOS="6226" />
+                <GraphicalElement ID="Page3_Block156" HEIGHT="770" WIDTH="28" VPOS="8020"
+                    HPOS="6320" />
+                <GraphicalElement ID="Page3_Block157" HEIGHT="314" WIDTH="16" VPOS="9050"
+                    HPOS="6348" />
+                <GraphicalElement ID="Page3_Block158" HEIGHT="410" WIDTH="14" VPOS="8804"
+                    HPOS="6388" />
+                <GraphicalElement ID="Page3_Block159" HEIGHT="770" WIDTH="18" VPOS="8194"
+                    HPOS="6662" />
+                <GraphicalElement ID="Page3_Block160" HEIGHT="560" WIDTH="18" VPOS="9676"
+                    HPOS="6670" />
+                <GraphicalElement ID="Page3_Block161" HEIGHT="176" WIDTH="16" VPOS="7998"
+                    HPOS="1412" />
+                <GraphicalElement ID="Page3_Block162" HEIGHT="946" WIDTH="16" VPOS="4686"
+                    HPOS="3772" />
+                <GraphicalElement ID="Page3_Block163" HEIGHT="132" WIDTH="2" VPOS="5490" HPOS="4078" />
+                <GraphicalElement ID="Page3_Block164" HEIGHT="134" WIDTH="14" VPOS="8016"
+                    HPOS="5294" />
+                <GraphicalElement ID="Page3_Block165" HEIGHT="174" WIDTH="12" VPOS="7942"
+                    HPOS="5588" />
+                <GraphicalElement ID="Page3_Block166" HEIGHT="200" WIDTH="14" VPOS="7942"
+                    HPOS="6478" />
+                <GraphicalElement ID="Page3_Block167" HEIGHT="2" WIDTH="46" VPOS="8262" HPOS="3980" />
+                <GraphicalElement ID="Page3_Block168" HEIGHT="2" WIDTH="44" VPOS="9344" HPOS="6660" />
+                <GraphicalElement ID="Page3_Block169" HEIGHT="4" WIDTH="56" VPOS="9426" HPOS="1740" />
+                <GraphicalElement ID="Page3_Block170" HEIGHT="2" WIDTH="84" VPOS="9748" HPOS="2234" />
+                <GraphicalElement ID="Page3_Block171" HEIGHT="4" WIDTH="76" VPOS="10292" HPOS="494" />
+                <GraphicalElement ID="Page3_Block172" HEIGHT="96" WIDTH="4" VPOS="8724" HPOS="2164" />
+                <GraphicalElement ID="Page3_Block173" HEIGHT="64" WIDTH="2" VPOS="9014" HPOS="2548" />
+                <GraphicalElement ID="Page3_Block174" HEIGHT="372" WIDTH="8" VPOS="5896" HPOS="3042" />
+                <GraphicalElement ID="Page3_Block175" HEIGHT="62" WIDTH="6" VPOS="4596" HPOS="3050" />
+                <GraphicalElement ID="Page3_Block176" HEIGHT="106" WIDTH="4" VPOS="9434" HPOS="3286" />
+                <GraphicalElement ID="Page3_Block177" HEIGHT="336" WIDTH="12" VPOS="4624"
+                    HPOS="5064" />
+                <Illustration ID="Page3_Block178" HEIGHT="80" WIDTH="184" VPOS="5746" HPOS="5356" />
+                <Illustration ID="Page3_Block179" HEIGHT="148" WIDTH="96" VPOS="5590" HPOS="5676" />
+                <Illustration ID="Page3_Block180" HEIGHT="192" WIDTH="126" VPOS="6028" HPOS="5800" />
+                <Illustration ID="Page3_Block181" HEIGHT="182" WIDTH="124" VPOS="5582" HPOS="5806" />
+                <Illustration ID="Page3_Block182" HEIGHT="184" WIDTH="122" VPOS="5574" HPOS="5148" />
+                <Illustration ID="Page3_Block183" HEIGHT="186" WIDTH="120" VPOS="6020" HPOS="5138" />
+            </PrintSpace>
+        </Page>
+    </Layout>
+</alto>

--- a/spec/lib/dor/text_extraction/abbyy/split_alto_spec.rb
+++ b/spec/lib/dor/text_extraction/abbyy/split_alto_spec.rb
@@ -3,10 +3,14 @@
 require 'spec_helper'
 
 describe Dor::TextExtraction::Abbyy::SplitAlto do
-  subject(:results) { described_class.new(alto_path:) }
+  subject(:results) { described_class.new(alto_path:, logger:) }
+
+  let(:alto_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{druid}_abbyy_alto.xml") }
 
   let(:druid) { 'bb222cc3333' }
-  let(:alto_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{druid}_abbyy_alto.xml") }
+  let(:logger) { instance_double(Logger) }
+
+  before { allow(logger).to receive(:warn) }
 
   describe '.write_files' do
     let(:expected_files) { %w[bb222cc3333_00_0001.xml bb222cc3333_00_0002.xml bb222cc3333_00_0003.xml] }
@@ -20,6 +24,22 @@ describe Dor::TextExtraction::Abbyy::SplitAlto do
         actual_content = File.read(File.join(File.dirname(alto_path), file))
         expected_content = File.read(File.join(File.dirname(alto_path), "expected_#{file}"))
         expect(actual_content).to eq(expected_content)
+      end
+    end
+
+    context 'when there are fewer page filenames than Page nodes' do
+      let(:expected_files) { %w[bb222cc3333_00_0001.xml bb222cc3333_00_0002.xml] }
+      let(:third_missing_file) { 'bb222cc3333_00_0003.xml' }
+      let(:alto_path) { File.join(File.absolute_path('spec/fixtures/ocr'), "#{druid}_abbyy_alto_fewer_files.xml") }
+
+      after { expected_files.each { |file| FileUtils.rm_f(File.join(File.dirname(alto_path), file)) } }
+
+      it 'succeeeds and creates only first two XML files but logs a warning' do
+        expect(expected_files.all? { |file| File.exist?(File.join(File.dirname(alto_path), file)) }).to be false
+        expect(results.write_files).to be true
+        expect(expected_files.all? { |file| File.exist?(File.join(File.dirname(alto_path), file)) }).to be true
+        expect(File.exist?(File.join(File.dirname(alto_path), third_missing_file))).to be false
+        expect(logger).to have_received(:warn).with(/Page nodes exceed page filenames/)
       end
     end
   end


### PR DESCRIPTION
# SEE #1550 

## Why was this change made? 🤔

Do not fail if the number of page nodes does not match in the number of files listed in alto xml.

This can happen if there is a blank OCR page.  There ends up not being a file generated for that page, but there is still a page node in the single ALTO XML file.  See https://stanfordlib.slack.com/archives/C09M7P91R/p1757005335335649

HOLD for PO verification

## How was this change tested? 🤨

New spec