### PR TITLE
Upgrade dlss-capistrano

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,8 @@ group :test do
 end
 
 group :development do
-  gem 'capistrano', '~> 3.0'
-  gem 'capistrano-bundler', '~> 1.1'
+  gem 'capistrano', '~> 3.6'
+  gem 'capistrano-bundler'
   gem 'debug'
   gem 'dlss-capistrano', require: false
   gem "ruby-debug-completion"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,19 +63,12 @@ GEM
     bcrypt_pbkdf (1.1.1)
     bigdecimal (3.3.1)
     bond (0.5.1)
-    bundler-audit (0.9.3)
-      bundler (>= 1.2.0)
-      thor (~> 1.0)
     capistrano (3.19.2)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundle_audit (0.4.0)
-      bundler-audit (~> 0.5)
-      capistrano (~> 3.0)
-      capistrano-bundler (>= 1.4)
-    capistrano-bundler (1.6.0)
+    capistrano-bundler (2.2.0)
       capistrano (~> 3.1)
     capistrano-one_time_key (0.2.0)
       capistrano (~> 3.0)
@@ -112,10 +105,9 @@ GEM
     deprecation (1.1.0)
       activesupport
     diff-lcs (1.6.2)
-    dlss-capistrano (5.3.0)
+    dlss-capistrano (6.0.0)
       bcrypt_pbkdf
       capistrano (~> 3.0)
-      capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key (>= 0.2.0)
       capistrano-shared_configs
       ed25519
@@ -375,8 +367,8 @@ DEPENDENCIES
   aws-sdk-batch
   aws-sdk-s3
   aws-sdk-sqs
-  capistrano (~> 3.0)
-  capistrano-bundler (~> 1.1)
+  capistrano (~> 3.6)
+  capistrano-bundler
   config
   debug
   dlss-capistrano


### PR DESCRIPTION
## Why was this change made? 🤔

We were seeing an error like this on deploy:

```
The deploy has failed with an error: Exception while executing as lyberadmin@common-accessioning-stage-a.stanford.edu: bundle exit status: 15
bundle stdout: Nothing written
bundle stderr: The `--deployment` flag has been removed because it relied on being remembered
across bundler invocations, which bundler no longer does. Instead please use
`bundle config set deployment true`, and stop using this flag
```

Updating to the latest dlss-capistrano made it go away.

I also updated the minimum capistrano version to match what we are doing in
dor-services-app.


## How was this change tested? 🤨

`bundle exec stage deploy`
