### PR TITLE
Upgrade capistrano and capistrano-bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,8 +40,8 @@ group :test do
 end
 
 group :development do
-  gem 'capistrano', '~> 3.0'
-  gem 'capistrano-bundler', '~> 1.1'
+  gem 'capistrano', '~> 3.6'
+  gem 'capistrano-bundler'
   gem 'debug'
   gem 'dlss-capistrano', require: false
   gem "ruby-debug-completion"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ GEM
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundler (1.6.0)
+    capistrano-bundler (2.2.0)
       capistrano (~> 3.1)
     capistrano-one_time_key (0.2.0)
       capistrano (~> 3.0)
@@ -367,8 +367,8 @@ DEPENDENCIES
   aws-sdk-batch
   aws-sdk-s3
   aws-sdk-sqs
-  capistrano (~> 3.0)
-  capistrano-bundler (~> 1.1)
+  capistrano (~> 3.6)
+  capistrano-bundler
   config
   debug
   dlss-capistrano


### PR DESCRIPTION
## Why was this change made? 🤔

We are seeing this error when cap deploying, and upgrading capistrano and capistrano-bundler makes it go away.

```
    ✔ 01 lyberadmin@common-accessioning-stage-a.stanford.edu 0.364s
      01 The `--deployment` flag has been removed because it relied on being remembered
      01 across bundler invocations, which bundler no longer does. Instead please use
      01 `bundle config set deployment true`, and stop using this flag
/Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:13:in 'block (2 levels) in SSHKit::Runner::Parallel#execute': Exception while executing as lyberadmin@common-accessioning-stage-b.stanford.edu: bundle exit status: 15 (SSHKit::Runner::ExecuteError)
bundle stdout: Nothing written
bundle stderr: The `--deployment` flag has been removed because it relied on being remembered
across bundler invocations, which bundler no longer does. Instead please use
`bundle config set deployment true`, and stop using this flag

/Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/command.rb:97:in 'SSHKit::Command#exit_status=': bundle exit status: 15 (SSHKit::Command::Failed)
bundle stdout: Nothing written
bundle stderr: The `--deployment` flag has been removed because it relied on being remembered
across bundler invocations, which bundler no longer does. Instead please use
`bundle config set deployment true`, and stop using this flag

        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/netssh.rb:185:in 'SSHKit::Backend::Netssh#execute_command'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:147:in 'block in SSHKit::Backend::Abstract#create_command_and_execute'
        from <internal:kernel>:91:in 'Kernel#tap'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:147:in 'SSHKit::Backend::Abstract#create_command_and_execute'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:80:in 'SSHKit::Backend::Abstract#execute'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/capistrano-bundler-1.6.0/lib/capistrano/tasks/bundler.cap:39:in 'block (5 levels) in <top (required)>'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:100:in 'SSHKit::Backend::Abstract#with'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/capistrano-bundler-1.6.0/lib/capistrano/tasks/bundler.cap:27:in 'block (4 levels) in <top (required)>'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:92:in 'SSHKit::Backend::Abstract#within'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/capistrano-bundler-1.6.0/lib/capistrano/tasks/bundler.cap:26:in 'block (3 levels) in <top (required)>'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:31:in 'BasicObject#instance_exec'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/backends/abstract.rb:31:in 'SSHKit::Backend::Abstract#run'
        from /Users/edsu/.rbenv/versions/3.4.7/lib/ruby/gems/3.4.0/gems/sshkit-1.24.0/lib/sshkit/runners/parallel.rb:10:in 'block (2 levels) in SSHKit::Runner::Parallel#execute'
```

## How was this change tested? 🤨

```
bundle exec stage deploy
```
