### PR TITLE
Ensure publish/shelve for "dark" items

### DIFF
--- a/lib/dor/text_extraction/cocina_updater.rb
+++ b/lib/dor/text_extraction/cocina_updater.rb
@@ -216,10 +216,13 @@ module Dor
 
       # you can override this in a subclass to set the administrative attributes conditionally if needed
       def administrative(_object_file)
+        # dark items always have publish and shelve set to false
+        publish = shelve = dro.access.view != 'dark'
+
         {
-          publish: true,
+          publish:,
           sdrPreserve: true,
-          shelve: true
+          shelve:
         }
       end
 

--- a/lib/dor/text_extraction/speech_to_text_cocina_updater.rb
+++ b/lib/dor/text_extraction/speech_to_text_cocina_updater.rb
@@ -25,14 +25,21 @@ module Dor
         json['language']
       end
 
-      # set the administrative attributes based on the mimetype
-      # all speech to text files are preserved, shelved and published EXCEPT json files, which are only preserved
+      # set the administrative attributes based on the access rights and the mimetype
+      # if an item is dark then it should not be published or shelved
+      # the whisper json output file is not viewable (it's only preserved)
       def administrative(object_file)
-        preserve = true
-        publish = shelve = object_file.mimetype != 'application/json'
+        # rubocop:disable Style/ConditionalAssignment
+        if dro.access.view == 'dark' || object_file.mimetype == 'application/json'
+          publish = shelve = false
+        else
+          publish = shelve = true
+        end
+        # rubocop:enable Style/ConditionalAssignment
+
         {
           publish:,
-          sdrPreserve: preserve,
+          sdrPreserve: true,
           shelve:
         }
       end

--- a/spec/lib/dor/text_extraction/ocr_cocina_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/ocr_cocina_updater_spec.rb
@@ -331,6 +331,78 @@ describe Dor::TextExtraction::OcrCocinaUpdater do
     end
   end
 
+  context 'when object access rights are dark' do
+    let(:download) { 'none' }
+    let(:view) { 'dark' }
+    let(:item_type) { Cocina::Models::ObjectType.book }
+    let(:resource_type) { Cocina::Models::FileSetType.page }
+
+    let(:original_resources) do
+      [
+        {
+          externalIdentifier: "#{bare_druid}_1",
+          label: 'Page 1',
+          type: resource_type,
+          version: 1,
+          structural: {
+            contains: [
+              {
+                externalIdentifier: "https://cocina.sul.stanford.edu/file/#{bare_druid}_001",
+                label: 'page_001.tif',
+                type: Cocina::Models::ObjectType.file,
+                version: 1,
+                filename: 'page_001.tif',
+                hasMimeType: 'image/tiff',
+                access: { download: 'none', view: 'dark' }
+              }
+            ]
+          }
+        }
+      ]
+    end
+
+    before do
+      create_ocr_file('page_001.txt')
+      create_ocr_file('page_001.xml')
+      create_ocr_file("#{bare_druid}.pdf")
+      create_ocr_file("#{bare_druid}.txt")
+
+      described_class.update(dro:)
+    end
+
+    it 'sets the file level access rights to dark' do
+      expect(dro.structural.contains[0].structural.contains[0].access.view).to eq('dark')
+      expect(dro.structural.contains[0].structural.contains[1].access.view).to eq('dark')
+      expect(dro.structural.contains[0].structural.contains[2].access.view).to eq('dark')
+      expect(dro.structural.contains[1].structural.contains[0].access.view).to eq('dark')
+      expect(dro.structural.contains[2].structural.contains[0].access.view).to eq('dark')
+    end
+
+    it 'sets the file level publish to false' do
+      expect(dro.structural.contains[0].structural.contains[0].administrative.publish).to be false
+      expect(dro.structural.contains[0].structural.contains[1].administrative.publish).to be false
+      expect(dro.structural.contains[0].structural.contains[2].administrative.publish).to be false
+      expect(dro.structural.contains[1].structural.contains[0].administrative.publish).to be false
+      expect(dro.structural.contains[2].structural.contains[0].administrative.publish).to be false
+    end
+
+    it 'sets the file level shelve to false' do
+      expect(dro.structural.contains[0].structural.contains[0].administrative.shelve).to be false
+      expect(dro.structural.contains[0].structural.contains[1].administrative.shelve).to be false
+      expect(dro.structural.contains[0].structural.contains[2].administrative.shelve).to be false
+      expect(dro.structural.contains[1].structural.contains[0].administrative.shelve).to be false
+      expect(dro.structural.contains[2].structural.contains[0].administrative.shelve).to be false
+    end
+
+    it 'sets file level sdrPreserve to true' do
+      expect(dro.structural.contains[0].structural.contains[0].administrative.sdrPreserve).to be true
+      expect(dro.structural.contains[0].structural.contains[1].administrative.sdrPreserve).to be true
+      expect(dro.structural.contains[0].structural.contains[2].administrative.sdrPreserve).to be true
+      expect(dro.structural.contains[1].structural.contains[0].administrative.sdrPreserve).to be true
+      expect(dro.structural.contains[2].structural.contains[0].administrative.sdrPreserve).to be true
+    end
+  end
+
   context 'when it is a document' do
     let(:item_type) { Cocina::Models::ObjectType.document }
     let(:resource_type) { Cocina::Models::FileSetType.document }

--- a/spec/lib/dor/text_extraction/speech_to_text_cocina_updater_spec.rb
+++ b/spec/lib/dor/text_extraction/speech_to_text_cocina_updater_spec.rb
@@ -48,7 +48,7 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
                 version: 1,
                 filename: 'file_1.mp4',
                 hasMimeType: 'video/mp4',
-                access: { download: 'world', view: 'world' }
+                access: { download:, view: }
               }
             ]
           }
@@ -67,7 +67,7 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
                 version: 1,
                 filename: 'file_1.m4a',
                 hasMimeType: 'audio/m4a',
-                access: { download: 'world', view: 'world' }
+                access: { download:, view: }
               }
             ]
           }
@@ -233,20 +233,62 @@ describe Dor::TextExtraction::SpeechToTextCocinaUpdater do
       let(:view) { 'stanford' }
 
       it 'sets the file level access rights to restricted' do
-        expect(resource1_files[0].access.view).to eq('world') # original file can have different rights
+        expect(resource1_files[0].access.view).to eq('stanford') # original file
         expect(resource1_files[1].access.view).to eq('stanford') # new files below
         expect(resource1_files[2].access.view).to eq('stanford')
         expect(resource1_files[3].access.view).to eq('stanford')
         expect(resource1_files[1].access.download).to eq('stanford')
         expect(resource1_files[2].access.download).to eq('stanford')
         expect(resource1_files[3].access.download).to eq('stanford')
-        expect(resource2_files[0].access.view).to eq('world') # original file can have different rights
+        expect(resource2_files[0].access.view).to eq('stanford') # original file
         expect(resource2_files[1].access.view).to eq('stanford') # new files below
         expect(resource2_files[2].access.view).to eq('stanford')
         expect(resource2_files[3].access.view).to eq('stanford')
         expect(resource2_files[1].access.download).to eq('stanford')
         expect(resource2_files[2].access.download).to eq('stanford')
         expect(resource2_files[3].access.download).to eq('stanford')
+      end
+    end
+
+    context 'when object access rights are dark' do
+      let(:download) { 'none' }
+      let(:view) { 'dark' }
+
+      it 'sets the file level access rights to dark' do
+        expect(resource1_files[0].access.view).to eq('dark') # original file
+        expect(resource1_files[1].access.view).to eq('dark') # new files below
+        expect(resource1_files[2].access.view).to eq('dark')
+        expect(resource1_files[3].access.view).to eq('dark')
+
+        expect(resource1_files[0].access.download).to eq('none')
+        expect(resource1_files[1].access.download).to eq('none')
+        expect(resource1_files[2].access.download).to eq('none')
+        expect(resource1_files[3].access.download).to eq('none')
+
+        expect(resource1_files[0].administrative.shelve).to be false
+        expect(resource1_files[1].administrative.shelve).to be false
+        expect(resource1_files[2].administrative.shelve).to be false
+        expect(resource1_files[3].administrative.shelve).to be false
+
+        expect(resource1_files[0].administrative.sdrPreserve).to be true
+        expect(resource1_files[1].administrative.sdrPreserve).to be true
+        expect(resource1_files[2].administrative.sdrPreserve).to be true
+        expect(resource1_files[3].administrative.sdrPreserve).to be true
+
+        expect(resource1_files[0].administrative.publish).to be false
+        expect(resource1_files[1].administrative.publish).to be false
+        expect(resource1_files[2].administrative.publish).to be false
+        expect(resource1_files[3].administrative.publish).to be false
+
+        expect(resource2_files[0].access.view).to eq('dark') # original file
+        expect(resource2_files[1].access.view).to eq('dark') # new files below
+        expect(resource2_files[2].access.view).to eq('dark')
+        expect(resource2_files[3].access.view).to eq('dark')
+
+        expect(resource2_files[0].access.download).to eq('none')
+        expect(resource2_files[1].access.download).to eq('none')
+        expect(resource2_files[2].access.download).to eq('none')
+        expect(resource2_files[3].access.download).to eq('none')
       end
     end
     # rubocop:enable RSpec/ExampleLength


### PR DESCRIPTION
## Why was this change made? 🤔

This commit ensures that publish and shelve are set to "no" for items with "dark" access permissions. These changes apply to new files created by both ocrWF and speechToTextWF.

Fixes #1564

## How was this change tested? 🤨

Unit tests and relevant ocr and speech-to-text integration tests.



